### PR TITLE
Catalog sync on remove/destroy + init/harvest UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .agents/
+.tink-test-home/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 .agents/
-.tink-test-home/

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -113,7 +113,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | H3 | `skill add --stash <missing>` | Exit ≠ 0; mentions not found / missing; **no** GitHub network fetch |
 | H4 | `skill add --stash <name>` when project skill exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
 | H5 | `skill harvest` with fixture `$HOME/.agents/skills` + `$HOME/.claude/skills` + `TINK_HOME` | Copies complete skill trees into `$TINK_HOME/skills/`; no project `.agents` skill writes from harvest |
-| H6 | `skill harvest` when stash already identical | Exit 0; unchanged |
+| H6 | `skill harvest` when stash already identical | Exit 0; summary counts already present; no per-skill already-present lines |
 | H7 | `skill harvest` when stash diverges | Exit 0; stash unchanged; stderr skip warn |
 | H8 | `skill harvest` skips home stash sources and unsafe (symlink-inside) skill trees; still harvests cwd skills under `TINK_HOME` outside `skills/` | Stash/unsafe omitted; non-stash path under home deposited |
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -12,8 +12,8 @@ from GitHub Releases via `tink update`.
 below has an automated test that passes on macOS with `git` on `PATH`.
 
 **Out of v1:** weekly GitHub update workflows, private GitHub auth, Windows,
-Linux CI as a gate, pruning the home by-project catalog or home stash,
-bare-name stash promote without `--stash`.
+Linux CI as a gate, pruning the home stash, bare-name stash promote without
+`--stash`.
 
 **Dogfood:** Prefer an installed `tink` from this repo, or `cargo run -q -- …`.
 
@@ -33,9 +33,9 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill harvest` | Copy complete skill trees from known harness roots into the home stash (create-only; no project writes) |
 | `tink skill check` | Validate project skills; no network; no writes |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
-| `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` (not home stash or catalog) |
+| `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` and drop that name from the by-project catalog (not home stash) |
 | `tink update` | Replace this binary with the latest public GitHub Release (requires `curl` + `tar`) |
-| `tink destroy [--yes]` | Remove `.agents/`, `ZEN.md`, and `AGENTS.md` (not `~/.tink`) |
+| `tink destroy [--yes]` | Remove `.agents/`, `ZEN.md`, and `AGENTS.md`; drop this project's by-project catalog entry (not home stash) |
 
 ## On-disk contracts
 
@@ -45,7 +45,7 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | Receipt | `.tink-source.json` with exactly `source`, `revision`, `path` (non-empty strings) |
 | Home root | `$TINK_HOME` or `~/.tink`, with `layout.json` (`kind`: `tink-skill-inventory`) |
 | Home stash | `skills/<name>/` skill trees copied on successful add (rebuildable dump; identical tip may install project from stash; divergent → repair + warn; project overwrite still refused; not an agent discovery root) |
-| Offline catalog | `catalog/by-project/<project>/meta.json` with `name`, `root`, grow-only `skills` name list (not skill trees) |
+| Offline catalog | `catalog/by-project/<project>/meta.json` with `name`, `root`, `skills` name list (not skill trees); `skill remove` drops a name; `destroy` drops the project entry |
 
 ## Rows
 
@@ -140,16 +140,17 @@ Ids are stable. Tests must name or comment the id they prove.
 
 | Id | Action | Expect |
 |---|---|---|
-| X1 | `skill remove <name>` after init+add | Exit 0; project `.agents/skills/<name>/` gone; `skill list` omits name; home stash `$TINK_HOME/skills/<name>/` still present; catalog may still list the name |
+| X1 | `skill remove <name>` after init+add | Exit 0; project `.agents/skills/<name>/` gone; `skill list` omits name; home stash `$TINK_HOME/skills/<name>/` still present; `skill list --home` omits that skill for the project (siblings may remain) |
 | X2 | `skill remove <missing>` | Exit ≠ 0; mentions not found / missing; nothing deleted |
 | X3 | `skill remove` when `.agents` is a symlink | Exit ≠ 0; mentions symlink; tree unchanged |
 | X4 | Successful `skill remove <name>` | Does **not** delete `$TINK_HOME/skills/<name>/` |
+| X5 | `init` installs `manage-tink` | Embedded skill documents `tink skill remove NAME` as the only remove path; states remove drops the catalog name and destroy drops the project catalog entry; home stash remains unpruned |
 
 ### Destroy
 
 | Id | Action | Expect |
 |---|---|---|
-| D1 | `destroy --yes` after `init --with-zen` | Removes `.agents/`, `ZEN.md`, `AGENTS.md`; leaves `~/.tink` intact |
+| D1 | `destroy --yes` after `init --with-zen` (extra skill allowed) | Removes `.agents/`, `ZEN.md`, `AGENTS.md`; leaves home stash + `layout.json` intact; drops this project's by-project catalog entry (`skill list --home` has no rows for it) |
 | D2 | `destroy` without `--yes` (non-TTY) | Exit ≠ 0; refuses without confirmation; project files unchanged |
 | D3 | `destroy --yes` when `.agents` is a symlink | Exit ≠ 0; mentions symlink |
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,13 @@ cargo uninstall tink
 
 ```console
 cargo test
-cargo run -q -- init
+./tink-test init
+./tink-test skill list --home
 ```
+
+`./tink-test` builds this checkout and runs `target/debug/tink` (not
+`~/.local/bin/tink`). It forces `TINK_HOME` to `.tink-test-home/` (override with
+`TINK_TEST_HOME`) so dogfood does not touch `~/.tink`.
 
 See [ZEN.md](ZEN.md). Flag-level detail also lives in `tink --help` and
 `ACCEPTANCE.md`.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ cargo test
 ```
 
 `./tink-test` builds this checkout and runs `target/debug/tink` (not
-`~/.local/bin/tink`). It forces `TINK_HOME` to `.tink-test-home/` (override with
+`~/.local/bin/tink`). It forces `TINK_HOME` to `~/.tink-test` (override with
 `TINK_TEST_HOME`) so dogfood does not touch `~/.tink`.
 
 See [ZEN.md](ZEN.md). Flag-level detail also lives in `tink --help` and

--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ tink update
 
 If the GitHub tip is already in the stash and matches the tip byte-for-byte,
 `skill add` may install from the stash. If the stash differs, tink repairs it
-and warns. `skill remove` deletes only the project skill directory, not stash
-or catalog.
+and warns. `skill remove` deletes the project skill directory and drops that
+name from the by-project catalog; it does not delete home stash trees.
+`destroy` also drops this project's catalog entry.
 
 ### Uninstall the CLI
 

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -27,16 +27,17 @@ are hard stops — honor them; do not work around them.
    the home stash into the project, use `tink skill add --stash NAME` only.
    To fill the home stash from known harness skill locations, use
    `tink skill harvest` only (create-only; does not write project skills).
-   To remove a live project skill, use `tink skill remove NAME` only (does not
-   prune home stash or catalog). To update the tink CLI binary, use
-   `tink update` only.
+   To remove a live project skill, use `tink skill remove NAME` only (drops the
+   name from the by-project catalog; does not prune the home stash). To update
+   the tink CLI binary, use `tink update` only.
    - Done when: the chosen command has finished and its stdout/stderr is known.
 
 3. **Prove** — After every successful mutation except `destroy` and
    `skill remove`, run `tink skill check` and report the result. After
