### PR TITLE
Add TTY-aware anstyle colors to CLI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 name = "tink"
 version = "0.1.0"
 dependencies = [
+ "anstyle",
  "assert_cmd",
  "clap",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["agents", "skills", "cli"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
+anstyle = "1.0.14"
 clap = { version = "4.6.5", features = ["derive"] }
 serde_json = "1.0.151"
 tempfile = "3.27.0"

--- a/src/add.rs
+++ b/src/add.rs
@@ -8,6 +8,7 @@ use crate::init;
 use crate::inventory;
 use crate::skills::{self, Provenance, Skill};
 use crate::sources::{self, RemoteSource};
+use crate::style::CliStyle;
 
 #[derive(Debug)]
 #[allow(dead_code)] // Returned for callers / future CLI reporting.
@@ -139,14 +140,20 @@ fn looks_like_filesystem_path(value: &str) -> bool {
 }
 
 fn report_add(outcome: &AddOutcome) {
+    let style = CliStyle::auto_stdout();
     if outcome.created {
         println!(
-            "Installed {} → {}",
-            outcome.name,
-            outcome.project_path.display()
+            "{} {} → {}",
+            style.success("Installed"),
+            style.accent(&outcome.name),
+            style.accent(outcome.project_path.display())
         );
     } else {
-        println!("Unchanged {}", outcome.name);
+        println!(
+            "{} {}",
+            style.muted("Unchanged"),
+            style.accent(&outcome.name)
+        );
     }
 }
 

--- a/src/destroy.rs
+++ b/src/destroy.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::Error;
 use crate::paths::{map_io, refuse_symlink};
+use crate::style::CliStyle;
 
 #[derive(Debug, Default)]
 pub struct DestroyReport {
@@ -60,12 +61,16 @@ fn confirm_destroy() -> Result<(), Error> {
             "Refusing to destroy without confirmation (pass --yes, or run in a terminal)",
         ));
     }
+    let style = CliStyle::auto_stdout();
     let mut stdout = io::stdout();
     write!(
         stdout,
-        "Delete .agents/, ZEN.md, and AGENTS.md in this project? [y/N] "
+        "{} {}",
+        style.warn("Delete .agents/, ZEN.md, and AGENTS.md in this project?"),
+        style.accent("[y/N]")
     )
     .map_err(|e| Error::msg(format!("prompt: {e}")))?;
+    write!(stdout, " ").map_err(|e| Error::msg(format!("prompt: {e}")))?;
     stdout
         .flush()
         .map_err(|e| Error::msg(format!("prompt: {e}")))?;

--- a/src/init.rs
+++ b/src/init.rs
@@ -8,6 +8,7 @@ use crate::error::Error;
 use crate::inventory;
 use crate::manage_tink;
 use crate::paths::{map_io, mkdir_p, require_directory, require_file};
+use crate::style::CliStyle;
 use crate::templates::{
     self, TINK_SKILLS, TINK_SKILLS_SOURCE, ZEN, ZEN_REFERENCE, ZEN_REFERENCE_MARKER,
 };
@@ -48,7 +49,8 @@ pub fn opt_in(explicit: Option<bool>, question: &str) -> Result<bool, Error> {
     if !io::stdin().is_terminal() {
         return Ok(false);
     }
-    print!("{question} [y/N] ");
+    let style = CliStyle::auto_stdout();
+    print!("{} {}", style.warn(question), style.accent("[y/N] "));
     io::stdout()
         .flush()
         .map_err(|e| Error::msg(format!("prompt: {e}")))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod paths;
 mod refresh;
 mod skills;
 mod sources;
+mod style;
 mod templates;
 
 use clap::{Parser, Subcommand};
@@ -22,6 +23,7 @@ use std::process::ExitCode;
 
 use crate::error::Error;
 use crate::init::InitOptions;
+use crate::style::CliStyle;
 
 #[derive(Debug, Parser)]
 #[command(name = "tink", version, about = "Install Agent Skills into .agents/skills/")]
@@ -127,7 +129,8 @@ pub fn run(cli: Cli, cwd: PathBuf) -> ExitCode {
     match dispatch(cli, cwd) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            eprintln!("{err}");
+            let style = CliStyle::auto_stderr();
+            eprintln!("{}", style.error(&err));
             ExitCode::from(1)
         }
     }
@@ -155,12 +158,17 @@ fn dispatch(cli: Cli, cwd: PathBuf) -> Result<(), Error> {
         Command::Check => dispatch_skill_check(&cwd),
         Command::Refresh { name } => dispatch_skill_refresh(&cwd, name.as_deref()),
         Command::Destroy { yes } => {
+            let style = CliStyle::auto_stdout();
             let report = destroy::destroy_project(&cwd, yes)?;
             if report.removed.is_empty() {
-                println!("Nothing to destroy");
+                println!("{}", style.muted("Nothing to destroy"));
             } else {
                 for path in &report.removed {
-                    println!("Removed {}", path.display());
+                    println!(
+                        "{} {}",
+                        style.success("Removed"),
+                        style.accent(path.display())
+                    );
                 }
             }
             Ok(())
@@ -191,6 +199,7 @@ fn dispatch_init(
     with_tink_skills: Option<bool>,
     with_manage_tink: Option<bool>,
 ) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
     let report = init::init_project(
         cwd,
         InitOptions {
@@ -200,23 +209,43 @@ fn dispatch_init(
         },
     )?;
     if report.skills_created {
-        println!("Created {}", report.skills_path.display());
+        println!(
+            "{} {}",
+            style.success("Created"),
+            style.accent(report.skills_path.display())
+        );
     } else {
-        println!("Ready {}", report.skills_path.display());
+        println!(
+            "{} {}",
+            style.success("Ready"),
+            style.accent(report.skills_path.display())
+        );
     }
     if report.zen_written {
-        println!("Added ZEN.md maintainability principles");
+        println!(
+            "{} {}",
+            style.success("Added"),
+            style.accent("ZEN.md maintainability principles")
+        );
     }
     if let Some(name) = &report.manage_tink_added {
-        println!("Added {name}");
+        println!("{} {}", style.success("Added"), style.accent(name));
     }
     for name in &report.tink_skills_added {
-        println!("Added {name}");
+        println!("{} {}", style.success("Added"), style.accent(name));
     }
     if report.inventory_created {
-        println!("New home inventory at {}", report.inventory_home.display());
+        println!(
+            "{} {}",
+            style.success("New home inventory at"),
+            style.accent(report.inventory_home.display())
+        );
     } else {
-        println!("Home inventory at {}", report.inventory_home.display());
+        println!(
+            "{} {}",
+            style.muted("Home inventory at"),
+            style.accent(report.inventory_home.display())
+        );
     }
     Ok(())
 }
@@ -226,54 +255,76 @@ fn dispatch_skill_add(cwd: &Path, source: &str, skill: Option<&str>) -> Result<(
 }
 
 fn dispatch_skill_check(cwd: &Path) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
     let skills = check::check_project(cwd)?;
-    println!("OK {} skill(s)", skills.len());
+    println!(
+        "{} {} skill(s)",
+        style.success("OK"),
+        style.accent(skills.len())
+    );
     Ok(())
 }
 
 fn dispatch_skill_list(cwd: &Path) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
     let skills = check::check_project(cwd)?;
     if skills.is_empty() {
-        println!("(no skills)");
+        println!("{}", style.muted("(no skills)"));
     } else {
         for skill in &skills {
-            println!("{}", skill.name);
+            println!("{}", style.accent(&skill.name));
         }
     }
     Ok(())
 }
 
 fn dispatch_skill_list_home() -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
     let entries = inventory::list_catalog(None)?;
     if entries.is_empty() {
-        println!("(no catalog entries)");
+        println!("{}", style.muted("(no catalog entries)"));
     } else {
-        // Header + TSV rows: stable for agents, scannable for humans.
-        println!("project\troot\tskill");
+        // Header + TSV rows: plain when piped; lightly role-colored on a TTY.
+        println!(
+            "{}\t{}\t{}",
+            style.muted("project"),
+            style.muted("root"),
+            style.muted("skill")
+        );
         for entry in &entries {
-            println!("{}\t{}\t{}", entry.project, entry.root, entry.skill);
+            println!(
+                "{}\t{}\t{}",
+                style.muted(&entry.project),
+                style.muted(&entry.root),
+                style.accent(&entry.skill)
+            );
         }
     }
     Ok(())
 }
 
 fn dispatch_skill_refresh(cwd: &Path, name: Option<&str>) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
     match name {
         Some(name) => {
             let changed = refresh::refresh_skill(cwd, name)?;
             if changed {
-                println!("Refreshed {name}");
+                println!("{} {}", style.success("Refreshed"), style.accent(name));
             } else {
-                println!("Unchanged {name}");
+                println!("{} {}", style.muted("Unchanged"), style.accent(name));
             }
             Ok(())
         }
         None => {
             let refreshed = refresh::refresh_all(cwd)?;
             if refreshed.is_empty() {
-                println!("Unchanged (no imported skills updated)");
+                println!("{}", style.muted("Unchanged (no imported skills updated)"));
             } else {
-                println!("Refreshed {}", refreshed.join(", "));
+                println!(
+                    "{} {}",
+                    style.success("Refreshed"),
+                    style.accent(refreshed.join(", "))
+                );
             }
             Ok(())
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,118 @@
+//! Terminal styling for user-facing CLI output (`anstyle` + TTY / `NO_COLOR`).
+
+use std::io::IsTerminal;
+
+use anstyle::{AnsiColor, Effects, Style};
+
+/// Whether ANSI styling is enabled for a given output stream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CliStyle {
+    enabled: bool,
+}
+
+impl CliStyle {
+    /// Always-plain handle for tests and non-interactive formatters.
+    #[allow(dead_code)] // used by unit tests; integration builds omit cfg(test)
+    pub fn plain() -> Self {
+        Self { enabled: false }
+    }
+
+    /// Force ANSI on/off regardless of TTY / `NO_COLOR` (tests / smokes).
+    #[allow(dead_code)] // used by unit tests; integration builds omit cfg(test)
+    pub fn forced(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    pub fn auto_stdout() -> Self {
+        Self {
+            enabled: color_enabled() && std::io::stdout().is_terminal(),
+        }
+    }
+
+    pub fn auto_stderr() -> Self {
+        Self {
+            enabled: color_enabled() && std::io::stderr().is_terminal(),
+        }
+    }
+
+    #[allow(dead_code)] // used by unit tests; integration builds omit cfg(test)
+    pub fn enabled(self) -> bool {
+        self.enabled
+    }
+
+    pub fn paint(self, style: Style, text: impl std::fmt::Display) -> String {
+        if !self.enabled {
+            return text.to_string();
+        }
+        format!("{}{}{}", style.render(), text, style.render_reset())
+    }
+
+    pub fn success(self, text: impl std::fmt::Display) -> String {
+        self.paint(SUCCESS, text)
+    }
+
+    pub fn error(self, text: impl std::fmt::Display) -> String {
+        self.paint(ERROR, text)
+    }
+
+    pub fn warn(self, text: impl std::fmt::Display) -> String {
+        self.paint(WARN, text)
+    }
+
+    pub fn muted(self, text: impl std::fmt::Display) -> String {
+        self.paint(MUTED, text)
+    }
+
+    pub fn accent(self, text: impl std::fmt::Display) -> String {
+        self.paint(ACCENT, text)
+    }
+}
+
+fn color_enabled() -> bool {
+    std::env::var_os("NO_COLOR").is_none()
+}
+
+const SUCCESS: Style = Style::new()
+    .fg_color(Some(anstyle::Color::Ansi(AnsiColor::Green)))
+    .effects(Effects::BOLD);
+
+const ERROR: Style = Style::new()
+    .fg_color(Some(anstyle::Color::Ansi(AnsiColor::Red)))
+    .effects(Effects::BOLD);
+
+const WARN: Style = Style::new()
+    .fg_color(Some(anstyle::Color::Ansi(AnsiColor::Yellow)))
+    .effects(Effects::BOLD);
+
+const MUTED: Style = Style::new().effects(Effects::DIMMED);
+
+const ACCENT: Style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Cyan)));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_strips_styles() {
+        let style = CliStyle::plain();
+        assert_eq!(style.success("OK"), "OK");
+        assert_eq!(style.error("nope"), "nope");
+        assert_eq!(style.accent("tui-design"), "tui-design");
+        assert!(!style.enabled());
+    }
+
+    #[test]
+    fn forced_emits_ansi_and_reset() {
+        let style = CliStyle::forced(true);
+        let painted = style.success("OK");
+        assert!(painted.contains("OK"), "{painted}");
+        assert!(painted.contains('\u{1b}'), "{painted}");
+        assert_ne!(painted, "OK");
+        assert!(painted.ends_with("\u{1b}[0m") || painted.contains("\u{1b}[0m"), "{painted}");
+    }
+
+    #[test]
+    fn color_enabled_respects_no_color() {
+        assert_eq!(color_enabled(), std::env::var_os("NO_COLOR").is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a small `CliStyle` helper (`anstyle`) with success/error/warn/muted/accent roles
- Color status lines, lists/TSV, errors, and confirm prompts when the stream is a TTY and `NO_COLOR` is unset
- Keep pipes and acceptance tests plain (no ANSI)

## Test plan
- [x] `cargo test` (unit + acceptance)
- [x] PTY smoke: `skill list` cyan, `skill check` green OK, errors bold red
- [x] Piped output has no escapes; `NO_COLOR=1` under PTY is plain
- [ ] Spot-check in a real terminal: `./target/debug/tink skill list` vs `NO_COLOR=1 …`


Made with [Cursor](https://cursor.com)