### PR TITLE
Add tink skill remove

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -2,15 +2,16 @@
 
 **Outcome:** A smaller Tink core in Rust that installs complete Agent Skills into
 a project's `.agents/skills/`, proves them offline, refreshes clean GitHub
-imports, ensures a home root at `~/.tink` (override: `TINK_HOME`), and can list
-or promote skills from the home stash (`skills/<name>/`) into a project.
+imports, removes a project skill on request, ensures a home root at `~/.tink`
+(override: `TINK_HOME`), and can list or promote skills from the home stash
+(`skills/<name>/`) into a project.
 
 **Authority:** This file is the evaluator. Implementation stops when every row
 below has an automated test that passes on macOS with `git` on `PATH`.
 
 **Out of v1:** weekly GitHub update workflows, self-update, private GitHub auth,
-Windows, Linux CI as a gate, `skill remove`, pruning the home by-project catalog
-or home stash, bare-name stash promote without `--stash`.
+Windows, Linux CI as a gate, pruning the home by-project catalog or home stash,
+bare-name stash promote without `--stash`.
 
 **Dogfood:** Prefer an installed `tink` from this repo, or `cargo run -q -- …`.
 
@@ -29,6 +30,7 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill list --stash` | List skill names in the home stash (`skills/<name>/` with `SKILL.md`) |
 | `tink skill check` | Validate project skills; no network; no writes |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
+| `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` (not home stash or catalog) |
 | `tink destroy [--yes]` | Remove `.agents/`, `ZEN.md`, and `AGENTS.md` (not `~/.tink`) |
 
 ## On-disk contracts
@@ -125,6 +127,15 @@ Ids are stable. Tests must name or comment the id they prove.
 | P5 | `skill refresh` when home stash body diverges from project | Exit ≠ 0; "stash diverges"; project unchanged |
 | P6 | `skill refresh` when upstream revision moves but skill tree bytes match | Exit 0; bumps project + stash receipts |
 | P7 | `skill refresh` when project already at HEAD but home stash is stale | Exit 0; repairs stash from project |
+
+### Remove
+
+| Id | Action | Expect |
+|---|---|---|
+| X1 | `skill remove <name>` after init+add | Exit 0; project `.agents/skills/<name>/` gone; `skill list` omits name; home stash `$TINK_HOME/skills/<name>/` still present; catalog may still list the name |
+| X2 | `skill remove <missing>` | Exit ≠ 0; mentions not found / missing; nothing deleted |
+| X3 | `skill remove` when `.agents` is a symlink | Exit ≠ 0; mentions symlink; tree unchanged |
+| X4 | Successful `skill remove <name>` | Does **not** delete `$TINK_HOME/skills/<name>/` |
 
 ### Destroy
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@
 
 # tink
 
-**One skill manager. Any harness. Just works.**
+Install Agent Skills into a project's `.agents/skills/`.
 
-tink copies complete Agent Skills into a project's `.agents/skills/` directory.
-No registry, no daemon, no required `~/.agents`. Agents that already look for
-project skills find them where they live.
+tink copies a complete skill directory into the project. There is no registry
+and no daemon. You do not need `~/.agents`. Agents that already look for
+project skills find them in `.agents/skills/`.
 
 If you are an agent, follow [`skills/manage-tink/SKILL.md`](skills/manage-tink/SKILL.md).
+The v1 command contract is [`ACCEPTANCE.md`](ACCEPTANCE.md).
 
 ## Install
 
-Needs a current Rust toolchain and `git` on `PATH` for GitHub sources.
+You need a current Rust toolchain. For GitHub sources, `git` must be on `PATH`.
 
 ```console
 cargo install --git https://github.com/jon-devlapaz/tink.git --locked
@@ -47,8 +48,18 @@ tink skill list
 tink skill list --home
 tink skill list --stash
 tink skill add --stash my-skill
+tink skill remove my-skill
 tink skill check
 ```
+
+`init` does this by default:
+
+1. Creates `.agents/skills/`.
+2. Ensures `~/.tink` exists.
+3. Installs the embedded `manage-tink` skill.
+
+On a TTY it may ask about ZEN and the tink-skills bundle (`skill-scout`,
+`skill-eval-loop`). Non-interactive runs skip those unless you pass flags.
 
 ### More
 
@@ -67,32 +78,68 @@ tink skill add --stash skill-name
 tink skill refresh
 tink skill refresh skill-name
 
+# Remove one project skill (not home stash or catalog)
+tink skill remove skill-name
+
 # Remove project agent scaffolding (not ~/.tink)
 tink destroy --yes
 ```
 