-   `skill remove`, run `tink skill list` (or check if other skills remain) and
-   confirm the name is gone from the project. After `destroy`, confirm
-   `.agents/`, `ZEN.md`, and `AGENTS.md` are gone; do not run check.
+   `skill remove`, run `tink skill list` and `tink skill list --home` and
+   confirm the name is gone from the project and the catalog. After `destroy`,
+   confirm `.agents/`, `ZEN.md`, and `AGENTS.md` are gone and
+   `tink skill list --home` has no rows for this project; do not run check.
    - Done when: proof for that mutation type is reported to the user.
 
 ## Authority
@@ -59,13 +60,14 @@ are hard stops — honor them; do not work around them.
 
 - Leave `.tink-source.json` untouched — it is the refresh **receipt**.
 - On a refusal, stop and report it. Authorized deletes are only:
-  - `tink skill remove NAME` → `.agents/skills/<name>/`
-  - `tink destroy` → `.agents/`, `ZEN.md`, and `AGENTS.md`
+  - `tink skill remove NAME` → `.agents/skills/<name>/` and drops that name
+    from the by-project catalog
+  - `tink destroy` → `.agents/`, `ZEN.md`, and `AGENTS.md`, and drops this
+    project's by-project catalog entry
 - Treat local skills as non-refreshable unless they carry a valid receipt.
 - Never execute code from a skill while adding, checking, refreshing, removing,
   or destroying.
 - Home stash (`~/.tink/skills/`) is **not** an agent discovery root; do not
   symlink or copy from it by hand — use `tink skill add --stash NAME`.
-- Do not prune the home stash or by-project catalog unless the user explicitly
-  asks and a supporting command exists (prune is out of v1).
-  `skill remove` does not prune stash or catalog.
+- Do not prune the home stash by hand. `skill remove` and `destroy` sync the
+  by-project catalog; they do not delete stash trees.

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -49,7 +49,9 @@ form for add, list, check, refresh, and remove.
   `skill add`. Names are recorded in
   `catalog/by-project/<project>/meta.json`. List the catalog with
   `tink skill list --home` (TSV with header `project`, `root`, `skill`).
-  Do not hand-parse `meta.json` when the CLI is available. Destroy does not
-  delete home or prune that catalog or stash. `skill remove` deletes only
-  the project skill directory; it does not prune stash or catalog.
+  Do not hand-parse `meta.json` when the CLI is available. `skill remove`
+  deletes the project skill directory and drops that name from the by-project
+  catalog; it does not prune the home stash. `destroy` removes project
+  scaffolding and this project's catalog entry; it does not delete home stash
+  trees or other projects' catalog rows.
   Project skill overwrites are still refused.

--- a/src/add.rs
+++ b/src/add.rs
@@ -23,7 +23,7 @@ enum AddOrigin {
 #[derive(Debug)]
 pub(crate) struct AddOutcome {
     pub name: String,
-    created: bool,
+    pub created: bool,
     project_path: PathBuf,
     origin: AddOrigin,
 }
@@ -152,6 +152,24 @@ pub fn add_skill(
     source_value: &str,
     selected_name: Option<&str>,
 ) -> Result<AddOutcome, Error> {
+    add_skill_inner(project_root, source_value, selected_name, true)
+}
+
+/// Like [`add_skill`] but skips per-skill stdout (caller owns the narrative).
+pub(crate) fn add_skill_quiet(
+    project_root: &Path,
+    source_value: &str,
+    selected_name: Option<&str>,
+) -> Result<AddOutcome, Error> {
+    add_skill_inner(project_root, source_value, selected_name, false)
+}
+
+fn add_skill_inner(
+    project_root: &Path,
+    source_value: &str,
+    selected_name: Option<&str>,
+    report: bool,
+) -> Result<AddOutcome, Error> {
     init::ensure_project_layout(project_root)?;
     let destination_root = project_root.join(".agents").join("skills");
     let local_source = Path::new(source_value);
@@ -168,7 +186,9 @@ pub fn add_skill(
             None,
             None,
         )?;
-        report_add(&outcome);
+        if report {
+            report_add(&outcome);
+        }
         return Ok(outcome);
     }
     if looks_like_filesystem_path(source_value) {
@@ -176,7 +196,9 @@ pub fn add_skill(
     }
     let remote = sources::parse_remote(source_value)?;
     let outcome = add_from_remote(project_root, &destination_root, &remote, selected_name)?;
-    report_add(&outcome);
+    if report {
+        report_add(&outcome);
+    }
     Ok(outcome)
 }
 
@@ -205,20 +227,20 @@ fn report_add(outcome: &AddOutcome) {
         (true, AddOrigin::Stash) => println!(
             "{} {} → {} {}",
             style.success("Installed"),
-            style.accent(&outcome.name),
+            style.skill(&outcome.name),
             style.accent(outcome.project_path.display()),
             style.muted("(from stash)")
         ),
         (true, AddOrigin::Source) => println!(
             "{} {} → {}",
             style.success("Installed"),
-            style.accent(&outcome.name),
+            style.skill(&outcome.name),
             style.accent(outcome.project_path.display())
         ),
         (false, _) => println!(
             "{} {}",
             style.muted("Unchanged"),
-            style.accent(&outcome.name)
+            style.skill(&outcome.name)
         ),
     }
 }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -99,6 +99,26 @@ fn existing_home(home: Option<&Path>) -> Result<Option<PathBuf>, Error> {
     Ok(Some(home))
 }
 
+/// Whether withdraw/forget may mutate this basename entry for `project_root`.
+///
+/// Non-empty `meta.root` must canonicalize to `project_root` (already
+/// canonical). Missing/empty `root` keeps basename-keyed behavior for legacy
+/// metas. Unresolvable stored roots soft-refuse so a sibling basename cannot
+/// wipe another project's catalog.
+fn catalog_owned_by(value: &Value, project_root: &Path) -> bool {
+    let Some(stored) = value
+        .get("root")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    else {
+        return true;
+    };
+    match Path::new(stored).canonicalize() {
+        Ok(canon) => canon == project_root,
+        Err(_) => false,
+    }
+}
+
 /// Record that `skill_name` is installed in `project_root`.
 ///
 /// Last writer wins on `meta.json` `root` when two projects share a basename.
