### PR TITLE
Add tink skill harvest for home stash seeding

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -4,8 +4,9 @@
 a project's `.agents/skills/`, proves them offline, refreshes clean GitHub
 imports, removes a project skill on request, ensures a home root at `~/.tink`
 (override: `TINK_HOME`), can list or promote skills from the home stash
-(`skills/<name>/`) into a project, and can update the CLI binary from GitHub
-Releases via `tink update`.
+(`skills/<name>/`) into a project, can harvest complete skill trees from known
+harness locations into that stash (create-only), and can update the CLI binary
+from GitHub Releases via `tink update`.
 
 **Authority:** This file is the evaluator. Implementation stops when every row
 below has an automated test that passes on macOS with `git` on `PATH`.
@@ -29,6 +30,7 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill list` | List project skills under `.agents/skills/` (read-only) |
 | `tink skill list --home` | List offline by-project catalog (`project`, `root`, `skill` TSV) |
 | `tink skill list --stash` | List skill names in the home stash (`skills/<name>/` with `SKILL.md`) |
+| `tink skill harvest` | Copy complete skill trees from known harness roots into the home stash (create-only; no project writes) |
 | `tink skill check` | Validate project skills; no network; no writes |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
 | `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` (not home stash or catalog) |
@@ -110,6 +112,10 @@ Ids are stable. Tests must name or comment the id they prove.
 | H2 | `skill add --stash <name>` when stash has that skill and project lacks it | Exit 0; installs under `.agents/skills/<name>/`; catalogs name; **no** network; stdout notes stash |
 | H3 | `skill add --stash <missing>` | Exit ≠ 0; mentions not found / missing; **no** GitHub network fetch |
 | H4 | `skill add --stash <name>` when project skill exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
+| H5 | `skill harvest` with fixture `$HOME/.agents/skills` + `$HOME/.claude/skills` + `TINK_HOME` | Copies complete skill trees into `$TINK_HOME/skills/`; no project `.agents` skill writes from harvest |
+| H6 | `skill harvest` when stash already identical | Exit 0; unchanged |
+| H7 | `skill harvest` when stash diverges | Exit 0; stash unchanged; stderr skip warn |
+| H8 | `skill harvest` skips `$TINK_HOME` and unsafe (symlink-inside) skill trees | Those omitted; others still deposited |
 
 ### CLI surface
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -115,7 +115,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | H5 | `skill harvest` with fixture `$HOME/.agents/skills` + `$HOME/.claude/skills` + `TINK_HOME` | Copies complete skill trees into `$TINK_HOME/skills/`; no project `.agents` skill writes from harvest |
 | H6 | `skill harvest` when stash already identical | Exit 0; unchanged |
 | H7 | `skill harvest` when stash diverges | Exit 0; stash unchanged; stderr skip warn |
-| H8 | `skill harvest` skips `$TINK_HOME` and unsafe (symlink-inside) skill trees | Those omitted; others still deposited |
+| H8 | `skill harvest` skips home stash sources and unsafe (symlink-inside) skill trees; still harvests cwd skills under `TINK_HOME` outside `skills/` | Stash/unsafe omitted; non-stash path under home deposited |
 
 ### CLI surface
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Stash, catalog, init flags, and destroy:
 ```console
 tink skill list --stash
 tink skill add --stash skill-name
+tink skill harvest
 tink skill list --home
 
 tink init --with-zen --with-tink-skills

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-tink
-description: "Tink CLI for repository-owned Agent Skills. Use when the user asks to set up or init Tink, add or refresh a project skill, remove a project skill, update the tink CLI, list or check .agents/skills, list the home by-project catalog or home stash, promote a stash skill into the project, or destroy project agent scaffolding."
+description: "Tink CLI for repository-owned Agent Skills. Use when the user asks to set up or init Tink, add or refresh a project skill, remove a project skill, harvest harness skills into the home stash, update the tink CLI, list or check .agents/skills, list the home by-project catalog or home stash, promote a stash skill into the project, or destroy project agent scaffolding."
 ---
 
 # Manage Tink
@@ -25,6 +25,8 @@ are hard stops — honor them; do not work around them.
    command; do not invent flags, merges, force-overwrites, or alternate install
    paths (no symlinks, manual copies, or private registries). To promote from
    the home stash into the project, use `tink skill add --stash NAME` only.
