### PR TITLE
Let bare skill names promote from the home stash

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -70,7 +70,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | A3 | `skill add` when project target exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
 | A4 | `skill add` skill tree containing a symlink | Exit ≠ 0; refuse |
 | A5 | `skill add` multi-skill source without `--skill` | Exit ≠ 0; lists choices |
-| A6 | `skill add` when home stash has same name but different tree (project missing) | Exit 0; installs project; repairs stash; warns on stderr |
+| A6 | `skill add` when home stash has same name but different tree (project missing) | Exit 0; installs project; repairs stash; warns on stderr that the home copy was updated |
 | A7 | `skill add` skill named `by-project` | Exit ≠ 0; reserved name; no project/stash write |
 | A8 | `skill add` same GitHub tip already stashed at home | Exit 0; installs project from stash (no clone); stdout notes stash |
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -142,7 +142,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | X2 | `skill remove <missing>` | Exit ≠ 0; mentions not found / missing; nothing deleted |
 | X3 | `skill remove` when `.agents` is a symlink | Exit ≠ 0; mentions symlink; tree unchanged |
 | X4 | Successful `skill remove <name>` | Does **not** delete `$TINK_HOME/skills/<name>/` |
-| X5 | `init` installs `manage-tink` | Embedded skill documents `tink skill remove NAME` as the only remove path; states remove drops the catalog name and destroy drops the project catalog entry; home stash remains unpruned |
+| X5 | `init` installs `manage-tink` | Embedded skill documents `tink skill remove NAME` as the only remove path; documents bare `tink skill add NAME` for stash promote (not `add --stash`); states remove drops the catalog name and destroy drops the project catalog entry; home stash remains unpruned |
 
 ### Destroy
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -12,8 +12,7 @@ from GitHub Releases via `tink update`.
 below has an automated test that passes on macOS with `git` on `PATH`.
 
 **Out of v1:** weekly GitHub update workflows, private GitHub auth, Windows,
-Linux CI as a gate, pruning the home stash, bare-name stash promote without
-`--stash`.
+Linux CI as a gate, pruning the home stash.
 
 **Dogfood:** Prefer an installed `tink` from this repo, or `cargo run -q -- …`.
 
@@ -25,8 +24,7 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | Command | Meaning |
 |---|---|
 | `tink init` | Create `.agents/skills/`; install `manage-tink` by default; optional ZEN + tink-skills; ensure `~/.tink` |
-| `tink skill add <source> [--skill <name>]` | Install one local or public GitHub skill |
-| `tink skill add --stash <name>` | Install one skill from the home stash (`$TINK_HOME/skills/<name>/`) |
+| `tink skill add <source> [--skill <name>]` | Install one local path, public GitHub skill, or home stash skill by name |
 | `tink skill list` | List project skills under `.agents/skills/` (read-only) |
 | `tink skill list --home` | List offline by-project catalog (`project`, `root`, `skill` TSV) |
 | `tink skill list --stash` | List skill names in the home stash (`skills/<name>/` with `SKILL.md`) |
@@ -109,9 +107,9 @@ Ids are stable. Tests must name or comment the id they prove.
 | Id | Action | Expect |
 |---|---|---|
 | H1 | `skill list --stash` after init+add | Exit 0; stdout includes stashed skill names (at least the added skill) |
-| H2 | `skill add --stash <name>` when stash has that skill and project lacks it | Exit 0; installs under `.agents/skills/<name>/`; catalogs name; **no** network; stdout notes stash |
-| H3 | `skill add --stash <missing>` | Exit ≠ 0; mentions not found / missing; **no** GitHub network fetch |
-| H4 | `skill add --stash <name>` when project skill exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
+| H2 | `skill add <name>` when stash has that skill and project lacks it | Exit 0; installs under `.agents/skills/<name>/`; catalogs name; **no** network; stdout notes stash |
+| H3 | `skill add <missing-bare-name>` | Exit ≠ 0; mentions stash not found / missing; **no** GitHub network fetch |
+| H4 | `skill add <name>` when stash has skill and project skill exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
 | H5 | `skill harvest` with fixture `$HOME/.agents/skills` + `$HOME/.claude/skills` + `TINK_HOME` | Copies complete skill trees into `$TINK_HOME/skills/`; no project `.agents` skill writes from harvest |
 | H6 | `skill harvest` when stash already identical | Exit 0; summary counts already present; no per-skill already-present lines |
 | H7 | `skill harvest` when stash diverges | Exit 0; stash unchanged; stderr skip warn |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ flowchart LR
   tink -->|"add / remove"| live
   tink -->|"copies on add"| stash
   tink -->|"records names"| catalog