-Override the home root with `TINK_HOME` when you need an isolated home.
-Successful installs stash skill trees under `~/.tink/skills/<name>/` and
-record skill **names** under `~/.tink/catalog/by-project/<project>/meta.json`.
-Home is not an agent discovery root. List the stash with
-`tink skill list --stash`; promote into a project with
-`tink skill add --stash <name>`. When a GitHub tip is already stashed
-byte-for-byte, add installs the project copy from that stash. Divergent stash
-trees are repaired with a warning (project skill overwrites are still refused).
+Set `TINK_HOME` to use a different home directory.
 
-tink does not init Git, stage files, commit, push, or overwrite a skill that
-diverged from what it would install.
+A successful install copies the skill tree to `~/.tink/skills/<name>/`.
+It records the skill name in `~/.tink/catalog/by-project/<project>/meta.json`.
+Home is not an agent discovery root.
+
+`tink skill list --stash` lists stashed skill names.
+`tink skill add --stash <name>` copies one into the project.
+`tink skill list --home` prints the name catalog as TSV (`project`, `root`,
+`skill`).
+
+If the GitHub tip is already in the stash, and the stash copy matches the tip
+byte for byte, `skill add` installs the project skill from the stash.
+If the stash copy differs, tink repairs the stash and writes a warning.
+tink does not overwrite a different project skill.
+
+tink does not:
+
+- init Git
+- stage files
+- commit
+- push
+
+tink does not overwrite a skill that differs from the skill it would install.
+`skill remove` deletes only the project skill directory; it does not prune the
+home stash or catalog.
 
 ## Model
 
-A skill is a directory with `SKILL.md` plus whatever it needs. GitHub imports
-get a small receipt so refresh can prove the install still matches its source.
-tink does not execute skill code during add, check, or refresh.
+A skill is a directory that contains `SKILL.md` and the files that skill uses.
+A GitHub import writes a `.tink-source.json` receipt.
+`skill refresh` uses the receipt to check that the installed skill still
+matches its source.
+tink does not run skill code during add, check, or refresh.
 
-**Live** skills are only under `.agents/skills/`. **Home** (`~/.tink`) holds a
-rebuildable **stash** of skill trees (`skills/<name>/`) and a by-project **name
-catalog** (`catalog/by-project/`). Agents never load from home; promote with
+Installed project skills exist only under `.agents/skills/`.
+`~/.tink` stores skill trees in `skills/<name>/`.
+`~/.tink` stores the by-project name catalog in `catalog/by-project/`.
+Agents do not load skills from home.
+To install a stashed skill into the project, run
 `tink skill add --stash <name>`.
+
+## Layout
+
+```text
+.
+├── ACCEPTANCE.md     # v1 command and on-disk contracts
+├── ZEN.md            # maintainability principles
+├── assets/           # logo
+├── skills/           # embedded manage-tink (shipped with the binary)
+├── src/              # Rust CLI
+└── tests/            # acceptance tests
+```
+
+After `init` or `skill add`, installed skills are under `.agents/skills/<name>/`.
 
 ## Develop
 