@@ -146,7 +166,8 @@ pub(crate) fn deposit_skill_at(
 
 /// Drop `skill_name` from the by-project catalog for `project_root`.
 ///
-/// Soft success when home, project entry, or name is already absent. Never
+/// Soft success when home, project entry, or name is already absent, or when
+/// `meta.root` belongs to a different project sharing this basename. Never
 /// creates inventory. Preserves existing meta `name`/`root` when siblings
 /// remain. Removes the project catalog directory when no names remain.
 pub fn withdraw_skill(project_root: &Path, skill_name: &str) -> Result<(), Error> {
@@ -174,6 +195,9 @@ pub(crate) fn withdraw_skill_at(
     refuse_symlink(&meta_path)?;
 
     let value = parse_meta(&meta_path)?;
+    if !catalog_owned_by(&value, &project_root) {
+        return Ok(());
+    }
     let mut skills = skills_from_meta(&value);
     if !skills.remove(skill_name) {
         return Ok(());
@@ -208,7 +232,8 @@ pub(crate) fn withdraw_skill_at(
 
 /// Remove this project's by-project catalog entry entirely.
 ///
-/// Soft success when absent. Does not create inventory or touch stash trees.
+/// Soft success when absent, or when `meta.root` belongs to a different
+/// project sharing this basename. Does not create inventory or touch stash.
 pub fn forget_project(project_root: &Path) -> Result<(), Error> {
     forget_project_at(None, project_root)
 }
@@ -223,6 +248,14 @@ pub(crate) fn forget_project_at(home: Option<&Path>, project_root: &Path) -> Res
         return Ok(());
     };
     let catalog = project_catalog_dir(&home, &project_root)?;
+    let meta_path = catalog.join("meta.json");
+    if meta_path.is_file() {
+        refuse_symlink(&meta_path)?;
+        let value = parse_meta(&meta_path)?;
+        if !catalog_owned_by(&value, &project_root) {
+            return Ok(());
+        }
+    }
     remove_catalog_dir(&catalog)
 }
 
@@ -415,11 +448,10 @@ mod tests {
         let catalog = deposit_skill_at(Some(&home), &app, "keep").unwrap();
         deposit_skill_at(Some(&home), &app, "drop").unwrap();
 
-        // Simulate a divergent root already stored; withdraw must not rewrite it.
+        // Custom name with matching root: withdraw must preserve name/root.
         let before: Value =
             serde_json::from_str(&fs::read_to_string(catalog.join("meta.json")).unwrap()).unwrap();
         let mut patched = before.clone();
-        patched["root"] = json!("/preserved/root");
         patched["name"] = json!("preserved-name");
         write_meta(&catalog.join("meta.json"), &patched).unwrap();
 
@@ -427,7 +459,7 @@ mod tests {
         let after: Value =
             serde_json::from_str(&fs::read_to_string(catalog.join("meta.json")).unwrap()).unwrap();
         assert_eq!(after["name"], "preserved-name");
-        assert_eq!(after["root"], "/preserved/root");
+        assert_eq!(after["root"], before["root"]);
         assert_eq!(
             after["skills"]
                 .as_array()
@@ -436,6 +468,38 @@ mod tests {
                 .filter_map(|s| s.as_str())
                 .collect::<Vec<_>>(),
             vec!["keep"]
+        );
+    }
+
+    #[test]
+    fn withdraw_and_forget_skip_foreign_basename_entry() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let clone_a = temp.path().join("clone-a").join("app");
+        let clone_b = temp.path().join("clone-b").join("app");
+        fs::create_dir_all(&clone_a).unwrap();
+        fs::create_dir_all(&clone_b).unwrap();
+        deposit_skill_at(Some(&home), &clone_a, "alpha").unwrap();
+        deposit_skill_at(Some(&home), &clone_a, "beta").unwrap();
+
+        withdraw_skill_at(Some(&home), &clone_b, "alpha").unwrap();
+        assert_eq!(
+            list_catalog(Some(&home))
+                .unwrap()
+                .iter()
+                .map(|e| e.skill.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+
+        forget_project_at(Some(&home), &clone_b).unwrap();
+        assert_eq!(
+            list_catalog(Some(&home))
+                .unwrap()
+                .iter()
+                .map(|e| e.skill.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
         );
     }
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,4 +1,7 @@
-//! Grow-only by-project name catalog under `$TINK_HOME/catalog/by-project/`.
+//! By-project name catalog under `$TINK_HOME/catalog/by-project/`.
+//!
+//! Names are recorded on install and dropped on `skill remove`; a project's
+//! catalog entry is removed on `destroy` (or when the last name is withdrawn).
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -34,7 +37,69 @@ fn project_catalog_dir(home: &Path, project_root: &Path) -> Result<PathBuf, Erro
     Ok(by_project_path(home).join(safe_project_dirname(label)))
 }
 
-/// Record that `skill_name` is installed in `project_root` (grow-only name list).
+fn skills_from_meta(value: &Value) -> BTreeSet<String> {
+    let mut skills = BTreeSet::new();
+    if let Some(arr) = value.get("skills").and_then(|v| v.as_array()) {
+        for item in arr {
+            if let Some(name) = item.as_str() {
+                skills.insert(name.to_string());
+            }
+        }
+    }
+    skills
+}
+
+fn parse_meta(meta_path: &Path) -> Result<Value, Error> {
+    let raw = fs::read_to_string(meta_path).map_err(|e| map_io(meta_path, e))?;
+    serde_json::from_str(&raw).map_err(|e| {
+        Error::msg(format!(
+            "Invalid catalog meta {}: {e}",
+            meta_path.display()
+        ))
+    })
+}
+
+fn write_meta(meta_path: &Path, body: &Value) -> Result<(), Error> {
+    let text = format!(
+        "{}\n",
+        serde_json::to_string_pretty(body).map_err(|e| Error::msg(e.to_string()))?
+    );
+    fs::write(meta_path, text).map_err(|e| map_io(meta_path, e))?;
+    Ok(())
+}
+
+fn remove_catalog_dir(catalog: &Path) -> Result<(), Error> {
+    if !catalog.exists() && !catalog.is_symlink() {
+        return Ok(());
+    }
+    refuse_symlink(catalog)?;
+    if !catalog.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing to remove non-directory catalog: {}",
+            catalog.display()
+        )));
+    }
+    fs::remove_dir_all(catalog).map_err(|e| map_io(catalog, e))?;
+    Ok(())
+}
+
+/// Soft-resolve home for withdraw/forget: missing home is success, not create.
+fn existing_home(home: Option<&Path>) -> Result<Option<PathBuf>, Error> {
+    let home = match home {
+        Some(path) => path.to_path_buf(),
+        None => match resolve_home() {
+            Ok(path) => path,
+            Err(_) => return Ok(None),
+        },
+    };
+    if !home.exists() {
+        return Ok(None);
+    }
+    refuse_symlink(&home)?;
+    Ok(Some(home))
+}
+
+/// Record that `skill_name` is installed in `project_root`.
 ///
 /// Last writer wins on `meta.json` `root` when two projects share a basename.
 /// Failure fails the caller.
@@ -59,23 +124,11 @@ pub(crate) fn deposit_skill_at(
     let meta_path = catalog.join("meta.json");
     require_file(&meta_path)?;
 
-    let mut skills: BTreeSet<String> = BTreeSet::new();
-    if meta_path.is_file() {
-        let raw = fs::read_to_string(&meta_path).map_err(|e| map_io(&meta_path, e))?;
-        let value: Value = serde_json::from_str(&raw).map_err(|e| {
-            Error::msg(format!(
-                "Invalid catalog meta {}: {e}",
-                meta_path.display()
-            ))
-        })?;
-        if let Some(arr) = value.get("skills").and_then(|v| v.as_array()) {
-            for item in arr {
-                if let Some(name) = item.as_str() {
-                    skills.insert(name.to_string());
-                }
-            }
-        }
-    }
+    let mut skills = if meta_path.is_file() {
+        skills_from_meta(&parse_meta(&meta_path)?)
+    } else {
+        BTreeSet::new()
+    };
     skills.insert(skill_name.to_string());
 
     let label = project_root
@@ -87,12 +140,90 @@ pub(crate) fn deposit_skill_at(
         "root": project_root.to_string_lossy(),
         "skills": skills.into_iter().collect::<Vec<_>>(),
     });
-    let text = format!(
-        "{}\n",
-        serde_json::to_string_pretty(&body).map_err(|e| Error::msg(e.to_string()))?
-    );
-    fs::write(&meta_path, text).map_err(|e| map_io(&meta_path, e))?;
+    write_meta(&meta_path, &body)?;
     Ok(catalog)
+}
+
+/// Drop `skill_name` from the by-project catalog for `project_root`.
+///
+/// Soft success when home, project entry, or name is already absent. Never
+/// creates inventory. Preserves existing meta `name`/`root` when siblings
+/// remain. Removes the project catalog directory when no names remain.
+pub fn withdraw_skill(project_root: &Path, skill_name: &str) -> Result<(), Error> {
+    withdraw_skill_at(None, project_root, skill_name)
+}
+
+/// Like [`withdraw_skill`], with an optional home root (tests).
+pub(crate) fn withdraw_skill_at(
+    home: Option<&Path>,
+    project_root: &Path,
+    skill_name: &str,
+) -> Result<(), Error> {
+    let project_root = match project_root.canonicalize() {
+        Ok(path) => path,
+        Err(_) => return Ok(()),
+    };
+    let Some(home) = existing_home(home)? else {
+        return Ok(());
+    };
+    let catalog = project_catalog_dir(&home, &project_root)?;
+    let meta_path = catalog.join("meta.json");
+    if !meta_path.is_file() {
+        return Ok(());
+    }
+    refuse_symlink(&meta_path)?;
+
+    let value = parse_meta(&meta_path)?;
+    let mut skills = skills_from_meta(&value);
+    if !skills.remove(skill_name) {
+        return Ok(());
+    }
+    if skills.is_empty() {
+        return remove_catalog_dir(&catalog);
+    }
+
+    let label = value
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            project_root
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(safe_project_dirname)
+                .unwrap_or_else(|| "project".into())
+        });
+    let root = value
+        .get("root")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| project_root.to_string_lossy().into_owned());
+    let body = json!({
+        "name": label,
+        "root": root,
+        "skills": skills.into_iter().collect::<Vec<_>>(),
+    });
+    write_meta(&meta_path, &body)
+}
+
+/// Remove this project's by-project catalog entry entirely.
+///
+/// Soft success when absent. Does not create inventory or touch stash trees.
+pub fn forget_project(project_root: &Path) -> Result<(), Error> {
+    forget_project_at(None, project_root)
+}
+
+/// Like [`forget_project`], with an optional home root (tests).
+pub(crate) fn forget_project_at(home: Option<&Path>, project_root: &Path) -> Result<(), Error> {
+    let project_root = match project_root.canonicalize() {
+        Ok(path) => path,
+        Err(_) => return Ok(()),
+    };
+    let Some(home) = existing_home(home)? else {
+        return Ok(());
+    };
+    let catalog = project_catalog_dir(&home, &project_root)?;
+    remove_catalog_dir(&catalog)
 }
 
 /// One skill row from the offline by-project name catalog.
