### PR TITLE
Unify stash write policy for create-only and repair

### DIFF
--- a/docs/handoff-unify-stash-write-policy.md
+++ b/docs/handoff-unify-stash-write-policy.md
@@ -1,0 +1,147 @@
+# Handoff: Unify stash write policy
+
+**Repo:** tink (`main` @ shipped `v0.2.2` baseline; branch from current `main`)  
+**Outcome:** One module owns “what happens when `$TINK_HOME/skills/<name>/` exists and differs.” Callers express intent; they do not re-implement preflight branches.  
+**Authority:** This plan + existing [`ACCEPTANCE.md`](../ACCEPTANCE.md) rows A6, H6–H8, P5–P7. Do not expand product behavior.  
+**Non-goals:** discovery unification, three-store install deepen, paths module, new CLI flags, stash prune, version bump/release unless product asks.
+
+**Framing:** Prefer the smallest complete loop. Do **not** introduce a `StashPolicy` enum/trait/adapters in Phase 1 unless the compile forces a shared type. Charge complexity rent — deletion of `harvest::create_only_deposit` is the win.
+
+```mermaid
+flowchart LR
+  add["add"] --> stash["stash"]
+  harvest["harvest"] --> stash
+  refresh["refresh"] -.->|"Phase 2 only"| stash
+  stash --> skills["skills::preflight / install_local"]
+```
+
+---
+
+## Context (why)
+
+Today diverge handling is split:
+
+| Caller | Function | On diverge |
+|--------|----------|------------|
+| `add` | `stash::deposit` | repair |
+| `harvest` | `harvest::create_only_deposit` | skip (receipt-equal body → unchanged) |
+| `refresh` | `preflight_refresh` / `deposit_refresh` / `sync_from_installed` | refuse or sync under refresh rules |
+
+All three already sit on `skills::preflight_install` outcomes. The bug class is locality, not missing features.
+
+---
+
+## Baseline (before any edit)
+
+**Gate B0**
+
+- [ ] Working tree clean; branch cut from current `main`
+- [ ] `cargo test --test acceptance` → 55 pass
+- [ ] Record HEAD SHA for rollback
+
+---
+
+## Phase 1 — Move create-only into `stash` (required)
+
+**Intent:** Harvest stops owning diverge logic. Behavior unchanged.
+
+### Steps
+
+1. In [`src/stash.rs`](../src/stash.rs), add a create-only write path next to `deposit` (same preflight, same tree engine):
+   - `Ready` → `skills::install_local(..., None)` → Created
+   - `Identical` → Unchanged
+   - `Divergent` + body equal except `.tink-source.json` → Unchanged
+   - `Divergent` otherwise → Skipped (no repair, no write)
+   - Unsafe/unreadable trees → Skipped with reason (match today’s harvest error→skip)
+2. Return a small result harvest’s CLI already understands (Created / Unchanged / Skipped + optional detail). Avoid a parallel type zoo; reuse or map cleanly to `HarvestAction`.
+3. In [`src/harvest.rs`](../src/harvest.rs), delete `create_only_deposit`; call the stash function. Keep root tables, recursive walk, name collision, and “skip under home stash root” in harvest.
+4. Leave [`src/add.rs`](../src/add.rs) on `stash::deposit` (repair). Leave refresh helpers unchanged.
+
+### Gate P1 (all must pass)
+
+| Check | Expect |
+|-------|--------|
+| `cargo test --test acceptance a6_` | Repair-on-add unchanged |
+| `cargo test --test acceptance h6_ h7_ h8_` | Identical / skip diverge / unsafe + stash-root skip |
+| `cargo test --test acceptance skill_harvest` | All harvest rows |
+| `cargo test --test acceptance` | Full suite green |
+| Diff review | `create_only_deposit` gone from harvest; no new public policy enum unless unavoidable |
+| Docs | No ACCEPTANCE.md product-behavior edits required for Phase 1 |
+
+**Stop if:** A6 or H7 behavior flips, or the change grows a framework instead of a moved function.
+
+**Phase 1 alone is a complete, shippable PR.**
+
+---
+
+## Phase 2 — Refresh locality (optional, only if cheap)
+
+**Intent:** If refresh’s stash path is a thin wrapper over the same preflight, route it through `stash` without changing P* outcomes.
+
+### Steps
+
+1. Read [`src/refresh.rs`](../src/refresh.rs) and [`src/stash.rs`](../src/stash.rs) (`preflight_refresh`, `deposit_refresh`, `sync_from_installed`).
+2. Fold only clear duplication. Do **not** merge refuse-with-error into create-only skip.
+3. If folding needs new policy vocabulary or changes P5/P7 semantics → **skip Phase 2**; note follow-up instead of forcing it.
+
+### Gate P2
+
+| Check | Expect |
+|-------|--------|
+| `cargo test --test acceptance p1_ p2_ p3_ p4_ p5_ p6_ p7_` | All refresh rows unchanged |
+| `cargo test --test acceptance` | Full suite green |
+| Diff | Net deletion or neutral; no new acceptance rows |
+
+**Stop if:** Refresh refuse cannot share a type with harvest skip without semantic muddle.
+
+---
+
+## Phase 3 — Unit tests at the stash seam (optional leverage)
+
+**Intent:** Prove diverge outcomes without the full CLI (acceptance stays the product evaluator).
+
+### Steps
+
+1. Add focused unit tests in `stash` (temp `TINK_HOME`) for:
+   - missing → create (create-only)
+   - identical → unchanged
+   - diverge → skip (create-only)
+   - diverge → repair (`deposit`)
+   - receipt-only body match → unchanged (create-only)
+2. Do **not** delete acceptance rows.
+
+### Gate P3
+
+| Check | Expect |
+|-------|--------|
+| `cargo test` filtered to new stash unit tests | Pass |
+| `cargo test --test acceptance a6_ h6_ h7_` | Still green |
+| Assertions | Outcomes / tree bytes — not private helper names |
+
+---
+
+## Explicit out of scope
+
+| Item | Why |
+|------|-----|
+| `StashPolicy` enum / trait / strategy pattern in Phase 1 | Speculative abstraction |
+| Unifying `skills::discover` vs harvest walk | Separate architecture candidate |
+| Deepening `place_skill` three-store contract | Separate candidate |
+| `paths::project_skills_root` | Separate candidate |
+| Automating ACCEPTANCE S2 | Separate candidate |
+| Changing create-only ↔ repair product semantics | Needs explicit product ask |
+
+---
+
+## Suggested PR shape
+
+- **Branch:** `refactor/stash-create-only-owner` (from `main`)
+- **Commits:** one commit per phase that lands; Phase 1 alone is enough to merge
+- **PR body:** link this document; paste Gate P1 command results; state behavior-preserving
+- **Release:** do not bump Cargo version / tag unless asked
+
+---
+
+## Done when
+
+Phase 1 Gate P1 is green and `harvest` no longer contains diverge-branch write logic. Phases 2–3 are optional follow-ups, not blockers for this handoff.