@@ -101,7 +148,7 @@ cargo test
 cargo run -q -- init
 ```
 
-Maintainability notes live in [ZEN.md](ZEN.md).
+Maintainability notes are in [ZEN.md](ZEN.md).
 
 ## License
 

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-tink
-description: "Tink CLI for repository-owned Agent Skills. Use when the user asks to set up or init Tink, add or refresh a project skill, list or check .agents/skills, list the home by-project catalog or home stash, promote a stash skill into the project, or destroy project agent scaffolding."
+description: "Tink CLI for repository-owned Agent Skills. Use when the user asks to set up or init Tink, add or refresh a project skill, remove a project skill, list or check .agents/skills, list the home by-project catalog or home stash, promote a stash skill into the project, or destroy project agent scaffolding."
 ---
 
 # Manage Tink
@@ -25,10 +25,14 @@ are hard stops — honor them; do not work around them.
    command; do not invent flags, merges, force-overwrites, or alternate install
    paths (no symlinks, manual copies, or private registries). To promote from
    the home stash into the project, use `tink skill add --stash NAME` only.
+   To remove a live project skill, use `tink skill remove NAME` only (does not
+   prune home stash or catalog).
    - Done when: the chosen command has finished and its stdout/stderr is known.
 
-3. **Prove** — After every successful mutation except `destroy`, run
-   `tink skill check` and report the result. After `destroy`, confirm
+3. **Prove** — After every successful mutation except `destroy` and
+   `skill remove`, run `tink skill check` and report the result. After
+   `skill remove`, run `tink skill list` (or check if other skills remain) and
+   confirm the name is gone from the project. After `destroy`, confirm
    `.agents/`, `ZEN.md`, and `AGENTS.md` are gone; do not run check.
    - Done when: proof for that mutation type is reported to the user.
 
@@ -38,9 +42,10 @@ are hard stops — honor them; do not work around them.
 |---|---|
 | Set up / init Tink (no extras) | `tink init --no-zen --no-tink-skills` (embeds `manage-tink`) |
 | …and ZEN / tink-skills / skip manage-tink | Only the matching `--with-*` / `--no-*` flags |
-| Add / list / check / refresh … | The matching `tink skill …` command |
+| Add / list / check / refresh / remove … | The matching `tink skill …` command |
 | List home catalog | `tink skill list --home` |
 | List home stash / promote from stash | `tink skill list --stash` / `tink skill add --stash NAME` |
+| Remove one project skill | `tink skill remove NAME` |
 | Remove scaffolding / destroy Tink setup | `tink destroy` (TTY) or `tink destroy --yes` (scripts) |
 
 "Set up Tink" does **not** authorize ZEN, tink-skills, or destroy.
@@ -48,11 +53,14 @@ are hard stops — honor them; do not work around them.
 ## Ownership (always)
 
 - Leave `.tink-source.json` untouched — it is the refresh **receipt**.
-- On a refusal, stop and report it; only authorized `destroy` may delete, and
-  only `.agents/`, `ZEN.md`, and `AGENTS.md`.
+- On a refusal, stop and report it. Authorized deletes are only:
+  - `tink skill remove NAME` → `.agents/skills/<name>/`
+  - `tink destroy` → `.agents/`, `ZEN.md`, and `AGENTS.md`
 - Treat local skills as non-refreshable unless they carry a valid receipt.
-- Never execute code from a skill while adding, checking, refreshing, or destroying.
+- Never execute code from a skill while adding, checking, refreshing, removing,
+  or destroying.
 - Home stash (`~/.tink/skills/`) is **not** an agent discovery root; do not
   symlink or copy from it by hand — use `tink skill add --stash NAME`.
 - Do not prune the home stash or by-project catalog unless the user explicitly
   asks and a supporting command exists (prune is out of v1).
+  `skill remove` does not prune stash or catalog.

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -1,7 +1,7 @@
 # Tink commands
 
 Load when choosing or running a mutation (step 2). Use the `tink skill …`
-form for add, list, check, and refresh.
+form for add, list, check, refresh, and remove.
 
 | Intent | Command |
 |---|---|
@@ -19,6 +19,7 @@ form for add, list, check, and refresh.
 | Check | `tink skill check` |
 | Refresh all clean imports | `tink skill refresh` |
 | Refresh one | `tink skill refresh NAME` |
+| Remove one project skill | `tink skill remove NAME` |
 | Destroy scaffolding | `tink destroy --yes` (non-TTY/scripts) or `tink destroy` (TTY, confirm `y`) |
 
 ## Layout facts
@@ -32,5 +33,6 @@ form for add, list, check, and refresh.
   Names are recorded in `catalog/by-project/<project>/meta.json`. List the
   catalog with `tink skill list --home` (TSV with header `project`, `root`,
   `skill`). Do not hand-parse `meta.json` when the CLI is available. Destroy
-  does not delete home or prune that catalog or stash. Project skill overwrites
-  are still refused.
+  does not delete home or prune that catalog or stash. `skill remove` deletes
+  only the project skill directory; it does not prune stash or catalog.
+  Project skill overwrites are still refused.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod manage_tink;
 mod paths;
 mod provenance;
 mod refresh;
+mod remove;
 mod skills;
 mod sources;
 mod stash;
@@ -105,6 +106,11 @@ pub enum SkillCommand {
         /// Optional skill name; default refreshes all imported skills
         name: Option<String>,
     },
+    /// Delete one project skill directory (not home stash or catalog)
+    Remove {
+        /// Skill directory name under `.agents/skills/`
+        name: String,
+    },
 }
 
 fn flag_tri(yes: bool, no: bool) -> Option<bool> {
@@ -191,6 +197,7 @@ fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
         }
         SkillCommand::Check => dispatch_skill_check(cwd),
         SkillCommand::Refresh { name } => dispatch_skill_refresh(cwd, name.as_deref()),
+        SkillCommand::Remove { name } => dispatch_skill_remove(cwd, &name),
     }
 }
 
@@ -322,6 +329,17 @@ fn dispatch_skill_list_stash() -> Result<(), Error> {
             println!("{}", style.accent(name));
         }
     }
+    Ok(())
+}
+
+fn dispatch_skill_remove(cwd: &Path, name: &str) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
+    let report = remove::remove_skill(cwd, name)?;
+    println!(
+        "{} {}",
+        style.success("Removed"),
+        style.accent(report.removed.display())
+    );
     Ok(())
 }
 

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -1,0 +1,47 @@
+//! `tink skill remove` — delete one project skill directory.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::Error;
+use crate::paths::{map_io, refuse_symlink};
+use crate::skills;
+
+#[derive(Debug)]
+pub struct RemoveReport {
+    pub removed: PathBuf,
+}
+
+/// Delete `<project>/.agents/skills/<name>/` only.
+///
+/// Does not touch `$TINK_HOME` stash trees or the by-project catalog.
+pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Error> {
+    if !skills::valid_skill_name(name) {
+        return Err(Error::msg(format!("Invalid skill name: {name}")));
+    }
+
+    let agents = project_root.join(".agents");
+    let skills_root = agents.join("skills");
+    let target = skills_root.join(name);
+
+    if agents.exists() || agents.is_symlink() {
+        refuse_symlink(&agents)?;
+    }
+    if skills_root.exists() || skills_root.is_symlink() {
+        refuse_symlink(&skills_root)?;
+    }
+
+    if !target.exists() && !target.is_symlink() {
+        return Err(Error::msg(format!("Skill not found: {name}")));
+    }
+    refuse_symlink(&target)?;
+    if !target.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing to remove non-directory: {}",
+            target.display()
+        )));
+    }
+
+    fs::remove_dir_all(&target).map_err(|e| map_io(&target, e))?;
+    Ok(RemoveReport { removed: target })
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -14,7 +14,7 @@ pub struct Skill {
     pub path: PathBuf,
 }
 
-fn valid_skill_name(name: &str) -> bool {
+pub fn valid_skill_name(name: &str) -> bool {
     if name.is_empty() || name.len() > 64 {
         return false;
     }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -1211,6 +1211,97 @@ fn d3_destroy_refuses_agents_symlink() {
     assert!(project.join(".agents").is_symlink());
 }
 
+// --- X*: skill remove ---
+
+#[test]
+fn x1_remove_deletes_project_skill_keeps_stash_and_catalog() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    let source = ws.root.join("demo-skill");
+    write_skill(&source, "demo-skill", "Do the work.");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+    assert!(Workspace::skill_path(&project, "demo-skill").is_dir());
+    ws.assert_cataloged("app", "demo-skill");
+
+    ws.cmd(&project)
+        .args(["skill", "remove", "demo-skill"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed"));
+
+    assert!(!Workspace::skill_path(&project, "demo-skill").exists());
+    ws.cmd(&project)
+        .args(["skill", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("demo-skill").not());
+    assert!(
+        ws.stash_skill("demo-skill").join("SKILL.md").is_file(),
+        "home stash must remain after project remove"
+    );
+    ws.assert_cataloged("app", "demo-skill");
+}
+
+#[test]
+fn x2_remove_missing_fails() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    ws.cmd(&project)
+        .args(["skill", "remove", "missing-skill"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("not found")
+                .or(predicate::str::contains("missing"))
+                .or(predicate::str::contains("Missing")),
+        );
+    assert!(Workspace::skill_path(&project, "manage-tink").is_dir());
+}
+
+#[test]
+fn x3_remove_refuses_agents_symlink() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let real = ws.root.join("real-agents");
+    fs::create_dir_all(real.join("skills").join("demo-skill")).unwrap();
+    write_skill(&real.join("skills").join("demo-skill"), "demo-skill", "body");
+    std::os::unix::fs::symlink(&real, project.join(".agents")).unwrap();
+    ws.cmd(&project)
+        .args(["skill", "remove", "demo-skill"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("symlink").or(predicate::str::contains("Symlink")));
+    assert!(project.join(".agents").is_symlink());
+    assert!(real.join("skills").join("demo-skill").join("SKILL.md").is_file());
+}
+
+#[test]
+fn x4_remove_does_not_delete_home_stash() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    let source = ws.root.join("keep-stash");
+    write_skill(&source, "keep-stash", "body");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+    let stash_md = ws.stash_skill("keep-stash").join("SKILL.md");
+    let before = fs::read(&stash_md).unwrap();
+    ws.cmd(&project)
+        .args(["skill", "remove", "keep-stash"])
+        .assert()
+        .success();
+    assert!(!Workspace::skill_path(&project, "keep-stash").exists());
+    let after = fs::read(&stash_md).unwrap();
+    assert_eq!(before, after);
+}
+
 // --- S*: safety ---
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `tink skill remove <name>` to delete one project skill under `.agents/skills/<name>/`
- Leave home stash and by-project catalog untouched (prune remains out of v1)
- Extend ACCEPTANCE (X1–X4), manage-tink docs, and README

## Test plan
- [x] `cargo test` (unit + 48 acceptance rows, including X1–X4)
- [ ] `tink skill add …` then `tink skill remove <name>`; confirm project skill gone and `~/.tink/skills/<name>/` still present
- [ ] `tink skill remove missing` fails with not found
- [ ] Symlinked `.agents` refuses remove


Made with [Cursor](https://cursor.com)