@@ -273,5 +404,87 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![("app", "alpha"), ("app", "zebra"), ("other", "beta")]
         );
+    }
+
+    #[test]
+    fn withdraw_keeps_siblings_and_preserves_meta() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        let catalog = deposit_skill_at(Some(&home), &app, "keep").unwrap();
+        deposit_skill_at(Some(&home), &app, "drop").unwrap();
+
+        // Simulate a divergent root already stored; withdraw must not rewrite it.
+        let before: Value =
+            serde_json::from_str(&fs::read_to_string(catalog.join("meta.json")).unwrap()).unwrap();
+        let mut patched = before.clone();
+        patched["root"] = json!("/preserved/root");
+        patched["name"] = json!("preserved-name");
+        write_meta(&catalog.join("meta.json"), &patched).unwrap();
+
+        withdraw_skill_at(Some(&home), &app, "drop").unwrap();
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(catalog.join("meta.json")).unwrap()).unwrap();
+        assert_eq!(after["name"], "preserved-name");
+        assert_eq!(after["root"], "/preserved/root");
+        assert_eq!(
+            after["skills"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|s| s.as_str())
+                .collect::<Vec<_>>(),
+            vec!["keep"]
+        );
+    }
+
+    #[test]
+    fn withdraw_last_name_removes_project_entry() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        deposit_skill_at(Some(&home), &app, "only").unwrap();
+        withdraw_skill_at(Some(&home), &app, "only").unwrap();
+        assert!(list_catalog(Some(&home)).unwrap().is_empty());
+        assert!(!project_catalog_dir(&home, &app.canonicalize().unwrap())
+            .unwrap()
+            .exists());
+    }
+
+    #[test]
+    fn forget_project_clears_entry() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        deposit_skill_at(Some(&home), &app, "alpha").unwrap();
+        deposit_skill_at(Some(&home), &app, "beta").unwrap();
+        forget_project_at(Some(&home), &app).unwrap();
+        assert!(list_catalog(Some(&home)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn withdraw_and_forget_soft_ok_when_nothing_to_do() {
+        let temp = TempDir::new().unwrap();
+        let missing_home = temp.path().join("no-home");
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        withdraw_skill_at(Some(&missing_home), &app, "any").unwrap();
+        forget_project_at(Some(&missing_home), &app).unwrap();
+
+        let home = temp.path().join("home");
+        deposit_skill_at(Some(&home), &app, "keep").unwrap();
+        withdraw_skill_at(Some(&home), &app, "absent").unwrap();
+        assert_eq!(
+            list_catalog(Some(&home))
+                .unwrap()
+                .iter()
+                .map(|e| e.skill.as_str())
+                .collect::<Vec<_>>(),
+            vec!["keep"]
+        );
+        forget_project_at(Some(&home), &temp.path().join("other-missing")).unwrap();
     }
 }

--- a/src/destroy.rs
+++ b/src/destroy.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
+use crate::catalog;
 use crate::error::Error;
 use crate::paths::{map_io, refuse_symlink};
 use crate::style::CliStyle;
@@ -13,10 +14,10 @@ pub struct DestroyReport {
     pub removed: Vec<PathBuf>,
 }
 
-/// Remove `.agents/`, `ZEN.md`, and `AGENTS.md` from the project root.
-///
-/// Does not touch `~/.tink` or the by-project name catalog. Refuses symlinks.
-/// Requires `--yes` or an interactive `y` confirmation (default no).
+/// Remove `.agents/`, `ZEN.md`, and `AGENTS.md` from the project root, and drop
+/// this project's by-project catalog entry. Does not touch the home stash.
+/// Refuses symlinks. Requires `--yes` or an interactive `y` confirmation
+/// (default no).
 pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, Error> {
     if !yes {
         confirm_destroy()?;
@@ -52,6 +53,7 @@ pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, 
         removed.push(path);
     }
 
+    catalog::forget_project(project_root)?;
     Ok(DestroyReport { removed })
 }
 

--- a/src/destroy.rs
+++ b/src/destroy.rs
@@ -14,16 +14,17 @@ pub struct DestroyReport {
     pub removed: Vec<PathBuf>,
 }
 
-/// Remove `.agents/`, `ZEN.md`, and `AGENTS.md` from the project root, and drop
-/// this project's by-project catalog entry. Does not touch the home stash.
-/// Refuses symlinks. Requires `--yes` or an interactive `y` confirmation
-/// (default no).
+/// Drop this project's by-project catalog entry, then remove `.agents/`,
+/// `ZEN.md`, and `AGENTS.md` from the project root. Does not touch the home
+/// stash. Catalog sync runs before disk deletes; sync errors leave project
+/// files intact. Refuses symlinks. Requires `--yes` or an interactive `y`
+/// confirmation (default no).
 pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, Error> {
     if !yes {
         confirm_destroy()?;
     }
 
-    let mut removed = Vec::new();
+    let mut to_remove = Vec::new();
     let agents = project_root.join(".agents");
     if agents.exists() || agents.is_symlink() {
         refuse_symlink(&agents)?;
@@ -33,8 +34,7 @@ pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, 
                 agents.display()
             )));
         }