-  tink -->|"add --stash"| live
+  tink -->|"add <stash-name>"| live
 ```
 
 Home (`~/.tink` or `$TINK_HOME`) is **not** an agent discovery root. Stash holds
@@ -117,7 +117,7 @@ Stash, catalog, init flags, and destroy:
 
 ```console
 tink skill list --stash
-tink skill add --stash skill-name
+tink skill add skill-name
 tink skill harvest
 tink skill list --home
 
@@ -130,9 +130,10 @@ tink update
 
 If the GitHub tip is already in the stash and matches the tip byte-for-byte,
 `skill add` may install from the stash. If the stash differs, tink repairs it
-and warns. `skill remove` deletes the project skill directory and drops that
-name from the by-project catalog; it does not delete home stash trees.
-`destroy` also drops this project's catalog entry.
+and warns. A bare skill name (not a path and not `owner/repo`) promotes from
+the home stash into the project. `skill remove` deletes the project skill
+directory and drops that name from the by-project catalog; it does not delete
+home stash trees. `destroy` also drops this project's catalog entry.
 
 ### Uninstall the CLI
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ skill trees; catalog holds by-project **names** only.
 
 ```console
 tink skill add ../my-skill
+tink skill add skill-name
 tink skill add owner/repository --skill skill-name
 tink skill add jon-devlapaz/tink-skills --skill skill-eval-loop
 tink skill list
@@ -105,6 +106,7 @@ tink skill refresh skill-name
 tink skill remove skill-name
 ```
 
+- Bare `skill-name` promotes from the home stash (`tink skill list --stash`).
 - `--skill` when the source repo publishes several skills.
 - Refresh only clean GitHub imports; local edits are refused.
 - tink does not overwrite a project skill that differs from what it would

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -24,7 +24,8 @@ are hard stops — honor them; do not work around them.
    command from [references/commands.md](references/commands.md). Run that
    command; do not invent flags, merges, force-overwrites, or alternate install
    paths (no symlinks, manual copies, or private registries). To promote from