+   To fill the home stash from known harness skill locations, use
+   `tink skill harvest` only (create-only; does not write project skills).
    To remove a live project skill, use `tink skill remove NAME` only (does not
    prune home stash or catalog). To update the tink CLI binary, use
    `tink update` only.
@@ -46,6 +48,7 @@ are hard stops — honor them; do not work around them.
 | Add / list / check / refresh / remove … | The matching `tink skill …` command |
 | List home catalog | `tink skill list --home` |
 | List home stash / promote from stash | `tink skill list --stash` / `tink skill add --stash NAME` |
+| Harvest harness skills into home stash | `tink skill harvest` |
 | Remove one project skill | `tink skill remove NAME` |
 | Update the tink CLI | `tink update` |
 | Remove scaffolding / destroy Tink setup | `tink destroy` (TTY) or `tink destroy --yes` (scripts) |

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -13,6 +13,7 @@ form for add, list, check, refresh, and remove.
 | Add one skill | `tink skill add SOURCE` |
 | Add from multi-skill repo | `tink skill add SOURCE --skill NAME` |
 | Add from home stash | `tink skill add --stash NAME` |
+| Harvest harness skills into home stash | `tink skill harvest` |
 | List (this project) | `tink skill list` |
 | List (home catalog) | `tink skill list --home` |
 | List (home stash) | `tink skill list --stash` |
@@ -29,11 +30,26 @@ form for add, list, check, refresh, and remove.
 - Home (`$TINK_HOME` or `~/.tink`) is not an agent discovery root. Installs
   stash trees at `skills/<name>/`. List the stash with
   `tink skill list --stash`; promote into a project with
-  `tink skill add --stash NAME`. Matching GitHub tips install into the
-  project from that stash; divergent stash trees are repaired with a warning.
-  Names are recorded in `catalog/by-project/<project>/meta.json`. List the
-  catalog with `tink skill list --home` (TSV with header `project`, `root`,
-  `skill`). Do not hand-parse `meta.json` when the CLI is available. Destroy
-  does not delete home or prune that catalog or stash. `skill remove` deletes
-  only the project skill directory; it does not prune stash or catalog.
+  `tink skill add --stash NAME`. `tink skill harvest` copies complete trees
+  from known harness roots into the stash create-only (never overwrites a
+  divergent stash entry). Global roots include `~/.agents/skills`,
+  `~/.claude/skills`, `~/.codex/skills`, `~/.cursor/skills`,
+  `~/.cursor/skills-cursor`, `~/.copilot/skills`, `~/.github/skills`,
+  `~/.codeium/windsurf/skills`, `~/.cline/skills`, `~/.aider/skills`,
+  `~/.gemini/skills` (+ Antigravity paths), `~/.roo/skills`,
+  `~/.kilocode/skills`, `~/.amazonq/skills`, `~/.augment/skills`,
+  `~/.tabnine/skills`, `~/.sourcegraph/skills`, and
+  `~/.config/opencode/skills`. Project (cwd) roots include `.agents/skills`,
+  `.claude/skills`, `.codex/skills`, `.cursor/skills`, `.github/skills`,
+  `.windsurf/skills`, `.cline/skills`, `.clinerules/skills`, `.aider/skills`,
+  `.gemini/skills`, `.agent/skills`, `.roo/skills`, `.kilocode/skills`,
+  `.amazonq/skills`, `.augment/skills`, `.tabnine/skills`, `.opencode/skills`,
+  and `.sourcegraph/skills`. Matching GitHub tips install into the project
+  from that stash; divergent stash trees are repaired with a warning on
+  `skill add`. Names are recorded in
+  `catalog/by-project/<project>/meta.json`. List the catalog with
+  `tink skill list --home` (TSV with header `project`, `root`, `skill`).
+  Do not hand-parse `meta.json` when the CLI is available. Destroy does not
+  delete home or prune that catalog or stash. `skill remove` deletes only
+  the project skill directory; it does not prune stash or catalog.
   Project skill overwrites are still refused.