-        fs::remove_dir_all(&agents).map_err(|e| map_io(&agents, e))?;
-        removed.push(agents);
+        to_remove.push(agents);
     }
 
     for name in ["ZEN.md", "AGENTS.md"] {
@@ -49,11 +49,20 @@ pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, 
                 path.display()
             )));
         }
-        fs::remove_file(&path).map_err(|e| map_io(&path, e))?;
-        removed.push(path);
+        to_remove.push(path);
     }
 
     catalog::forget_project(project_root)?;
+
+    let mut removed = Vec::new();
+    for path in to_remove {
+        if path.is_dir() {
+            fs::remove_dir_all(&path).map_err(|e| map_io(&path, e))?;
+        } else {
+            fs::remove_file(&path).map_err(|e| map_io(&path, e))?;
+        }
+        removed.push(path);
+    }
     Ok(DestroyReport { removed })
 }
 

--- a/src/home.rs
+++ b/src/home.rs
@@ -26,6 +26,9 @@ Successful installs:
 - stash skill trees under `skills/<name>/` (divergent entries are repaired)
 - record skill **names** under `catalog/by-project/<project>/meta.json`
 
+`skill remove` and `destroy` update that name catalog; they do not delete
+stash trees.
+
 Default location: `~/.tink` (override with `TINK_HOME`).
 ";
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -30,19 +30,28 @@ pub struct InitOptions {
 }
 
 #[derive(Debug)]
+pub struct InstalledSkill {
+    pub name: String,
+    pub created: bool,
+}
+
+#[derive(Debug)]
 pub struct InitReport {
     pub skills_path: PathBuf,
     pub skills_created: bool,
     pub inventory_home: PathBuf,
     pub inventory_created: bool,
     pub zen_written: bool,
-    pub tink_skills_added: Vec<String>,
-    pub manage_tink_added: Option<String>,
+    pub tink_skills_added: Vec<InstalledSkill>,
+    pub manage_tink_added: Option<InstalledSkill>,
 }
 
 /// Ask `[y/N]` when `explicit` is unset and stdin is a TTY; otherwise use
 /// `explicit` or default `false`.