-   the home stash into the project, use `tink skill add --stash NAME` only.
+   the home stash into the project, use `tink skill add NAME` only (bare stash
+   skill name; not a path and not `owner/repo`).
    To fill the home stash from known harness skill locations, use
    `tink skill harvest` only (create-only; does not write project skills).
    To remove a live project skill, use `tink skill remove NAME` only (drops the
@@ -48,7 +49,7 @@ are hard stops — honor them; do not work around them.
 | …and ZEN / tink-skills / skip manage-tink | Only the matching `--with-*` / `--no-*` flags |
 | Add / list / check / refresh / remove … | The matching `tink skill …` command |
 | List home catalog | `tink skill list --home` |
-| List home stash / promote from stash | `tink skill list --stash` / `tink skill add --stash NAME` |
+| List home stash / promote from stash | `tink skill list --stash` / `tink skill add NAME` |
 | Harvest harness skills into home stash | `tink skill harvest` |
 | Remove one project skill | `tink skill remove NAME` |
 | Update the tink CLI | `tink update` |
@@ -68,6 +69,6 @@ are hard stops — honor them; do not work around them.
 - Never execute code from a skill while adding, checking, refreshing, removing,
   or destroying.
 - Home stash (`~/.tink/skills/`) is **not** an agent discovery root; do not
-  symlink or copy from it by hand — use `tink skill add --stash NAME`.
+  symlink or copy from it by hand — use `tink skill add NAME`.
 - Do not prune the home stash by hand. `skill remove` and `destroy` sync the
   by-project catalog; they do not delete stash trees.

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -12,7 +12,7 @@ form for add, list, check, refresh, and remove.
 | Init without embedded manage-tink | add `--no-manage-tink` |
 | Add one skill | `tink skill add SOURCE` |
 | Add from multi-skill repo | `tink skill add SOURCE --skill NAME` |
-| Add from home stash | `tink skill add --stash NAME` |
+| Add from home stash | `tink skill add NAME` |
 | Harvest harness skills into home stash | `tink skill harvest` |
 | List (this project) | `tink skill list` |
 | List (home catalog) | `tink skill list --home` |
@@ -30,7 +30,7 @@ form for add, list, check, refresh, and remove.
 - Home (`$TINK_HOME` or `~/.tink`) is not an agent discovery root. Installs
   stash trees at `skills/<name>/`. List the stash with
   `tink skill list --stash`; promote into a project with
-  `tink skill add --stash NAME`. `tink skill harvest` copies complete trees
+  `tink skill add NAME` (bare stash skill name). `tink skill harvest` copies complete trees
   from known harness roots into the stash create-only (never overwrites a
   divergent stash entry). Global roots include `~/.agents/skills`,
   `~/.claude/skills`, `~/.codex/skills`, `~/.cursor/skills`,

--- a/src/add.rs
+++ b/src/add.rs
@@ -43,7 +43,7 @@ fn place_skill(
         let err = CliStyle::auto_stderr();
         eprintln!(
             "{}",
-            err.warn(format!("Repaired divergent stash for {}", skill.name))
+            err.warn(format!("Updated home copy of {}", skill.name))
         );
     }
     let (installed, created) = skills::install_local(skill, destination_root, provenance)?;

--- a/src/add.rs
+++ b/src/add.rs
@@ -194,22 +194,30 @@ fn add_skill_inner(
     if looks_like_filesystem_path(source_value) {
         return Err(Error::msg(format!("Path does not exist: {source_value}")));
     }
-    let remote = sources::parse_remote(source_value)?;
-    let outcome = add_from_remote(project_root, &destination_root, &remote, selected_name)?;
+    // Slash or URL → remote only. Bare name → home stash promote.
+    if looks_like_remote_source(source_value) {
+        let remote = sources::parse_remote(source_value)?;
+        let outcome = add_from_remote(project_root, &destination_root, &remote, selected_name)?;
+        if report {
+            report_add(&outcome);
+        }
+        return Ok(outcome);
+    }
+    if selected_name.is_some() {
+        return Err(Error::msg(
+            "Do not combine --skill with a stash skill name; pass only the stash name",
+        ));
+    }
+    let skill = stash::load(source_value)?;
+    let outcome = place_from_stash(project_root, &skill, &destination_root)?;
     if report {
         report_add(&outcome);
     }
     Ok(outcome)
 }
 
-/// Promote one skill from the home stash into the project by name.
-pub fn add_from_stash(project_root: &Path, name: &str) -> Result<AddOutcome, Error> {
-    init::ensure_project_layout(project_root)?;
-    let destination_root = project_root.join(".agents").join("skills");
-    let skill = stash::load(name)?;
-    let outcome = place_from_stash(project_root, &skill, &destination_root)?;
-    report_add(&outcome);
-    Ok(outcome)
+fn looks_like_remote_source(value: &str) -> bool {
+    value.contains('/') || value.contains("://")
 }
 
 fn looks_like_filesystem_path(value: &str) -> bool {

--- a/src/init.rs
+++ b/src/init.rs
@@ -84,11 +84,23 @@ fn opt_in_zen(explicit: Option<bool>) -> Result<bool, Error> {
         return Ok(false);
     }
     let style = CliStyle::auto_stdout();
-    let question = style.warn("Add tink's maintainability principles (ZEN.md)?");
-    let hint = style.muted("r = print ZEN.md without adding it");
+    let zen = style.rainbow("ZEN.md");
+    let r = style.rainbow("r");
+    let question = format!(
+        "{} ({})?",
+        style.warn("Add tink's maintainability principles"),
+        zen
+    );
+    let hint = format!("{r} = print {zen} without adding it");
+    let choices = format!(
+        "[{}/{}/{}] ",
+        style.accent("y"),
+        style.accent("N"),
+        r
+    );
     loop {
         println!("{hint}");
-        print!("{} {}", question, style.accent("[y/N/r] "));
+        print!("{question} {choices}");
         io::stdout()
             .flush()
             .map_err(|e| Error::msg(format!("prompt: {e}")))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,9 +227,10 @@ fn dispatch_init(
     }
     if report.zen_written {
         println!(
-            "{} {}",
+            "{} {} {}",
             style.success("Added"),
-            style.accent("ZEN.md maintainability principles")
+            style.rainbow("ZEN.md"),
+            style.accent("maintainability principles")
         );
     }
     if let Some(skill) = &report.manage_tink_added {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,14 +85,11 @@ pub enum Command {
 pub enum SkillCommand {
     /// Copy one complete skill into the project
     Add {
-        /// Local skill/repository path, `owner/repo`, public GitHub HTTPS URL, or stash name with `--stash`
+        /// Local path, `owner/repo`, public GitHub HTTPS URL, or home stash skill name
         source: String,
         /// Skill name when the source contains several skills
         #[arg(long)]
         skill: Option<String>,
-        /// Install from the home stash (`$TINK_HOME/skills/<name>/`) by skill name
-        #[arg(long)]
-        stash: bool,
     },
     /// List installed project skills, the home by-project catalog, or the home stash
     List {
@@ -181,21 +178,8 @@ fn dispatch(cli: Cli, cwd: PathBuf) -> Result<(), Error> {
 
 fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
     match command {
-        SkillCommand::Add {
-            source,
-            skill,
-            stash,
-        } => {
-            if stash {
-                if skill.is_some() {
-                    return Err(Error::msg(
-                        "Do not combine --skill with --stash; pass the stash skill name as the source",
-                    ));
-                }
-                dispatch_skill_add_stash(cwd, &source)
-            } else {
-                dispatch_skill_add(cwd, &source, skill.as_deref())
-            }
+        SkillCommand::Add { source, skill } => {
+            dispatch_skill_add(cwd, &source, skill.as_deref())
         }
         SkillCommand::List { home, stash } => {
             if home {
@@ -284,10 +268,6 @@ fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) {
 
 fn dispatch_skill_add(cwd: &Path, source: &str, skill: Option<&str>) -> Result<(), Error> {
     add::add_skill(cwd, source, skill).map(|_| ())
-}
-
-fn dispatch_skill_add_stash(cwd: &Path, name: &str) -> Result<(), Error> {
-    add::add_from_stash(cwd, name).map(|_| ())
 }
 
 fn dispatch_skill_check(cwd: &Path) -> Result<(), Error> {

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -1,7 +1,7 @@
 //! Home skill stash (`$TINK_HOME/skills/<name>/`).
 //!
 //! Rebuildable dump of skill trees from successful installs. Not an agent
-//! discovery root — promote into a project with `tink skill add --stash`.
+//! discovery root — promote into a project with `tink skill add <name>`.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/style.rs
+++ b/src/style.rs
@@ -11,8 +11,11 @@ const GREEN: Ansi = Color::Ansi(AnsiColor::Green);
 const RED: Ansi = Color::Ansi(AnsiColor::Red);
 const YELLOW: Ansi = Color::Ansi(AnsiColor::Yellow);
 const CYAN: Ansi = Color::Ansi(AnsiColor::Cyan);
+const BLUE: Ansi = Color::Ansi(AnsiColor::Blue);
 const MAGENTA: Ansi = Color::Ansi(AnsiColor::Magenta);
 const WHITE: Ansi = Color::Ansi(AnsiColor::White);
+
+const RAINBOW: [Ansi; 6] = [RED, YELLOW, GREEN, CYAN, BLUE, MAGENTA];
 
 /// Clap help/error styles.
 pub const CLAP_STYLES: Styles = Styles::styled()
@@ -90,6 +93,28 @@ impl CliStyle {
         self.paint(Style::new().fg_color(Some(MAGENTA)).effects(Effects::BOLD), text)
     }
 
+    /// Per-character rainbow (init ZEN tease). Plain text when styling is off.
+    pub fn rainbow(self, text: impl std::fmt::Display) -> String {
+        let text = text.to_string();
+        if !self.enabled {
+            return text;
+        }
+        let mut out = String::with_capacity(text.len() * 12);
+        let mut color_i = 0usize;
+        for ch in text.chars() {
+            if ch.is_whitespace() {
+                out.push(ch);
+                continue;
+            }
+            let style = Style::new()
+                .fg_color(Some(RAINBOW[color_i % RAINBOW.len()]))
+                .effects(Effects::BOLD);
+            out.push_str(&format!("{}{}{}", style.render(), ch, style.render_reset()));
+            color_i += 1;
+        }
+        out
+    }
+
     /// Clickable terminal hyperlink (OSC 8). Plain label when styling is off.
     pub fn link(self, url: &str, text: impl std::fmt::Display) -> String {
         let label = text.to_string();
@@ -121,6 +146,7 @@ mod tests {
         assert_eq!(style.error("nope"), "nope");
         assert_eq!(style.accent("tui-design"), "tui-design");
         assert_eq!(style.skill("manage-tink"), "manage-tink");
+        assert_eq!(style.rainbow("ZEN.md"), "ZEN.md");
         assert_eq!(
             style.link("https://github.com/jon-devlapaz/tink-skills", "tink-skills"),
             "tink-skills"
@@ -138,6 +164,10 @@ mod tests {
         let skill = style.skill("manage-tink");
         assert!(skill.contains("manage-tink"), "{skill}");
         assert!(skill.contains('\u{1b}'), "{skill}");
+        let rainbow = style.rainbow("ZEN.md");
+        assert!(rainbow.contains('Z') && rainbow.contains('N'), "{rainbow}");
+        assert!(rainbow.contains('\u{1b}'), "{rainbow}");
+        assert_ne!(rainbow, "ZEN.md");
         let link = style.link("https://github.com/jon-devlapaz/tink-skills", "tink-skills");
         assert!(link.contains("tink-skills"), "{link}");
         assert!(

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -1513,6 +1513,17 @@ fn x5_manage_tink_documents_remove_and_catalog_sync() {
         "manage-tink must authorize skill remove"
     );
     assert!(
+        skill_md.contains("tink skill add NAME")
+            && skill_md.contains("bare stash")
+            && !skill_md.contains("add --stash"),
+        "manage-tink must teach bare-name stash promote, not add --stash: {skill_md}"
+    );
+    assert!(
+        commands.contains("tink skill add NAME")
+            && !commands.contains("add --stash"),
+        "commands.md must list bare-name stash promote, not add --stash: {commands}"
+    );
+    assert!(
         skill_md.contains("by-project catalog")
             && (skill_md.contains("drops") || skill_md.contains("drop")),
         "manage-tink must state remove/destroy sync the catalog: {skill_md}"

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -735,7 +735,7 @@ fn h2_skill_add_stash_installs_into_project() {
         .assert()
         .success();
     ws.cmd(&app)
-        .args(["skill", "add", "--stash", "stash-skill"])
+        .args(["skill", "add", "stash-skill"])
         .assert()
         .success()
         .stdout(
@@ -757,7 +757,7 @@ fn h3_skill_add_stash_missing_refuses_without_github() {
         .assert()
         .success();
     ws.cmd(&project)
-        .args(["skill", "add", "--stash", "no-such-skill"])
+        .args(["skill", "add", "no-such-skill"])
         .assert()
         .failure()
         .stderr(
@@ -792,7 +792,7 @@ fn h4_skill_add_stash_refuses_overwrite_when_diverged() {
         "project local body",
     );
     ws.cmd(&app)
-        .args(["skill", "add", "--stash", "demo-skill"])
+        .args(["skill", "add", "demo-skill"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("Refusing to overwrite"));

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -369,7 +369,7 @@ fn a6_add_repairs_divergent_home_archive_and_installs_project() {
         .args(["skill", "add", second.to_str().unwrap()])
         .assert()
         .success()
-        .stderr(predicate::str::contains("Repaired divergent stash"));
+        .stderr(predicate::str::contains("Updated home copy of"));
     assert!(Workspace::skill_path(&other, "demo-skill")
         .join("SKILL.md")
         .is_file());


### PR DESCRIPTION
## Summary
- Bare `tink skill add <name>` promotes from `$TINK_HOME/skills/<name>/` (catalog + receipt-as-present; refuse overwrite).
- Removes `add --stash`; keeps `list --stash`. Resolve order: path → GitHub `owner/repo`/URL → stash name → stash-miss.
- Updates ACCEPTANCE H2–H4, README, and manage-tink docs to match.

## Test plan
- [x] `cargo test --test acceptance` (56/56)
- [x] Dogfood: `skill add ask-matt` from stash; miss → `Stash skill not found`; `--stash` rejected by clap
- [x] Path add and overwrite refuse still behave
- [ ] Spot-check `owner/repo` add still works on a clean project


Made with [Cursor](https://cursor.com)