--- a/src/harvest.rs
+++ b/src/harvest.rs
@@ -18,7 +18,8 @@ use std::path::{Path, PathBuf};
 use crate::error::Error;
 use crate::home::{ensure_inventory_root, skills_stash_path};
 use crate::paths::{map_io, refuse_symlink};
-use crate::skills::{self, PreflightOutcome, Skill};
+use crate::skills;
+use crate::stash::{self, CreateOnlyWrite};
 
 /// Relative skill roots under `$HOME` (user/global harness locations).
 ///
@@ -220,35 +221,11 @@ fn candidate_roots(cwd: &Path) -> Result<Vec<PathBuf>, Error> {
     Ok(roots)
 }
 
-fn create_only_deposit(
-    skill: &Skill,
-    stash: &Path,
-) -> Result<(HarvestAction, Option<String>), Error> {
-    // Validate the tree is copyable before touching the stash.
-    match skills::preflight_install(skill, stash, None) {
-        Err(err) => Ok((HarvestAction::Skipped, Some(err.to_string()))),
-        Ok(PreflightOutcome::Ready) => {
-            skills::install_local(skill, stash, None)?;
-            Ok((HarvestAction::Created, None))
-        }
-        Ok(PreflightOutcome::Identical) => Ok((HarvestAction::Unchanged, None)),
-        Ok(PreflightOutcome::Divergent) => {
-            let target = stash.join(&skill.name);
-            if target.is_dir()
-                && skills::skill_contents_equal_except(
-                    &target,
-                    &skill.path,
-                    &[".tink-source.json"],
-                )?
-            {
-                Ok((HarvestAction::Unchanged, None))
-            } else {
-                Ok((
-                    HarvestAction::Skipped,
-                    Some("stash differs; create-only".into()),
-                ))
-            }
-        }
+fn map_create_only(write: CreateOnlyWrite) -> (HarvestAction, Option<String>) {
+    match write {
+        CreateOnlyWrite::Created => (HarvestAction::Created, None),
+        CreateOnlyWrite::Unchanged => (HarvestAction::Unchanged, None),
+        CreateOnlyWrite::Skipped(detail) => (HarvestAction::Skipped, detail),
     }
 }
 
@@ -328,7 +305,8 @@ pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
             continue;
         }
 
-        let (action, detail) = create_only_deposit(&skill, &stash)?;
+        let (_, write) = stash::deposit_create_only(&skill)?;
+        let (action, detail) = map_create_only(write);
         match action {
             HarvestAction::Created => {
                 claimed_names.insert(skill.name.clone());

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -23,6 +23,17 @@ pub enum StashWrite {
     Repaired,
 }
 
+/// Result of a create-only stash write (never repairs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CreateOnlyWrite {
+    /// Stash entry was missing; tree was created.
+    Created,
+    /// Stash already matched (exact, or body equal except receipt).
+    Unchanged,
+    /// Divergent or unreadable; no write. Optional reason for the caller.
+    Skipped(Option<String>),
+}
+
 fn clear_path(target: &Path) -> Result<(), Error> {
     refuse_symlink(target)?;
     if target.is_dir() {
@@ -92,6 +103,40 @@ pub fn deposit(
             clear_path(&stash.join(&skill.name))?;
             let (path, _) = skills::install_local(skill, &stash, provenance)?;
             Ok((path, StashWrite::Repaired))
+        }
+    }
+}
+
+/// Copy skill tree into the home stash only when missing or identical.
+///
+/// Divergent trees are skipped (no repair). Unreadable/unsafe trees surface as
+/// [`CreateOnlyWrite::Skipped`] with the error detail — same create-only
+/// contract harvest used before this lived in `stash`.
+pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), Error> {
+    let stash = stash_root(None)?;
+    let target = stash.join(&skill.name);
+    match skills::preflight_install(skill, &stash, None) {
+        Err(err) => Ok((target, CreateOnlyWrite::Skipped(Some(err.to_string())))),
+        Ok(PreflightOutcome::Ready) => {
+            let (path, _) = skills::install_local(skill, &stash, None)?;
+            Ok((path, CreateOnlyWrite::Created))
+        }
+        Ok(PreflightOutcome::Identical) => Ok((target, CreateOnlyWrite::Unchanged)),
+        Ok(PreflightOutcome::Divergent) => {
+            if target.is_dir()
+                && skills::skill_contents_equal_except(
+                    &target,
+                    &skill.path,
+                    &[".tink-source.json"],
+                )?
+            {
+                Ok((target, CreateOnlyWrite::Unchanged))
+            } else {
+                Ok((
+                    target,
+                    CreateOnlyWrite::Skipped(Some("stash differs; create-only".into())),
+                ))
+            }
         }
     }
 }

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -278,3 +278,178 @@ pub fn sync_from_installed(installed: &Skill) -> Result<(), Error> {
 pub fn deposit_refresh(new_skill: &Skill, new_provenance: &Provenance) -> Result<(), Error> {
     deposit(new_skill, Some(new_provenance)).map(|_| ())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::home::TINK_HOME_ENV;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use tempfile::TempDir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Isolates `TINK_HOME` for in-process stash writes (serialized).
+    struct TempHome {
+        home: PathBuf,
+        root: PathBuf,
+        _temp: TempDir,
+        prev: Option<std::ffi::OsString>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+            let temp = TempDir::new().unwrap();
+            let root = temp.path().to_path_buf();
+            let home = root.join("tink-home");
+            let prev = std::env::var_os(TINK_HOME_ENV);
+            // SAFETY: exclusive via env_lock for all tests in this module.
+            unsafe { std::env::set_var(TINK_HOME_ENV, &home) };
+            Self {
+                home,
+                root,
+                _temp: temp,
+                prev,
+                _guard: guard,
+            }
+        }
+
+        fn stash_skill(&self, name: &str) -> PathBuf {
+            skills_stash_path(&self.home).join(name)
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            // SAFETY: still holding env_lock via `_guard`.
+            unsafe {
+                match &self.prev {
+                    Some(value) => std::env::set_var(TINK_HOME_ENV, value),
+                    None => std::env::remove_var(TINK_HOME_ENV),
+                }
+            }
+        }
+    }
+
+    fn write_skill(dir: &Path, name: &str, body: &str) -> Skill {
+        fs::create_dir_all(dir).unwrap();
+        let text = format!(
+            "---\nname: {name}\ndescription: Unit fixture {name}.\n---\n\n# {name}\n\n{body}\n"
+        );
+        fs::write(dir.join("SKILL.md"), text).unwrap();
+        skills::read_skill(dir, true).unwrap()
+    }
+
+    fn skill_md(path: &Path) -> String {
+        fs::read_to_string(path.join("SKILL.md")).unwrap()
+    }
+
+    fn sample_provenance() -> Provenance {
+        let mut provenance = Provenance::new();
+        provenance.insert(
+            "source".into(),
+            "https://github.com/example/repo.git".into(),
+        );
+        provenance.insert(
+            "revision".into(),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+        );
+        provenance.insert("path".into(), "skills/demo-skill".into());
+        provenance
+    }
+
+    #[test]
+    fn create_only_missing_creates() {
+        let home = TempHome::new();
+        let src = home.root.join("src").join("demo-skill");
+        let skill = write_skill(&src, "demo-skill", "fresh body");
+
+        let (path, write) = deposit_create_only(&skill).unwrap();
+        assert_eq!(write, CreateOnlyWrite::Created);
+        assert_eq!(path, home.stash_skill("demo-skill"));
+        assert!(skill_md(&path).contains("fresh body"));
+    }
+
+    #[test]
+    fn create_only_identical_unchanged() {
+        let home = TempHome::new();
+        let src = home.root.join("src").join("demo-skill");
+        let skill = write_skill(&src, "demo-skill", "same body");
+
+        assert_eq!(
+            deposit_create_only(&skill).unwrap().1,
+            CreateOnlyWrite::Created
+        );
+        let before = skill_md(&home.stash_skill("demo-skill"));
+
+        let (path, write) = deposit_create_only(&skill).unwrap();
+        assert_eq!(write, CreateOnlyWrite::Unchanged);
+        assert_eq!(skill_md(&path), before);
+    }
+
+    #[test]
+    fn create_only_diverge_skips() {
+        let home = TempHome::new();
+        let first = home.root.join("first").join("demo-skill");
+        let second = home.root.join("second").join("demo-skill");
+        let original = write_skill(&first, "demo-skill", "original body");
+        let incoming = write_skill(&second, "demo-skill", "incoming body");
+
+        assert_eq!(
+            deposit_create_only(&original).unwrap().1,
+            CreateOnlyWrite::Created
+        );
+        let before = skill_md(&home.stash_skill("demo-skill"));
+
+        let (path, write) = deposit_create_only(&incoming).unwrap();
+        assert!(
+            matches!(write, CreateOnlyWrite::Skipped(Some(ref detail)) if detail.contains("create-only")),
+            "{write:?}"
+        );
+        assert_eq!(skill_md(&path), before);
+        assert!(before.contains("original body"));
+    }
+
+    #[test]
+    fn deposit_diverge_repairs() {
+        let home = TempHome::new();
+        let first = home.root.join("first").join("demo-skill");
+        let second = home.root.join("second").join("demo-skill");
+        let original = write_skill(&first, "demo-skill", "original body");
+        let incoming = write_skill(&second, "demo-skill", "incoming body");
+
+        assert_eq!(deposit(&original, None).unwrap().1, StashWrite::Created);
+
+        let (path, write) = deposit(&incoming, None).unwrap();
+        assert_eq!(write, StashWrite::Repaired);
+        assert!(skill_md(&path).contains("incoming body"));
+        assert!(!skill_md(&path).contains("original body"));
+    }
+
+    #[test]
+    fn create_only_receipt_only_diff_unchanged() {
+        let home = TempHome::new();
+        let src = home.root.join("src").join("demo-skill");
+        let skill = write_skill(&src, "demo-skill", "shared body");
+        let provenance = sample_provenance();
+
+        assert_eq!(
+            deposit(&skill, Some(&provenance)).unwrap().1,
+            StashWrite::Created
+        );
+        let stash = home.stash_skill("demo-skill");
+        assert!(stash.join(".tink-source.json").is_file());
+        let before = skill_md(&stash);
+
+        // Incoming tree matches body but has no receipt — create-only must not rewrite.
+        let (path, write) = deposit_create_only(&skill).unwrap();
+        assert_eq!(write, CreateOnlyWrite::Unchanged);
+        assert_eq!(skill_md(&path), before);
+        assert!(path.join(".tink-source.json").is_file());
+    }
+}
+

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -270,27 +270,11 @@ pub fn preflight_refresh(
 
 /// Keep `$TINK_HOME/skills/<name>/` aligned with the installed project skill.
 pub fn sync_from_installed(installed: &Skill) -> Result<(), Error> {
-    let stash = stash_root(None)?;
-    let target = stash.join(&installed.name);
-    if target.is_dir() && skills::skill_contents_equal(&target, &installed.path)? {
-        return Ok(());
-    }
-    if target.exists() || target.is_symlink() {
-        clear_path(&target)?;
-    }
-    skills::install_local(installed, &stash, None)?;
-    Ok(())
+    deposit(installed, None).map(|_| ())
 }
 
 /// After a project refresh passed [`preflight_refresh`], write the new tree
-/// into the stash (replace if present, install if missing).
+/// into the stash (create, noop, or repair — same rules as [`deposit`]).
 pub fn deposit_refresh(new_skill: &Skill, new_provenance: &Provenance) -> Result<(), Error> {
-    let stash = stash_root(None)?;
-    let target = stash.join(&new_skill.name);
-    if target.is_dir() {
-        skills::replace_verified(new_skill, &stash, new_provenance)?;
-    } else {
-        skills::install_local(new_skill, &stash, Some(new_provenance))?;
-    }
-    Ok(())
+    deposit(new_skill, Some(new_provenance)).map(|_| ())
 }


### PR DESCRIPTION
## Summary
- Move harvest’s create-only diverge handling into `stash::deposit_create_only` so stash owns “what happens when the home skill differs.”
- Route refresh `sync_from_installed` / `deposit_refresh` through `deposit`; keep `preflight_refresh` refuse-on-diverge separate from create-only skip.
- Add focused stash unit tests for create / unchanged / skip / repair / receipt-only unchanged.

Plan: [docs/handoff-unify-stash-write-policy.md](docs/handoff-unify-stash-write-policy.md). Behavior-preserving; no ACCEPTANCE product-behavior edits; no version bump.

## Test plan
- [x] `cargo test --lib 'stash::tests::'` (5 pass)
- [x] `cargo test --test acceptance a6_` (repair-on-add)
- [x] `cargo test --test acceptance h6_` / `h7_` / `h8_` / `skill_harvest`
- [x] `cargo test --test acceptance p1_` … `p7_`
- [x] `cargo test --test acceptance` → 55 pass
- [ ] Spot-check: harvest still skips divergent stash; add still repairs; refresh still refuses divergent stash (P5) and repairs stale archive when project already new (P7)


Made with [Cursor](https://cursor.com)