-pub fn opt_in(explicit: Option<bool>, question: &str) -> Result<bool, Error> {
+///
+/// `question` is printed as-is (callers apply styling, including purple skill names).
+/// Optional `hint` is printed above the prompt in muted style.
+pub fn opt_in(explicit: Option<bool>, question: &str, hint: Option<&str>) -> Result<bool, Error> {
     if let Some(value) = explicit {
         return Ok(value);
     }
@@ -50,7 +59,10 @@ pub fn opt_in(explicit: Option<bool>, question: &str) -> Result<bool, Error> {
         return Ok(false);
     }
     let style = CliStyle::auto_stdout();
-    print!("{} {}", style.warn(question), style.accent("[y/N] "));
+    if let Some(hint) = hint {
+        println!("{}", style.muted(hint));
+    }
+    print!("{} {}", question, style.accent("[y/N] "));
     io::stdout()
         .flush()
         .map_err(|e| Error::msg(format!("prompt: {e}")))?;
@@ -61,6 +73,41 @@ pub fn opt_in(explicit: Option<bool>, question: &str) -> Result<bool, Error> {
         .map_err(|e| Error::msg(format!("prompt: {e}")))?;
     let answer = line.trim().to_ascii_lowercase();
     Ok(answer == "y" || answer == "yes")
+}
+
+/// Like [`opt_in`], but offers `r` to print embedded `ZEN.md` before deciding.
+fn opt_in_zen(explicit: Option<bool>) -> Result<bool, Error> {
+    if let Some(value) = explicit {
+        return Ok(value);
+    }
+    if !io::stdin().is_terminal() {
+        return Ok(false);
+    }
+    let style = CliStyle::auto_stdout();
+    let question = style.warn("Add tink's maintainability principles (ZEN.md)?");
+    let hint = style.muted("r = print ZEN.md without adding it");
+    loop {
+        println!("{hint}");
+        print!("{} {}", question, style.accent("[y/N/r] "));
+        io::stdout()
+            .flush()
+            .map_err(|e| Error::msg(format!("prompt: {e}")))?;
+        let mut line = String::new();
+        io::stdin()
+            .lock()
+            .read_line(&mut line)
+            .map_err(|e| Error::msg(format!("prompt: {e}")))?;
+        let answer = line.trim().to_ascii_lowercase();
+        match answer.as_str() {
+            "y" | "yes" => return Ok(true),
+            "r" | "read" => {
+                println!();
+                println!("{}", style.muted(ZEN.trim_end()));
+                println!();
+            }
+            _ => return Ok(false),
+        }
+    }
 }
 
 fn write_zen(project_root: &Path) -> Result<bool, Error> {
@@ -106,13 +153,22 @@ pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitRep
     require_directory(&skills)?;
     require_file(&readme)?;
 
-    let with_zen = opt_in(
-        options.with_zen,
-        "Add Tink's maintainability principles (ZEN.md)?",
-    )?;
+    let style = CliStyle::auto_stdout();
+    let with_zen = opt_in_zen(options.with_zen)?;
     let with_tink_skills = opt_in(
         options.with_tink_skills,
-        "Add skill-scout and skill-eval-loop from tink-skills?",
+        &format!(
+            "{}{} and {}{}{}?",
+            style.warn("Add "),
+            style.skill("skill-scout"),
+            style.skill("skill-eval-loop"),
+            style.warn(" from "),
+            style.link(
+                &format!("https://github.com/{TINK_SKILLS_SOURCE}"),
+                "tink-skills",
+            ),
+        ),
+        Some("Optional GitHub bundle — click tink-skills to open the repo"),
     )?;
     let with_manage_tink = options.with_manage_tink.unwrap_or(true);
 
@@ -135,7 +191,11 @@ pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitRep
     };
 
     let manage_tink_added = if with_manage_tink {
-        Some(manage_tink::install_manage_tink(project_root)?)
+        let outcome = manage_tink::install_manage_tink(project_root)?;
+        Some(InstalledSkill {
+            name: outcome.name,
+            created: outcome.created,
+        })
     } else {
         None
     };
@@ -143,8 +203,11 @@ pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitRep
     let mut tink_skills_added = Vec::new();
     if with_tink_skills {
         for name in TINK_SKILLS {
-            let outcome = add::add_skill(project_root, TINK_SKILLS_SOURCE, Some(name))?;
-            tink_skills_added.push(outcome.name);
+            let outcome = add::add_skill_quiet(project_root, TINK_SKILLS_SOURCE, Some(name))?;
+            tink_skills_added.push(InstalledSkill {
+                name: outcome.name,
+                created: outcome.created,
+            });
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,13 +257,13 @@ fn dispatch_init(
     if report.inventory_created {
         println!(
             "{} {}",
-            style.success("New home inventory at"),
+            style.success("New home at"),
             style.accent(report.inventory_home.display())
         );
     } else {
         println!(
             "{} {}",
-            style.muted("Home inventory at"),
+            style.muted("Home at"),
             style.accent(report.inventory_home.display())
         );
     }
@@ -376,24 +376,19 @@ fn dispatch_skill_harvest(cwd: &Path) -> Result<(), Error> {
             harvest::HarvestAction::Created => {
                 println!(
                     "{} {} {}",
-                    out.success("created"),
+                    out.success("Harvested"),
                     out.skill(&event.name),
                     out.muted(event.source.display())
                 );
             }
             harvest::HarvestAction::Unchanged => {
-                println!(
-                    "{} {} {}",
-                    out.muted("unchanged"),
-                    out.skill(&event.name),
-                    out.muted(event.source.display())
-                );
+                // Quiet no-ops; counts appear in the summary.
             }
             harvest::HarvestAction::Skipped => {
                 let detail = event.detail.as_deref().unwrap_or("skipped");
                 eprintln!(
                     "{} {} {} ({})",
-                    err.warn("skipped"),
+                    err.warn("Skipped"),
                     err.skill(&event.name),
                     err.muted(event.source.display()),
                     detail
@@ -401,13 +396,18 @@ fn dispatch_skill_harvest(cwd: &Path) -> Result<(), Error> {
             }
         }
     }
+    let home = home::resolve_home()?;
     println!(
-        "{} created={} unchanged={} skipped={}",
+        "{} {} {} · {} {} · {} {}",
         out.success("Harvest"),
         out.accent(report.created),
+        out.muted("harvested"),
         out.accent(report.unchanged),
-        out.accent(report.skipped)
+        out.muted("already present"),
+        out.accent(report.skipped),
+        out.muted("skipped")
     );
+    println!("{} {}", out.muted("Home"), out.accent(home.display()));
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub enum Command {
         #[command(subcommand)]
         command: SkillCommand,
     },
-    /// Remove `.agents/`, `ZEN.md`, and `AGENTS.md` from this project
+    /// Remove `.agents/`, `ZEN.md`, `AGENTS.md`, and this project's catalog entry (not home stash)
     Destroy {
         /// Skip the confirmation prompt
         #[arg(long)]
@@ -110,7 +110,7 @@ pub enum SkillCommand {
         /// Optional skill name; default refreshes all imported skills
         name: Option<String>,
     },
-    /// Delete one project skill directory (not home stash or catalog)
+    /// Delete one project skill directory and drop it from the by-project catalog (not home stash)
     Remove {
         /// Skill directory name under `.agents/skills/`
         name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,11 +248,11 @@ fn dispatch_init(
             style.accent("ZEN.md maintainability principles")
         );
     }
-    if let Some(name) = &report.manage_tink_added {
-        println!("{} {}", style.success("Added"), style.accent(name));
+    if let Some(skill) = &report.manage_tink_added {
+        print_init_skill(&style, skill);
     }
-    for name in &report.tink_skills_added {
-        println!("{} {}", style.success("Added"), style.accent(name));
+    for skill in &report.tink_skills_added {
+        print_init_skill(&style, skill);
     }
     if report.inventory_created {
         println!(
@@ -268,6 +268,18 @@ fn dispatch_init(
         );
     }
     Ok(())
+}
+
+fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) {
+    if skill.created {
+        println!("{} {}", style.success("Added"), style.skill(&skill.name));
+    } else {
+        println!(
+            "{} {}",
+            style.muted("Already present"),
+            style.skill(&skill.name)
+        );
+    }
 }
 
 fn dispatch_skill_add(cwd: &Path, source: &str, skill: Option<&str>) -> Result<(), Error> {
@@ -300,7 +312,7 @@ fn dispatch_skill_list(cwd: &Path) -> Result<(), Error> {
         println!("{}", out.muted("(no skills)"));
     } else {
         for skill in &skills {
-            println!("{}", out.accent(&skill.name));
+            println!("{}", out.skill(&skill.name));
         }
     }
     Ok(())
@@ -324,7 +336,7 @@ fn dispatch_skill_list_home() -> Result<(), Error> {
                 "{}\t{}\t{}",
                 style.muted(&entry.project),
                 style.muted(&entry.root),
-                style.accent(&entry.skill)
+                style.skill(&entry.skill)
             );
         }
     }
@@ -338,7 +350,7 @@ fn dispatch_skill_list_stash() -> Result<(), Error> {
         println!("{}", style.muted("(no stash skills)"));
     } else {
         for name in &names {
-            println!("{}", style.accent(name));
+            println!("{}", style.skill(name));
         }
     }
     Ok(())
@@ -365,7 +377,7 @@ fn dispatch_skill_harvest(cwd: &Path) -> Result<(), Error> {
                 println!(
                     "{} {} {}",
                     out.success("created"),
-                    out.accent(&event.name),
+                    out.skill(&event.name),
                     out.muted(event.source.display())
                 );
             }
@@ -373,7 +385,7 @@ fn dispatch_skill_harvest(cwd: &Path) -> Result<(), Error> {
                 println!(
                     "{} {} {}",
                     out.muted("unchanged"),
-                    out.accent(&event.name),
+                    out.skill(&event.name),
                     out.muted(event.source.display())
                 );
             }
@@ -382,7 +394,7 @@ fn dispatch_skill_harvest(cwd: &Path) -> Result<(), Error> {
                 eprintln!(
                     "{} {} {} ({})",
                     err.warn("skipped"),
-                    err.accent(&event.name),
+                    err.skill(&event.name),
                     err.muted(event.source.display()),
                     detail
                 );
@@ -405,9 +417,9 @@ fn dispatch_skill_refresh(cwd: &Path, name: Option<&str>) -> Result<(), Error> {
         Some(name) => {
             let changed = refresh::refresh_skill(cwd, name)?;
             if changed {
-                println!("{} {}", style.success("Refreshed"), style.accent(name));
+                println!("{} {}", style.success("Refreshed"), style.skill(name));
             } else {
-                println!("{} {}", style.muted("Unchanged"), style.accent(name));
+                println!("{} {}", style.muted("Unchanged"), style.skill(name));
             }
             Ok(())
         }
@@ -419,7 +431,7 @@ fn dispatch_skill_refresh(cwd: &Path, name: Option<&str>) -> Result<(), Error> {
                 println!(
                     "{} {}",
                     style.success("Refreshed"),
-                    style.accent(refreshed.join(", "))
+                    style.skill(refreshed.join(", "))
                 );
             }
             Ok(())

--- a/src/manage_tink.rs
+++ b/src/manage_tink.rs
@@ -12,9 +12,9 @@ const COMMANDS_MD: &str = include_str!("../skills/manage-tink/references/command
 
 /// Stage the embedded skill and install it into the project via `add`.
 ///
-/// Uses the normal add path (project install + home stash + name catalog).
-/// Returns the installed skill name.
-pub fn install_manage_tink(project_root: &Path) -> Result<String, Error> {
+/// Uses the quiet add path so init can own the closing narrative.
+/// Returns the install outcome (name + whether the project tree was created).
+pub fn install_manage_tink(project_root: &Path) -> Result<add::AddOutcome, Error> {
     let staging = tempfile::Builder::new()
         .prefix(".tink-manage-tink-")
         .tempdir()
@@ -30,12 +30,11 @@ pub fn install_manage_tink(project_root: &Path) -> Result<String, Error> {
         .map_err(|e| map_io(&agents.join("openai.yaml"), e))?;
     std::fs::write(references.join("commands.md"), COMMANDS_MD)
         .map_err(|e| map_io(&references.join("commands.md"), e))?;
-    let outcome = add::add_skill(
+    add::add_skill_quiet(
         project_root,
         skill_root
             .to_str()
             .ok_or_else(|| Error::msg("manage-tink path is not UTF-8"))?,
         None,
-    )?;
-    Ok(outcome.name)
+    )
 }

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -13,8 +13,9 @@ pub struct RemoveReport {
     pub removed: PathBuf,
 }
 
-/// Delete `<project>/.agents/skills/<name>/` and drop that name from the
-/// by-project catalog. Does not touch `$TINK_HOME` stash trees.
+/// Drop `<name>` from the by-project catalog, then delete
+/// `<project>/.agents/skills/<name>/`. Does not touch `$TINK_HOME` stash trees.
+/// Catalog sync runs before disk delete; sync errors leave the skill tree intact.
 pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Error> {
     if !skills::valid_skill_name(name) {
         return Err(Error::msg(format!("Invalid skill name: {name}")));
@@ -42,7 +43,7 @@ pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Err
         )));
     }
 
-    fs::remove_dir_all(&target).map_err(|e| map_io(&target, e))?;
     catalog::withdraw_skill(project_root, name)?;
+    fs::remove_dir_all(&target).map_err(|e| map_io(&target, e))?;
     Ok(RemoveReport { removed: target })
 }

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::catalog;
 use crate::error::Error;
 use crate::paths::{map_io, refuse_symlink};
 use crate::skills;
@@ -12,9 +13,8 @@ pub struct RemoveReport {
     pub removed: PathBuf,
 }
 
-/// Delete `<project>/.agents/skills/<name>/` only.
-///
-/// Does not touch `$TINK_HOME` stash trees or the by-project catalog.
+/// Delete `<project>/.agents/skills/<name>/` and drop that name from the
+/// by-project catalog. Does not touch `$TINK_HOME` stash trees.
 pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Error> {
     if !skills::valid_skill_name(name) {
         return Err(Error::msg(format!("Invalid skill name: {name}")));
@@ -43,5 +43,6 @@ pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Err
     }
 
     fs::remove_dir_all(&target).map_err(|e| map_io(&target, e))?;
+    catalog::withdraw_skill(project_root, name)?;
     Ok(RemoveReport { removed: target })
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -11,6 +11,7 @@ const GREEN: Ansi = Color::Ansi(AnsiColor::Green);
 const RED: Ansi = Color::Ansi(AnsiColor::Red);
 const YELLOW: Ansi = Color::Ansi(AnsiColor::Yellow);
 const CYAN: Ansi = Color::Ansi(AnsiColor::Cyan);
+const MAGENTA: Ansi = Color::Ansi(AnsiColor::Magenta);
 const WHITE: Ansi = Color::Ansi(AnsiColor::White);
 
 /// Clap help/error styles.
@@ -83,6 +84,26 @@ impl CliStyle {
     pub fn accent(self, text: impl std::fmt::Display) -> String {
         self.paint(Style::new().fg_color(Some(CYAN)), text)
     }
+
+    /// Skill names — magenta so they read apart from cyan paths/accents.
+    pub fn skill(self, text: impl std::fmt::Display) -> String {
+        self.paint(Style::new().fg_color(Some(MAGENTA)).effects(Effects::BOLD), text)
+    }
+
+    /// Clickable terminal hyperlink (OSC 8). Plain label when styling is off.
+    pub fn link(self, url: &str, text: impl std::fmt::Display) -> String {
+        let label = text.to_string();
+        if !self.enabled {
+            return label;
+        }
+        let painted = self.paint(
+            Style::new()
+                .fg_color(Some(CYAN))
+                .effects(Effects::UNDERLINE),
+            &label,
+        );
+        format!("\u{1b}]8;;{url}\u{1b}\\{painted}\u{1b}]8;;\u{1b}\\")
+    }
 }
 
 fn color_enabled() -> bool {
@@ -99,6 +120,11 @@ mod tests {
         assert_eq!(style.success("OK"), "OK");
         assert_eq!(style.error("nope"), "nope");
         assert_eq!(style.accent("tui-design"), "tui-design");
+        assert_eq!(style.skill("manage-tink"), "manage-tink");
+        assert_eq!(
+            style.link("https://github.com/jon-devlapaz/tink-skills", "tink-skills"),
+            "tink-skills"
+        );
         assert!(!style.enabled());
     }
 
@@ -109,6 +135,15 @@ mod tests {
         assert!(painted.contains("OK"), "{painted}");
         assert!(painted.contains('\u{1b}'), "{painted}");
         assert_ne!(painted, "OK");
+        let skill = style.skill("manage-tink");
+        assert!(skill.contains("manage-tink"), "{skill}");
+        assert!(skill.contains('\u{1b}'), "{skill}");
+        let link = style.link("https://github.com/jon-devlapaz/tink-skills", "tink-skills");
+        assert!(link.contains("tink-skills"), "{link}");
+        assert!(
+            link.contains("\u{1b}]8;;https://github.com/jon-devlapaz/tink-skills\u{1b}\\"),
+            "{link}"
+        );
     }
 
     #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -833,7 +833,7 @@ fn h5_skill_harvest_copies_harness_skills_into_stash() {
         .assert()
         .success()
         .stdout(
-            predicate::str::contains("created")
+            predicate::str::contains("Harvested")
                 .and(predicate::str::contains("agents-skill"))
                 .and(predicate::str::contains("claude-skill"))
                 .and(predicate::str::contains("nested-skill")),
@@ -865,7 +865,11 @@ fn h6_skill_harvest_identical_is_unchanged() {
         .args(["skill", "harvest"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("unchanged").and(predicate::str::contains("same-skill")));
+        .stdout(
+            predicate::str::contains("already present")
+                .and(predicate::str::contains("0 harvested"))
+                .and(predicate::str::contains("same-skill").not()),
+        );
 }
 
 #[test]
@@ -887,7 +891,7 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
         .args(["skill", "harvest"])
         .assert()
         .success()
-        .stderr(predicate::str::contains("skipped").and(predicate::str::contains("demo-skill")));
+        .stderr(predicate::str::contains("Skipped").and(predicate::str::contains("demo-skill")));
 
     let after = fs::read_to_string(ws.stash_skill("demo-skill").join("SKILL.md")).unwrap();
     assert_eq!(before, after, "create-only must not repair divergent stash");

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -1321,10 +1321,18 @@ fn d1_destroy_yes_removes_agents_zen_agents_md() {
         .args(["init", "--with-zen", "--no-tink-skills"])
         .assert()
         .success();
+    let source = ws.root.join("extra-skill");
+    write_skill(&source, "extra-skill", "also cataloged");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
     assert!(project.join(".agents").is_dir());
     assert!(project.join("ZEN.md").is_file());
     assert!(project.join("AGENTS.md").is_file());
     assert!(ws.inventory.join("layout.json").is_file());
+    ws.assert_cataloged("app", "manage-tink");
+    ws.assert_cataloged("app", "extra-skill");
 
     ws.cmd(&project)
         .args(["destroy", "--yes"])
@@ -1335,6 +1343,23 @@ fn d1_destroy_yes_removes_agents_zen_agents_md() {
     assert!(!project.join("ZEN.md").exists());
     assert!(!project.join("AGENTS.md").exists());
     assert!(ws.inventory.join("layout.json").is_file());
+    assert!(
+        ws.stash_skill("manage-tink").join("SKILL.md").is_file(),
+        "home stash must remain after destroy"
+    );
+    assert!(
+        ws.stash_skill("extra-skill").join("SKILL.md").is_file(),
+        "home stash must remain after destroy"
+    );
+    ws.cmd(&project)
+        .args(["skill", "list", "--home"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("manage-tink")
+                .not()
+                .and(predicate::str::contains("extra-skill").not()),
+        );
 }
 
 #[test]
@@ -1368,7 +1393,7 @@ fn d3_destroy_refuses_agents_symlink() {
 // --- X*: skill remove ---
 
 #[test]
-fn x1_remove_deletes_project_skill_keeps_stash_and_catalog() {
+fn x1_remove_deletes_project_skill_keeps_stash_drops_catalog() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -1397,7 +1422,15 @@ fn x1_remove_deletes_project_skill_keeps_stash_and_catalog() {
         ws.stash_skill("demo-skill").join("SKILL.md").is_file(),
         "home stash must remain after project remove"
     );
-    ws.assert_cataloged("app", "demo-skill");
+    ws.cmd(&project)
+        .args(["skill", "list", "--home"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("demo-skill")
+                .not()
+                .and(predicate::str::contains("manage-tink")),
+        );
 }
 
 #[test]
@@ -1454,6 +1487,47 @@ fn x4_remove_does_not_delete_home_stash() {
     assert!(!Workspace::skill_path(&project, "keep-stash").exists());
     let after = fs::read(&stash_md).unwrap();
     assert_eq!(before, after);
+}
+
+#[test]
+fn x5_manage_tink_documents_remove_and_catalog_sync() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    let skill_md =
+        fs::read_to_string(Workspace::skill_path(&project, "manage-tink").join("SKILL.md"))
+            .expect("manage-tink SKILL.md");
+    let commands = fs::read_to_string(
+        Workspace::skill_path(&project, "manage-tink")
+            .join("references")
+            .join("commands.md"),
+    )
+    .expect("manage-tink commands.md");
+
+    assert!(
+        skill_md.contains("tink skill remove NAME"),
+        "manage-tink must authorize skill remove"
+    );
+    assert!(
+        skill_md.contains("by-project catalog")
+            && (skill_md.contains("drops") || skill_md.contains("drop")),
+        "manage-tink must state remove/destroy sync the catalog: {skill_md}"
+    );
+    assert!(
+        !skill_md.contains("prune is out of v1"),
+        "manage-tink must not claim catalog prune is out of v1"
+    );
+    assert!(
+        commands.contains("tink skill remove NAME"),
+        "commands.md must list skill remove"
+    );
+    assert!(
+        commands.contains("catalog")
+            && (commands.contains("drops")
+                || commands.contains("drop")
+                || commands.contains("updates")),
+        "commands.md must describe catalog sync on remove/destroy: {commands}"
+    );
 }
 
 // --- S*: safety ---

--- a/tink-test
+++ b/tink-test
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Run this checkout's tink without using ~/.local/bin or ~/.cargo/bin.
-# Always uses <repo>/.tink-test-home (ignores ambient TINK_HOME) so inventory
-# stays off ~/.tink. Override: TINK_TEST_HOME=/other/path ./tink-test …
+# Always uses ~/.tink-test (ignores ambient TINK_HOME) so dogfood stays off
+# ~/.tink. Override: TINK_TEST_HOME=/other/path ./tink-test …
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cargo build -q --manifest-path "$ROOT/Cargo.toml"
-export TINK_HOME="${TINK_TEST_HOME:-$ROOT/.tink-test-home}"
+export TINK_HOME="${TINK_TEST_HOME:-$HOME/.tink-test}"
 exec "$ROOT/target/debug/tink" "$@"

--- a/tink-test
+++ b/tink-test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Run this checkout's tink without using ~/.local/bin or ~/.cargo/bin.
+# Always uses <repo>/.tink-test-home (ignores ambient TINK_HOME) so inventory
+# stays off ~/.tink. Override: TINK_TEST_HOME=/other/path ./tink-test …
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cargo build -q --manifest-path "$ROOT/Cargo.toml"
+export TINK_HOME="${TINK_TEST_HOME:-$ROOT/.tink-test-home}"
+exec "$ROOT/target/debug/tink" "$@"


### PR DESCRIPTION
## Summary
- Sync by-project catalog on `skill remove` / `destroy` via `withdraw_skill` / `forget_project` (soft Ok when home/entry/name missing; never `ensure_inventory_root`; preserve meta `name`/`root` on partial withdraw). Stash prune stays out of v1; no new CLI verbs; basename collisions (#2) unchanged.
- Tighten ACCEPTANCE X1/D1 and add X5 manage-tink docs gate; update manage-tink prove/authority and README.
- Init owns one outcome narrative (`Added` / `Already present`); quiet per-skill add chatter during init. Prompt polish: ZEN `[y/N/r]`, muted hints, purple skill names, tink-skills OSC 8 link. Init labels home as `Home at` (not “inventory”).
- Harvest: `Harvested` / `Skipped` lines; already-present quiet; summary `Harvest N harvested · …`; `Home` path. `./tink-test` forces `~/.tink-test` (override `TINK_TEST_HOME`).

## Test plan
- [x] `cargo test --lib catalog::`
- [x] Acceptance X1, D1, X5, X2–X4, D2–D3
- [x] Acceptance I1–I7; H5–H8
- [x] Dogfood: re-init → `Already present`; harvest summary without per-skill already-present spam
- [ ] CI green on this PR

Fixes #13
Fixes #1
Fixes #3
Fixes #16