--- a/src/harvest.rs
+++ b/src/harvest.rs
@@ -1,0 +1,354 @@
+//! `tink skill harvest` — copy harness skill trees into the home stash.
+//!
+//! Create-only: never repair divergent or receipt-backed stash entries.
+//! Stash remains offline inventory, not an agent discovery root.
+//!
+//! Root tables track documented Agent Skills (`SKILL.md`) locations from:
+//! - agentskills.io client guidance (`.agents/skills` + client-specific)
+//! - Cursor docs (`.agents`/`.cursor` + Claude/Codex compat)
+//! - OpenAI Codex docs (`~/.agents`, `.agents`, `/etc/codex` skipped here)
+//! - mdskills.ai install paths (Claude, Cursor, Copilot, Codex, Gemini)
+//! - Windsurf/Devin, Cline, Gemini CLI, and community agent path tables
+
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::Error;
+use crate::home::{ensure_inventory_root, skills_stash_path};
+use crate::paths::{map_io, refuse_symlink};
+use crate::skills::{self, PreflightOutcome, Skill};
+
+/// Relative skill roots under `$HOME` (user/global harness locations).
+///
+/// Sorted for stable discovery order. Missing dirs are skipped.
+const GLOBAL_SKILL_ROOTS: &[&str] = &[
+    // Cross-agent / Codex user scope
+    ".agents/skills",
+    // Claude Code
+    ".claude/skills",
+    // Codex (also used; Cursor loads these for compat)
+    ".codex/skills",
+    // Cursor
+    ".cursor/skills",
+    ".cursor/skills-cursor",
+    // GitHub Copilot (VS Code)
+    ".copilot/skills",
+    ".github/skills",
+    // Windsurf / Cascade
+    ".codeium/windsurf/skills",
+    // Cline
+    ".cline/skills",
+    // Aider
+    ".aider/skills",
+    // Gemini CLI + Antigravity
+    ".gemini/skills",
+    ".gemini/antigravity/skills",
+    ".gemini/antigravity/global_skills",
+    // Roo / Kilo
+    ".roo/skills",
+    ".kilocode/skills",
+    // Amazon Q, Augment, Tabnine, Sourcegraph
+    ".amazonq/skills",
+    ".augment/skills",
+    ".tabnine/skills",
+    ".sourcegraph/skills",
+    // OpenCode (XDG-style)
+    ".config/opencode/skills",
+];
+
+/// Relative skill roots under the current project (cwd).
+const PROJECT_SKILL_ROOTS: &[&str] = &[
+    // Cross-agent / Codex repo scope
+    ".agents/skills",
+    // Claude / Cursor / Codex project
+    ".claude/skills",
+    ".codex/skills",
+    ".cursor/skills",
+    // Copilot
+    ".github/skills",
+    // Windsurf
+    ".windsurf/skills",
+    // Cline (+ legacy)
+    ".cline/skills",
+    ".clinerules/skills",
+    // Aider
+    ".aider/skills",
+    // Gemini CLI + Antigravity (note singular `.agent`)
+    ".gemini/skills",
+    ".agent/skills",
+    // Roo / Kilo
+    ".roo/skills",
+    ".kilocode/skills",
+    // Amazon Q, Augment, Tabnine, OpenCode, Sourcegraph
+    ".amazonq/skills",
+    ".augment/skills",
+    ".tabnine/skills",
+    ".opencode/skills",
+    ".sourcegraph/skills",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarvestAction {
+    Created,
+    Unchanged,
+    Skipped,
+}
+
+#[derive(Debug, Clone)]
+pub struct HarvestEvent {
+    pub name: String,
+    pub source: PathBuf,
+    pub action: HarvestAction,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct HarvestReport {
+    pub events: Vec<HarvestEvent>,
+    pub created: usize,
+    pub unchanged: usize,
+    pub skipped: usize,
+}
+
+fn user_home() -> Result<PathBuf, Error> {
+    let home = env::var_os("HOME").ok_or_else(|| Error::msg("HOME is not set"))?;
+    Ok(PathBuf::from(home))
+}
+
+fn is_under(path: &Path, ancestor: &Path) -> bool {
+    path.starts_with(ancestor)
+}
+
+fn resolve_skill_root(path: &Path) -> Result<Option<PathBuf>, Error> {
+    if path.is_symlink() {
+        let target = fs::read_link(path).map_err(|e| map_io(path, e))?;
+        let resolved = if target.is_absolute() {
+            target
+        } else {
+            path.parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(target)
+        };
+        let canonical = match resolved.canonicalize() {
+            Ok(p) => p,
+            Err(_) => return Ok(None),
+        };
+        if canonical.join("SKILL.md").is_file() {
+            return Ok(Some(canonical));
+        }
+        return Ok(None);
+    }
+    if path.is_dir() && path.join("SKILL.md").is_file() {
+        match path.canonicalize() {
+            Ok(p) => Ok(Some(p)),
+            Err(_) => Ok(None),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+/// Recursively find skill directories (dirs containing `SKILL.md`) under `root`.
+fn find_skills_under(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let root = if root.is_symlink() {
+        match root.canonicalize() {
+            Ok(p) if p.is_dir() => p,
+            _ => return Ok(()),
+        }
+    } else {
+        refuse_symlink(root)?;
+        if !root.is_dir() {
+            return Ok(());
+        }
+        root.to_path_buf()
+    };
+
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
+        for entry in fs::read_dir(dir).map_err(|e| map_io(dir, e))? {
+            let entry = entry.map_err(|e| map_io(dir, e))?;
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with('.') {
+                continue;
+            }
+            let path = entry.path();
+            if path.is_symlink() {
+                if let Some(resolved) = resolve_skill_root(&path)? {
+                    out.push(resolved);
+                }
+                continue;
+            }
+            if !path.is_dir() {
+                continue;
+            }
+            if path.join("SKILL.md").is_file() {
+                if let Some(resolved) = resolve_skill_root(&path)? {
+                    out.push(resolved);
+                }
+                // Skill trees are leaves for discovery — do not nest-scan.
+                continue;
+            }
+            walk(&path, out)?;
+        }
+        Ok(())
+    }
+
+    // Root itself may be a single skill directory.
+    if root.join("SKILL.md").is_file() {
+        if let Some(resolved) = resolve_skill_root(&root)? {
+            out.push(resolved);
+        }
+        return Ok(());
+    }
+    walk(&root, out)
+}
+
+fn candidate_roots(cwd: &Path) -> Result<Vec<PathBuf>, Error> {
+    let home = user_home()?;
+    let mut roots = Vec::new();
+    for rel in GLOBAL_SKILL_ROOTS {
+        roots.push(home.join(rel));
+    }
+    for rel in PROJECT_SKILL_ROOTS {
+        roots.push(cwd.join(rel));
+    }
+    Ok(roots)
+}
+
+fn create_only_deposit(
+    skill: &Skill,
+    stash: &Path,
+) -> Result<(HarvestAction, Option<String>), Error> {
+    // Validate the tree is copyable before touching the stash.
+    match skills::preflight_install(skill, stash, None) {
+        Err(err) => Ok((HarvestAction::Skipped, Some(err.to_string()))),
+        Ok(PreflightOutcome::Ready) => {
+            skills::install_local(skill, stash, None)?;
+            Ok((HarvestAction::Created, None))
+        }
+        Ok(PreflightOutcome::Identical) => Ok((HarvestAction::Unchanged, None)),
+        Ok(PreflightOutcome::Divergent) => {
+            let target = stash.join(&skill.name);
+            if target.is_dir()
+                && skills::skill_contents_equal_except(
+                    &target,
+                    &skill.path,
+                    &[".tink-source.json"],
+                )?
+            {
+                Ok((HarvestAction::Unchanged, None))
+            } else {
+                Ok((
+                    HarvestAction::Skipped,
+                    Some("stash differs; create-only".into()),
+                ))
+            }
+        }
+    }
+}
+
+/// Scan harness skill locations and create missing trees in the home stash.
+pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
+    let (tink_home, _) = ensure_inventory_root(None)?;
+    let stash = skills_stash_path(&tink_home);
+    let tink_home_canon = tink_home
+        .canonicalize()
+        .unwrap_or_else(|_| tink_home.clone());
+
+    let mut skill_paths = Vec::new();
+    for root in candidate_roots(cwd)? {
+        find_skills_under(&root, &mut skill_paths)?;
+    }
+    skill_paths.sort();
+    skill_paths.dedup();
+
+    let mut seen_paths: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut claimed_names: BTreeSet<String> = BTreeSet::new();
+    let mut report = HarvestReport::default();
+
+    for path in skill_paths {
+        if is_under(&path, &tink_home_canon) || is_under(&path, &tink_home) {
+            report.events.push(HarvestEvent {
+                name: path
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.display().to_string()),
+                source: path,
+                action: HarvestAction::Skipped,
+                detail: Some("under TINK_HOME".into()),
+            });
+            report.skipped += 1;
+            continue;
+        }
+        if !seen_paths.insert(path.clone()) {
+            continue;
+        }
+
+        let skill = match skills::read_skill(&path, true) {
+            Ok(skill) => skill,
+            Err(err) => {
+                report.events.push(HarvestEvent {
+                    name: path
+                        .file_name()
+                        .map(|s| s.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| "unknown".into()),
+                    source: path,
+                    action: HarvestAction::Skipped,
+                    detail: Some(err.to_string()),
+                });
+                report.skipped += 1;
+                continue;
+            }
+        };
+
+        if !skills::valid_skill_name(&skill.name) {
+            report.events.push(HarvestEvent {
+                name: skill.name,
+                source: path,
+                action: HarvestAction::Skipped,
+                detail: Some("invalid or reserved name".into()),
+            });
+            report.skipped += 1;
+            continue;
+        }
+
+        if claimed_names.contains(&skill.name) {
+            report.events.push(HarvestEvent {
+                name: skill.name,
+                source: path,
+                action: HarvestAction::Skipped,
+                detail: Some("name already harvested".into()),
+            });
+            report.skipped += 1;
+            continue;
+        }
+
+        let (action, detail) = create_only_deposit(&skill, &stash)?;
+        match action {
+            HarvestAction::Created => {
+                claimed_names.insert(skill.name.clone());
+                report.created += 1;
+            }
+            HarvestAction::Unchanged => {
+                claimed_names.insert(skill.name.clone());
+                report.unchanged += 1;
+            }
+            HarvestAction::Skipped => {
+                report.skipped += 1;
+            }
+        }
+        report.events.push(HarvestEvent {
+            name: skill.name,
+            source: path,
+            action,
+            detail,
+        });
+    }
+
+    Ok(report)
+}

--- a/src/harvest.rs
+++ b/src/harvest.rs
@@ -256,9 +256,7 @@ fn create_only_deposit(
 pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
     let (tink_home, _) = ensure_inventory_root(None)?;
     let stash = skills_stash_path(&tink_home);
-    let tink_home_canon = tink_home
-        .canonicalize()
-        .unwrap_or_else(|_| tink_home.clone());
+    let stash_canon = stash.canonicalize().unwrap_or_else(|_| stash.clone());
 
     let mut skill_paths = Vec::new();
     for root in candidate_roots(cwd)? {
@@ -272,7 +270,9 @@ pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
     let mut report = HarvestReport::default();
 
     for path in skill_paths {
-        if is_under(&path, &tink_home_canon) || is_under(&path, &tink_home) {
+        // Skip only the stash inventory — not the whole TINK_HOME tree
+        // (a workspace nested under TINK_HOME remains harvestable).
+        if is_under(&path, &stash_canon) || is_under(&path, &stash) {
             report.events.push(HarvestEvent {
                 name: path
                     .file_name()
@@ -280,7 +280,7 @@ pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
                     .unwrap_or_else(|| path.display().to_string()),
                 source: path,
                 action: HarvestAction::Skipped,
-                detail: Some("under TINK_HOME".into()),
+                detail: Some("under home stash".into()),
             });
             report.skipped += 1;
             continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod check;
 mod destroy;
 mod error;
 mod git;
+mod harvest;
 mod home;
 mod init;
 mod manage_tink;
@@ -114,6 +115,8 @@ pub enum SkillCommand {
         /// Skill directory name under `.agents/skills/`
         name: String,
     },
+    /// Copy harness skill trees into the home stash (create-only)
+    Harvest,
 }
 
 fn flag_tri(yes: bool, no: bool) -> Option<bool> {
@@ -206,6 +209,7 @@ fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
         SkillCommand::Check => dispatch_skill_check(cwd),
         SkillCommand::Refresh { name } => dispatch_skill_refresh(cwd, name.as_deref()),
         SkillCommand::Remove { name } => dispatch_skill_remove(cwd, &name),
+        SkillCommand::Harvest => dispatch_skill_harvest(cwd),
     }
 }
 
@@ -347,6 +351,50 @@ fn dispatch_skill_remove(cwd: &Path, name: &str) -> Result<(), Error> {
         "{} {}",
         style.success("Removed"),
         style.accent(report.removed.display())
+    );
+    Ok(())
+}
+
+fn dispatch_skill_harvest(cwd: &Path) -> Result<(), Error> {
+    let out = CliStyle::auto_stdout();
+    let err = CliStyle::auto_stderr();
+    let report = harvest::harvest(cwd)?;
+    for event in &report.events {
+        match event.action {
+            harvest::HarvestAction::Created => {
+                println!(
+                    "{} {} {}",
+                    out.success("created"),
+                    out.accent(&event.name),
+                    out.muted(event.source.display())
+                );
+            }
+            harvest::HarvestAction::Unchanged => {
+                println!(
+                    "{} {} {}",
+                    out.muted("unchanged"),
+                    out.accent(&event.name),
+                    out.muted(event.source.display())
+                );
+            }
+            harvest::HarvestAction::Skipped => {
+                let detail = event.detail.as_deref().unwrap_or("skipped");
+                eprintln!(
+                    "{} {} {} ({})",
+                    err.warn("skipped"),
+                    err.accent(&event.name),
+                    err.muted(event.source.display()),
+                    detail
+                );
+            }
+        }
+    }
+    println!(
+        "{} created={} unchanged={} skipped={}",
+        out.success("Harvest"),
+        out.accent(report.created),
+        out.accent(report.unchanged),
+        out.accent(report.skipped)
     );
     Ok(())
 }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -801,6 +801,149 @@ fn h4_skill_add_stash_refuses_overwrite_when_diverged() {
     assert!(body.contains("project local body"));
 }
 
+#[test]
+fn h5_skill_harvest_copies_harness_skills_into_stash() {
+    let ws = Workspace::new();
+    let home = ws.root.join("home");
+    let project = ws.project("app");
+    write_skill(
+        &home.join(".agents").join("skills").join("agents-skill"),
+        "agents-skill",
+        "from agents",
+    );
+    write_skill(
+        &home.join(".claude").join("skills").join("claude-skill"),
+        "claude-skill",
+        "from claude",
+    );
+    // Nested under codex (recursive).
+    write_skill(
+        &home
+            .join(".codex")
+            .join("skills")
+            .join("workflows")
+            .join("nested-skill"),
+        "nested-skill",
+        "from codex nest",
+    );
+
+    ws.cmd(&project)
+        .env("HOME", &home)
+        .args(["skill", "harvest"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("created")
+                .and(predicate::str::contains("agents-skill"))
+                .and(predicate::str::contains("claude-skill"))
+                .and(predicate::str::contains("nested-skill")),
+        );
+
+    assert!(ws.stash_skill("agents-skill").join("SKILL.md").is_file());
+    assert!(ws.stash_skill("claude-skill").join("SKILL.md").is_file());
+    assert!(ws.stash_skill("nested-skill").join("SKILL.md").is_file());
+    assert!(
+        !project.join(".agents").exists(),
+        "harvest must not create project .agents"
+    );
+}
+
+#[test]
+fn h6_skill_harvest_identical_is_unchanged() {
+    let ws = Workspace::new();
+    let home = ws.root.join("home");
+    let project = ws.project("app");
+    let skill = home.join(".agents").join("skills").join("same-skill");
+    write_skill(&skill, "same-skill", "body");
+    ws.cmd(&project)
+        .env("HOME", &home)
+        .args(["skill", "harvest"])
+        .assert()
+        .success();
+    ws.cmd(&project)
+        .env("HOME", &home)
+        .args(["skill", "harvest"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("unchanged").and(predicate::str::contains("same-skill")));
+}
+
+#[test]
+fn h7_skill_harvest_divergent_skips_without_repair() {
+    let ws = Workspace::new();
+    let home = ws.root.join("home");
+    let project = ws.project("app");
+    write_skill(
+        &home.join(".agents").join("skills").join("demo-skill"),
+        "demo-skill",
+        "harness body",
+    );
+    // Pre-seed divergent stash.
+    write_skill(ws.stash_skill("demo-skill").as_path(), "demo-skill", "stash body");
+    let before = fs::read_to_string(ws.stash_skill("demo-skill").join("SKILL.md")).unwrap();
+
+    ws.cmd(&project)
+        .env("HOME", &home)
+        .args(["skill", "harvest"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("skipped").and(predicate::str::contains("demo-skill")));
+
+    let after = fs::read_to_string(ws.stash_skill("demo-skill").join("SKILL.md")).unwrap();
+    assert_eq!(before, after, "create-only must not repair divergent stash");
+    assert!(after.contains("stash body"));
+}
+
+#[test]
+fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
+    let ws = Workspace::new();
+    let home = ws.root.join("home");
+    let project = ws.project("app");
+    write_skill(
+        &home.join(".agents").join("skills").join("good-skill"),
+        "good-skill",
+        "ok",
+    );
+    // Unsafe: symlink inside skill tree.
+    let bad = home.join(".claude").join("skills").join("bad-skill");
+    write_skill(&bad, "bad-skill", "has link");
+    std::os::unix::fs::symlink("/tmp", bad.join("link-out")).unwrap();
+
+    ws.cmd(&project)
+        .env("HOME", &home)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    write_skill(
+        ws.stash_skill("from-home").as_path(),
+        "from-home",
+        "stash resident",
+    );
+    // Harness entry that realpaths into TINK_HOME — must be skipped as a source.
+    fs::create_dir_all(home.join(".cursor").join("skills")).unwrap();
+    std::os::unix::fs::symlink(
+        ws.stash_skill("from-home"),
+        home.join(".cursor").join("skills").join("from-home"),
+    )
+    .unwrap();
+
+    ws.cmd(&project)
+        .env("HOME", &home)
+        .args(["skill", "harvest"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("good-skill"))
+        .stderr(
+            predicate::str::contains("bad-skill")
+                .and(predicate::str::contains("from-home")),
+        );
+
+    assert!(ws.stash_skill("good-skill").join("SKILL.md").is_file());
+    assert!(!ws.stash_skill("bad-skill").exists());
+    let home_body = fs::read_to_string(ws.stash_skill("from-home").join("SKILL.md")).unwrap();
+    assert!(home_body.contains("stash resident"));
+}
+
 // --- V*: CLI surface (skill nest) ---
 
 #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -898,11 +898,18 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
 fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
     let ws = Workspace::new();
     let home = ws.root.join("home");
-    let project = ws.project("app");
+    // Project lives under TINK_HOME but outside skills/ — must still harvest.
+    let project = ws.inventory.join("workspace");
+    fs::create_dir_all(&project).unwrap();
     write_skill(
         &home.join(".agents").join("skills").join("good-skill"),
         "good-skill",
         "ok",
+    );
+    write_skill(
+        &project.join(".agents").join("skills").join("nested-home-skill"),
+        "nested-home-skill",
+        "under tink home workspace",
     );
     // Unsafe: symlink inside skill tree.
     let bad = home.join(".claude").join("skills").join("bad-skill");
@@ -919,7 +926,7 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
         "from-home",
         "stash resident",
     );
-    // Harness entry that realpaths into TINK_HOME — must be skipped as a source.
+    // Harness entry that realpaths into the stash — must be skipped as a source.
     fs::create_dir_all(home.join(".cursor").join("skills")).unwrap();
     std::os::unix::fs::symlink(
         ws.stash_skill("from-home"),
@@ -932,13 +939,17 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
         .args(["skill", "harvest"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("good-skill"))
+        .stdout(
+            predicate::str::contains("good-skill")
+                .and(predicate::str::contains("nested-home-skill")),
+        )
         .stderr(
             predicate::str::contains("bad-skill")
                 .and(predicate::str::contains("from-home")),
         );
 
     assert!(ws.stash_skill("good-skill").join("SKILL.md").is_file());
+    assert!(ws.stash_skill("nested-home-skill").join("SKILL.md").is_file());
     assert!(!ws.stash_skill("bad-skill").exists());
     let home_body = fs::read_to_string(ws.stash_skill("from-home").join("SKILL.md")).unwrap();
     assert!(home_body.contains("stash resident"));


### PR DESCRIPTION
## Summary
- Adds `tink skill harvest` to scan documented harness skill roots (global + cwd) and copy complete `SKILL.md` trees into `$TINK_HOME/skills/` create-only.
- Covers nested category folders, symlink realpath + dedupe, and skips divergent/receipt-backed stash entries, unsafe trees, and `TINK_HOME` sources.
- Acceptance rows H5–H8 plus manage-tink / README / ACCEPTANCE updates.

## Test plan
- [x] `cargo test --test acceptance skill_harvest`
- [x] `cargo test --test acceptance` (55/55)
- [ ] Manual: `tink skill harvest` then `tink skill list --stash`
- [ ] Confirm divergent stash entries are skipped (not repaired)

## Reviews
- Bugbot: 1 medium — `TINK_HOME` skip excludes any path under the home root (not only `skills/`), which can miss project skills if someone nests a workspace under `TINK_HOME`
- Security: no medium/high/critical findings


Made with [Cursor](https://cursor.com)