### PR TITLE
Rename stash CLI to library/catalog (0.3.0)

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -3,16 +3,16 @@
 **Outcome:** A smaller Tink core in Rust that installs complete Agent Skills into
 a project's `.agents/skills/`, proves them offline, refreshes clean GitHub
 imports, removes a project skill on request, ensures a home root at `~/.tink`
-(override: `TINK_HOME`), can list or promote skills from the home stash
+(override: `TINK_HOME`), can list or promote skills from the library
 (`skills/<name>/`) into a project, can harvest complete skill trees from known
-harness locations into that stash (create-only), and can update the CLI binary
+harness locations into that library (create-only), and can update the CLI binary
 from GitHub Releases via `tink update`.
 
 **Authority:** This file is the evaluator. Implementation stops when every row
 below has an automated test that passes on macOS with `git` on `PATH`.
 
 **Out of v1:** weekly GitHub update workflows, private GitHub auth, Windows,
-Linux CI as a gate, pruning the home stash.
+Linux CI as a gate, pruning the library.
 
 **Dogfood:** Prefer an installed `tink` from this repo, or `cargo run -q -- …`.
 
@@ -24,16 +24,16 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | Command | Meaning |
 |---|---|
 | `tink init` | Create `.agents/skills/`; install `manage-tink` by default; optional ZEN + tink-skills; ensure `~/.tink` |
-| `tink skill add <source> [--skill <name>]` | Install one local path, public GitHub skill, or home stash skill by name |
+| `tink skill add <source> [--skill <name>]` | Install one local path, public GitHub skill, or library skill by name |
 | `tink skill list` | List project skills under `.agents/skills/` (read-only) |
-| `tink skill list --home` | List offline by-project catalog (`project`, `root`, `skill` TSV) |
-| `tink skill list --stash` | List skill names in the home stash (`skills/<name>/` with `SKILL.md`) |
-| `tink skill harvest` | Copy complete skill trees from known harness roots into the home stash (create-only; no project writes) |
+| `tink skill list --catalog` | List offline by-project catalog (`project`, `root`, `skill` TSV) |
+| `tink skill list --library` | List skill names in the library (`skills/<name>/` with `SKILL.md`) |
+| `tink skill harvest` | Copy complete skill trees from known harness roots into the library (create-only; no project writes) |
 | `tink skill check` | Validate project skills; no network; no writes |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
-| `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` and drop that name from the by-project catalog (not home stash) |
+| `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` and drop that name from the by-project catalog (not library) |
 | `tink update` | Replace this binary with the latest public GitHub Release (requires `curl` + `tar`) |
-| `tink destroy [--yes]` | Remove `.agents/`, `ZEN.md`, and `AGENTS.md`; drop this project's by-project catalog entry (not home stash) |
+| `tink destroy [--yes]` | Remove `.agents/`, `ZEN.md`, and `AGENTS.md`; drop this project's by-project catalog entry (not library) |
 
 ## On-disk contracts
 
@@ -41,8 +41,8 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 |---|---|
 | Live skills | `<project>/.agents/skills/<name>/` with `SKILL.md` |
 | Receipt | `.tink-source.json` with exactly `source`, `revision`, `path` (non-empty strings) |
-| Home root | `$TINK_HOME` or `~/.tink`, with `layout.json` (`kind`: `tink-skill-inventory`) |
-| Home stash | `skills/<name>/` skill trees copied on successful add (rebuildable dump; identical tip may install project from stash; divergent → repair + warn; project overwrite still refused; not an agent discovery root) |
+| Home root | `$TINK_HOME` or `~/.tink` (relative `$TINK_HOME` absolutized against cwd), with `layout.json` (`kind`: `tink-skill-inventory`) |
+| Library | `skills/<name>/` skill trees copied on successful add (rebuildable collection; identical tip may install project from library; divergent → repair + warn; project overwrite still refused; not an agent discovery root) |
 | Offline catalog | `catalog/by-project/<project>/meta.json` with `name`, `root`, `skills` name list (not skill trees); `skill remove` drops a name; `destroy` drops the project entry |
 
 ## Rows
@@ -58,21 +58,22 @@ Ids are stable. Tests must name or comment the id they prove.
 | I3 | `init` (non-interactive / `--no-zen --no-tink-skills`) | Does **not** write `AGENTS.md`, `ZEN.md`, or `.github/workflows/*` (may still install `manage-tink`) |
 | I4 | `init` with `TINK_HOME` set | Creates home root + `layout.json` + `catalog/by-project/` + `skills/` |
 | I5 | `init --with-zen` | Writes `ZEN.md` and an `AGENTS.md` that references it |
-| I6 | `init` (default) | Installs `.agents/skills/manage-tink/`; catalogs `manage-tink`; stashes tree at `skills/manage-tink/` |
+| I6 | `init` (default) | Installs `.agents/skills/manage-tink/`; catalogs `manage-tink`; copies tree into library at `skills/manage-tink/` |
 | I7 | `init --no-manage-tink` | Does **not** install `manage-tink` |
+| I8 | `init` with relative `TINK_HOME` (e.g. `../home`) from project cwd | Exit 0; home is the absolutized sibling path (not nested under the project); stdout shows an absolute home path |
 
 ### Local add
 
 | Id | Action | Expect |
 |---|---|---|
-| A1 | `skill add` valid local skill dir | Installs under `.agents/skills/<name>/`; records name in catalog; stashes tree at `$TINK_HOME/skills/<name>/` |
-| A2 | `skill add` same skill again (byte-identical) | Success noop; project + home stash unchanged |
+| A1 | `skill add` valid local skill dir | Installs under `.agents/skills/<name>/`; records name in catalog; copies tree into library at `$TINK_HOME/skills/<name>/` |
+| A2 | `skill add` same skill again (byte-identical) | Success noop; project + library unchanged |
 | A3 | `skill add` when project target exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
 | A4 | `skill add` skill tree containing a symlink | Exit ≠ 0; refuse |
 | A5 | `skill add` multi-skill source without `--skill` | Exit ≠ 0; lists choices |
-| A6 | `skill add` when home stash has same name but different tree (project missing) | Exit 0; installs project; repairs stash; warns on stderr that the home copy was updated |
-| A7 | `skill add` skill named `by-project` | Exit ≠ 0; reserved name; no project/stash write |
-| A8 | `skill add` same GitHub tip already stashed at home | Exit 0; installs project from stash (no clone); stdout notes stash |
+| A6 | `skill add` when library has same name but different tree (project missing) | Exit 0; installs project; repairs library; warns on stderr that the home copy was updated |
+| A7 | `skill add` skill named `by-project` | Exit ≠ 0; reserved name; no project/library write |
+| A8 | `skill add` same GitHub tip already in library | Exit 0; installs project from library (no clone); stdout notes library |
 
 ### Remote add
 
@@ -99,21 +100,22 @@ Ids are stable. Tests must name or comment the id they prove.
 |---|---|---|
 | L1 | `skill list` after `init` | Exit 0; stdout includes `manage-tink` |
 | L2 | `skill list` without `.agents/skills` | Exit ≠ 0 |
-| L3 | `skill list --home` after init+add | Exit 0; header `project\\troot\\tskill` plus TSV rows for cataloged skills |
+| L3 | `skill list --catalog` after init+add | Exit 0; header `project\\troot\\tskill` plus TSV rows for cataloged skills |
 | L4 | `skill list` when `ZEN.md` exists without `AGENTS.md` reference | Exit 0; lists skills; warns on stderr about ZEN/AGENTS; `skill check` still fails |
+| L5 | `skill list --stash` or `skill list --home` | Exit ≠ 0; stderr mentions the flag or unexpected argument (removed in 0.3.0; use `--library` / `--catalog`) |
 
-### Home stash
+### Library
 
 | Id | Action | Expect |
 |---|---|---|
-| H1 | `skill list --stash` after init+add | Exit 0; stdout includes stashed skill names (at least the added skill) |
-| H2 | `skill add <name>` when stash has that skill and project lacks it | Exit 0; installs under `.agents/skills/<name>/`; catalogs name; **no** network; stdout notes stash |
-| H3 | `skill add <missing-bare-name>` | Exit ≠ 0; mentions stash not found / missing; **no** GitHub network fetch |
-| H4 | `skill add <name>` when stash has skill and project skill exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
+| H1 | `skill list --library` after init+add | Exit 0; stdout includes library skill names (at least the added skill) |
+| H2 | `skill add <name>` when library has that skill and project lacks it | Exit 0; installs under `.agents/skills/<name>/`; catalogs name; **no** network; stdout notes library |
+| H3 | `skill add <missing-bare-name>` | Exit ≠ 0; mentions library not found / missing; **no** GitHub network fetch |
+| H4 | `skill add <name>` when library has skill and project skill exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
 | H5 | `skill harvest` with fixture `$HOME/.agents/skills` + `$HOME/.claude/skills` + `TINK_HOME` | Copies complete skill trees into `$TINK_HOME/skills/`; no project `.agents` skill writes from harvest |
-| H6 | `skill harvest` when stash already identical | Exit 0; summary counts already present; no per-skill already-present lines |
-| H7 | `skill harvest` when stash diverges | Exit 0; stash unchanged; stderr skip warn |
-| H8 | `skill harvest` skips home stash sources and unsafe (symlink-inside) skill trees; still harvests cwd skills under `TINK_HOME` outside `skills/` | Stash/unsafe omitted; non-stash path under home deposited |
+| H6 | `skill harvest` when library already identical | Exit 0; summary counts already present; no per-skill already-present lines |
+| H7 | `skill harvest` when library diverges | Exit 0; library unchanged; stderr skip warn |
+| H8 | `skill harvest` skips library sources and unsafe (symlink-inside) skill trees; still harvests cwd skills under `TINK_HOME` outside `skills/` | Library/unsafe omitted; non-library path under home deposited |
 
 ### CLI surface
 
@@ -128,27 +130,27 @@ Ids are stable. Tests must name or comment the id they prove.
 |---|---|---|
 | P1 | `skill refresh` clean GitHub-imported skill after upstream change | Updates project skill + receipt **and** `$TINK_HOME/skills/<name>/` |
 | P2 | `skill refresh` when installed skill has local modifications | Exit ≠ 0; mentions local modifications; tree unchanged |
-| P3 | `skill refresh` when upstream unchanged but home stash missing | Exit 0; backfills `$TINK_HOME/skills/<name>/` from project |
-| P4 | `skill refresh` when home stash lacks only `.tink-source.json` | Exit 0; updates project + stash |
-| P5 | `skill refresh` when home stash body diverges from project | Exit ≠ 0; "stash diverges"; project unchanged |
-| P6 | `skill refresh` when upstream revision moves but skill tree bytes match | Exit 0; bumps project + stash receipts |
-| P7 | `skill refresh` when project already at HEAD but home stash is stale | Exit 0; repairs stash from project |
+| P3 | `skill refresh` when upstream unchanged but library missing | Exit 0; backfills `$TINK_HOME/skills/<name>/` from project |
+| P4 | `skill refresh` when library lacks only `.tink-source.json` | Exit 0; updates project + library |
+| P5 | `skill refresh` when library body diverges from project | Exit ≠ 0; "library diverges"; project unchanged |
+| P6 | `skill refresh` when upstream revision moves but skill tree bytes match | Exit 0; bumps project + library receipts |
+| P7 | `skill refresh` when project already at HEAD but library is stale | Exit 0; repairs library from project |
 
 ### Remove
 
 | Id | Action | Expect |
 |---|---|---|
-| X1 | `skill remove <name>` after init+add | Exit 0; project `.agents/skills/<name>/` gone; `skill list` omits name; home stash `$TINK_HOME/skills/<name>/` still present; `skill list --home` omits that skill for the project (siblings may remain) |
+| X1 | `skill remove <name>` after init+add | Exit 0; project `.agents/skills/<name>/` gone; `skill list` omits name; library `$TINK_HOME/skills/<name>/` still present; `skill list --catalog` omits that skill for the project (siblings may remain) |
 | X2 | `skill remove <missing>` | Exit ≠ 0; mentions not found / missing; nothing deleted |
 | X3 | `skill remove` when `.agents` is a symlink | Exit ≠ 0; mentions symlink; tree unchanged |
 | X4 | Successful `skill remove <name>` | Does **not** delete `$TINK_HOME/skills/<name>/` |
-| X5 | `init` installs `manage-tink` | Embedded skill documents `tink skill remove NAME` as the only remove path; documents bare `tink skill add NAME` for stash promote (not `add --stash`); states remove drops the catalog name and destroy drops the project catalog entry; home stash remains unpruned |
+| X5 | `init` installs `manage-tink` | Embedded skill documents `tink skill remove NAME` as the only remove path; documents bare `tink skill add NAME` for library promote (not `add --library`); states remove drops the catalog name and destroy drops the project catalog entry; library remains unpruned |
 
 ### Destroy
 
 | Id | Action | Expect |
 |---|---|---|
-| D1 | `destroy --yes` after `init --with-zen` (extra skill allowed) | Removes `.agents/`, `ZEN.md`, `AGENTS.md`; leaves home stash + `layout.json` intact; drops this project's by-project catalog entry (`skill list --home` has no rows for it) |
+| D1 | `destroy --yes` after `init --with-zen` (extra skill allowed) | Removes `.agents/`, `ZEN.md`, `AGENTS.md`; leaves library + `layout.json` intact; drops this project's by-project catalog entry (`skill list --catalog` has no rows for it) |
 | D2 | `destroy` without `--yes` (non-TTY) | Exit ≠ 0; refuses without confirmation; project files unchanged |
 | D3 | `destroy --yes` when `.agents` is a symlink | Exit ≠ 0; mentions symlink |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -432,7 +432,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tink"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "anstyle",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tink"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2024"
 description = "Install Agent Skills into a project's .agents/skills/"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ flowchart LR
   agent["Agent harness"]
   tink["tink CLI"]
   live[".agents/skills/"]
-  stash["~/.tink/skills/"]
+  library["~/.tink/skills/"]
   catalog["~/.tink/catalog/"]
 
   agent -->|"discovers"| live
   tink -->|"add / remove"| live
-  tink -->|"copies on add"| stash
+  tink -->|"copies on add"| library
   tink -->|"records names"| catalog
-  tink -->|"add <stash-name>"| live
+  tink -->|"add <library-name>"| live
 ```
 
-Home (`~/.tink` or `$TINK_HOME`) is **not** an agent discovery root. Stash holds
+Home (`~/.tink` or `$TINK_HOME`) is **not** an agent discovery root. Library holds
 skill trees; catalog holds by-project **names** only.
 
 ## Use (everyday)
@@ -106,7 +106,7 @@ tink skill refresh skill-name
 tink skill remove skill-name
 ```
 
-- Bare `skill-name` promotes from the home stash (`tink skill list --stash`).
+- Bare `skill-name` promotes from the library (`tink skill list --library`).
 - `--skill` when the source repo publishes several skills.
 - Refresh only clean GitHub imports; local edits are refused.
 - tink does not overwrite a project skill that differs from what it would
@@ -115,13 +115,13 @@ tink skill remove skill-name
 
 ## Power
 
-Stash, catalog, init flags, and destroy:
+Library, catalog, init flags, and destroy:
 
 ```console
-tink skill list --stash
+tink skill list --library
 tink skill add skill-name
 tink skill harvest
-tink skill list --home
+tink skill list --catalog
 
 tink init --with-zen --with-tink-skills
 tink init --no-zen --no-tink-skills --no-manage-tink
@@ -130,12 +130,14 @@ tink destroy --yes
 tink update
 ```
 
-If the GitHub tip is already in the stash and matches the tip byte-for-byte,
-`skill add` may install from the stash. If the stash differs, tink repairs it
+**Breaking in 0.3.0:** `skill list --home` → `--catalog`; `skill list --stash` → `--library`. On-disk layout is still `$TINK_HOME/skills/` and `catalog/by-project/`. After a major CLI upgrade, refresh the live project skill: `tink skill remove manage-tink && tink init --no-zen --no-tink-skills`.
+
+If the GitHub tip is already in the library and matches the tip byte-for-byte,
+`skill add` may install from the library. If the library differs, tink repairs it
 and warns. A bare skill name (not a path and not `owner/repo`) promotes from
-the home stash into the project. `skill remove` deletes the project skill
+the library into the project. `skill remove` deletes the project skill
 directory and drops that name from the by-project catalog; it does not delete
-home stash trees. `destroy` also drops this project's catalog entry.
+library trees. `destroy` also drops this project's catalog entry.
 
 ### Uninstall the CLI
 
@@ -162,7 +164,7 @@ cargo uninstall tink
 ```console
 cargo test
 ./tink-test init
-./tink-test skill list --home
+./tink-test skill list --catalog
 ```
 
 `./tink-test` builds this checkout and runs `target/debug/tink` (not

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-tink
-description: "Tink CLI for repository-owned Agent Skills. Use when the user asks to set up or init Tink, add or refresh a project skill, remove a project skill, harvest harness skills into the home stash, update the tink CLI, list or check .agents/skills, list the home by-project catalog or home stash, promote a stash skill into the project, or destroy project agent scaffolding."
+description: "Tink CLI for repository-owned Agent Skills. Use when the user asks to set up or init Tink, add or refresh a project skill, remove a project skill, harvest harness skills into the library, update the tink CLI, list or check .agents/skills, list the by-project catalog or library, promote a library skill into the project, or destroy project agent scaffolding."
 ---
 
 # Manage Tink
@@ -13,9 +13,9 @@ are hard stops — honor them; do not work around them.
 1. **Inspect** — If `tink` is missing, report that it must be installed
    (`curl -fsSL https://raw.githubusercontent.com/jon-devlapaz/tink/main/install.sh | sh`)
    and stop. Otherwise: use `tink skill check` for this project's live state; use
-   `tink skill list` for live skill names; use `tink skill list --home` when the
-   user asks what Tink has recorded across projects; use `tink skill list --stash`
-   when the user asks what skill trees sit in the home dump (do not hand-parse
+   `tink skill list` for live skill names; use `tink skill list --catalog` when the
+   user asks what Tink has recorded across projects; use `tink skill list --library`
+   when the user asks what skill trees sit in the home library (do not hand-parse
    `~/.tink/catalog/by-project` or `~/.tink/skills`).
    - Done when: either install guidance was given, or the chosen inspect
      command's exit status and output are known.
@@ -24,21 +24,25 @@ are hard stops — honor them; do not work around them.
    command from [references/commands.md](references/commands.md). Run that
    command; do not invent flags, merges, force-overwrites, or alternate install
    paths (no symlinks, manual copies, or private registries). To promote from
-   the home stash into the project, use `tink skill add NAME` only (bare stash
+   the library into the project, use `tink skill add NAME` only (bare library
    skill name; not a path and not `owner/repo`).
-   To fill the home stash from known harness skill locations, use
+   To fill the library from known harness skill locations, use
    `tink skill harvest` only (create-only; does not write project skills).
    To remove a live project skill, use `tink skill remove NAME` only (drops the
-   name from the by-project catalog; does not prune the home stash). To update
-   the tink CLI binary, use `tink update` only.
+   name from the by-project catalog; does not prune the library). To update
+   the tink CLI binary, use `tink update` only. After a **major** binary
+   upgrade (new major version / removed flags), re-embed this skill:
+   `tink skill remove manage-tink && tink init --no-zen --no-tink-skills`
+   (init installs the manage-tink copy shipped with the binary; it does not
+   overwrite a divergent live skill otherwise).
    - Done when: the chosen command has finished and its stdout/stderr is known.
 
 3. **Prove** — After every successful mutation except `destroy` and
    `skill remove`, run `tink skill check` and report the result. After
-   `skill remove`, run `tink skill list` and `tink skill list --home` and
+   `skill remove`, run `tink skill list` and `tink skill list --catalog` and
    confirm the name is gone from the project and the catalog. After `destroy`,
    confirm `.agents/`, `ZEN.md`, and `AGENTS.md` are gone and
-   `tink skill list --home` has no rows for this project; do not run check.
+   `tink skill list --catalog` has no rows for this project; do not run check.
    - Done when: proof for that mutation type is reported to the user.
 
 ## Authority
@@ -48,9 +52,9 @@ are hard stops — honor them; do not work around them.
 | Set up / init Tink (no extras) | `tink init --no-zen --no-tink-skills` (embeds `manage-tink`) |
 | …and ZEN / tink-skills / skip manage-tink | Only the matching `--with-*` / `--no-*` flags |
 | Add / list / check / refresh / remove … | The matching `tink skill …` command |
-| List home catalog | `tink skill list --home` |
-| List home stash / promote from stash | `tink skill list --stash` / `tink skill add NAME` |
-| Harvest harness skills into home stash | `tink skill harvest` |
+| List catalog | `tink skill list --catalog` |
+| List library / promote from library | `tink skill list --library` / `tink skill add NAME` |
+| Harvest harness skills into library | `tink skill harvest` |
 | Remove one project skill | `tink skill remove NAME` |
 | Update the tink CLI | `tink update` |
 | Remove scaffolding / destroy Tink setup | `tink destroy` (TTY) or `tink destroy --yes` (scripts) |
@@ -68,7 +72,7 @@ are hard stops — honor them; do not work around them.
 - Treat local skills as non-refreshable unless they carry a valid receipt.
 - Never execute code from a skill while adding, checking, refreshing, removing,
   or destroying.
-- Home stash (`~/.tink/skills/`) is **not** an agent discovery root; do not
+- Library (`~/.tink/skills/`) is **not** an agent discovery root; do not
   symlink or copy from it by hand — use `tink skill add NAME`.
-- Do not prune the home stash by hand. `skill remove` and `destroy` sync the
-  by-project catalog; they do not delete stash trees.
+- Do not prune the library by hand. `skill remove` and `destroy` sync the
+  by-project catalog; they do not delete library trees.

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -12,27 +12,28 @@ form for add, list, check, refresh, and remove.
 | Init without embedded manage-tink | add `--no-manage-tink` |
 | Add one skill | `tink skill add SOURCE` |
 | Add from multi-skill repo | `tink skill add SOURCE --skill NAME` |
-| Add from home stash | `tink skill add NAME` |
-| Harvest harness skills into home stash | `tink skill harvest` |
+| Add from library | `tink skill add NAME` |
+| Harvest harness skills into library | `tink skill harvest` |
 | List (this project) | `tink skill list` |
-| List (home catalog) | `tink skill list --home` |
-| List (home stash) | `tink skill list --stash` |
+| List (catalog) | `tink skill list --catalog` |
+| List (library) | `tink skill list --library` |
 | Check | `tink skill check` |
 | Refresh all clean imports | `tink skill refresh` |
 | Refresh one | `tink skill refresh NAME` |
 | Remove one project skill | `tink skill remove NAME` |
 | Update the tink CLI binary | `tink update` |
+| Refresh live manage-tink after major upgrade | `tink skill remove manage-tink` then `tink init --no-zen --no-tink-skills` |
 | Destroy scaffolding | `tink destroy --yes` (non-TTY/scripts) or `tink destroy` (TTY, confirm `y`) |
 
 ## Layout facts
 
 - Live skills: `<project>/.agents/skills/<name>/` with `SKILL.md`.
 - Home (`$TINK_HOME` or `~/.tink`) is not an agent discovery root. Installs
-  stash trees at `skills/<name>/`. List the stash with
-  `tink skill list --stash`; promote into a project with
-  `tink skill add NAME` (bare stash skill name). `tink skill harvest` copies complete trees
-  from known harness roots into the stash create-only (never overwrites a
-  divergent stash entry). Global roots include `~/.agents/skills`,
+  library trees at `skills/<name>/`. List the library with
+  `tink skill list --library`; promote into a project with
+  `tink skill add NAME` (bare library skill name). `tink skill harvest` copies complete trees
+  from known harness roots into the library create-only (never overwrites a
+  divergent library entry). Global roots include `~/.agents/skills`,
   `~/.claude/skills`, `~/.codex/skills`, `~/.cursor/skills`,
   `~/.cursor/skills-cursor`, `~/.copilot/skills`, `~/.github/skills`,
   `~/.codeium/windsurf/skills`, `~/.cline/skills`, `~/.aider/skills`,
@@ -45,13 +46,13 @@ form for add, list, check, refresh, and remove.
   `.gemini/skills`, `.agent/skills`, `.roo/skills`, `.kilocode/skills`,
   `.amazonq/skills`, `.augment/skills`, `.tabnine/skills`, `.opencode/skills`,
   and `.sourcegraph/skills`. Matching GitHub tips install into the project
-  from that stash; divergent stash trees are repaired with a warning on
+  from that library; divergent library trees are repaired with a warning on
   `skill add`. Names are recorded in
   `catalog/by-project/<project>/meta.json`. List the catalog with
-  `tink skill list --home` (TSV with header `project`, `root`, `skill`).
+  `tink skill list --catalog` (TSV with header `project`, `root`, `skill`).
   Do not hand-parse `meta.json` when the CLI is available. `skill remove`
   deletes the project skill directory and drops that name from the by-project
-  catalog; it does not prune the home stash. `destroy` removes project
-  scaffolding and this project's catalog entry; it does not delete home stash
+  catalog; it does not prune the library. `destroy` removes project
+  scaffolding and this project's catalog entry; it does not delete library
   trees or other projects' catalog rows.
   Project skill overwrites are still refused.

--- a/src/add.rs
+++ b/src/add.rs
@@ -9,15 +9,15 @@ use crate::init;
 use crate::provenance::Provenance;
 use crate::skills::{self, Skill};
 use crate::sources::{self, RemoteSource};
-use crate::stash::{self, StashWrite};
+use crate::library::{self, LibraryWrite};
 use crate::style::CliStyle;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AddOrigin {
     /// Installed from a local path or fresh remote checkout.
     Source,
-    /// Installed from the home stash (`skills/<name>/`), including tip reuse.
-    Stash,
+    /// Installed from the library (`skills/<name>/`), including tip reuse.
+    Library,
 }
 
 #[derive(Debug)]
@@ -34,12 +34,12 @@ fn place_skill(
     destination_root: &Path,
     provenance: Option<&Provenance>,
 ) -> Result<AddOutcome, Error> {
-    // Protect the project tree first. Stash is a rebuildable dump: repair on
+    // Protect the project tree first. Library is a rebuildable collection: repair on
     // diverge, then install project (re-add recovers if that fails).
     skills::preflight_install(skill, destination_root, provenance)?
         .require_compatible(&skill.name, destination_root)?;
-    let (_, write) = stash::deposit(skill, provenance)?;
-    if write == StashWrite::Repaired {
+    let (_, write) = library::deposit(skill, provenance)?;
+    if write == LibraryWrite::Repaired {
         let err = CliStyle::auto_stderr();
         eprintln!(
             "{}",
@@ -57,8 +57,8 @@ fn place_skill(
     })
 }
 
-/// Install into the project from an already-complete stash tree (receipt included).
-fn place_from_stash(
+/// Install into the project from an already-complete library tree (receipt included).
+fn place_from_library(
     project_root: &Path,
     skill: &Skill,
     destination_root: &Path,
@@ -71,7 +71,7 @@ fn place_from_stash(
         name: skill.name.clone(),
         created,
         project_path: installed,
-        origin: AddOrigin::Stash,
+        origin: AddOrigin::Library,
     })
 }
 
@@ -141,8 +141,8 @@ fn install_from_checkout(
         }
         _ => None,
     };
-    if let Some(cached) = stash::matching(&skill, provenance.as_ref())? {
-        return place_from_stash(project_root, &cached, destination_root);
+    if let Some(cached) = library::matching(&skill, provenance.as_ref())? {
+        return place_from_library(project_root, &cached, destination_root);
     }
     place_skill(project_root, &skill, destination_root, provenance.as_ref())
 }
@@ -194,7 +194,7 @@ fn add_skill_inner(
     if looks_like_filesystem_path(source_value) {
         return Err(Error::msg(format!("Path does not exist: {source_value}")));
     }
-    // Slash or URL → remote only. Bare name → home stash promote.
+    // Slash or URL → remote only. Bare name → library promote.
     if looks_like_remote_source(source_value) {
         let remote = sources::parse_remote(source_value)?;
         let outcome = add_from_remote(project_root, &destination_root, &remote, selected_name)?;
@@ -205,11 +205,11 @@ fn add_skill_inner(
     }
     if selected_name.is_some() {
         return Err(Error::msg(
-            "Do not combine --skill with a stash skill name; pass only the stash name",
+            "Do not combine --skill with a library skill name; pass only the library name",
         ));
     }
-    let skill = stash::load(source_value)?;
-    let outcome = place_from_stash(project_root, &skill, &destination_root)?;
+    let skill = library::load(source_value)?;
+    let outcome = place_from_library(project_root, &skill, &destination_root)?;
     if report {
         report_add(&outcome);
     }
@@ -232,12 +232,12 @@ fn looks_like_filesystem_path(value: &str) -> bool {
 fn report_add(outcome: &AddOutcome) {
     let style = CliStyle::auto_stdout();
     match (outcome.created, outcome.origin) {
-        (true, AddOrigin::Stash) => println!(
+        (true, AddOrigin::Library) => println!(
             "{} {} → {} {}",
             style.success("Installed"),
             style.skill(&outcome.name),
             style.accent(outcome.project_path.display()),
-            style.muted("(from stash)")
+            style.muted("(from library)")
         ),
         (true, AddOrigin::Source) => println!(
             "{} {} → {}",
@@ -259,10 +259,10 @@ fn add_from_remote(
     remote: &RemoteSource,
     selected_name: Option<&str>,
 ) -> Result<AddOutcome, Error> {
-    // Cheap tip check: if stash already has this exact remote revision, copy it.
+    // Cheap tip check: if library already has this exact remote revision, copy it.
     let tip = git::remote_head(remote)?;
-    if let Some(cached) = stash::for_remote_tip(&remote.url, &tip, selected_name)? {
-        return place_from_stash(project_root, &cached, destination_root);
+    if let Some(cached) = library::for_remote_tip(&remote.url, &tip, selected_name)? {
+        return place_from_library(project_root, &cached, destination_root);
     }
     let (_temp, source_root, revision) = git::checkout(remote)?;
     install_from_checkout(

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -233,7 +233,7 @@ pub(crate) fn withdraw_skill_at(
 /// Remove this project's by-project catalog entry entirely.
 ///
 /// Soft success when absent, or when `meta.root` belongs to a different
-/// project sharing this basename. Does not create inventory or touch stash.
+/// project sharing this basename. Does not create inventory or touch library.
 pub fn forget_project(project_root: &Path) -> Result<(), Error> {
     forget_project_at(None, project_root)
 }

--- a/src/destroy.rs
+++ b/src/destroy.rs
@@ -16,7 +16,7 @@ pub struct DestroyReport {
 
 /// Drop this project's by-project catalog entry, then remove `.agents/`,
 /// `ZEN.md`, and `AGENTS.md` from the project root. Does not touch the home
-/// stash. Catalog sync runs before disk deletes; sync errors leave project
+/// library. Catalog sync runs before disk deletes; sync errors leave project
 /// files intact. Refuses symlinks. Requires `--yes` or an interactive `y`
 /// confirmation (default no).
 pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, Error> {

--- a/src/harvest.rs
+++ b/src/harvest.rs
@@ -1,7 +1,7 @@
-//! `tink skill harvest` — copy harness skill trees into the home stash.
+//! `tink skill harvest` — copy harness skill trees into the library.
 //!
-//! Create-only: never repair divergent or receipt-backed stash entries.
-//! Stash remains offline inventory, not an agent discovery root.
+//! Create-only: never repair divergent or receipt-backed library entries.
+//! Library remains offline inventory, not an agent discovery root.
 //!
 //! Root tables track documented Agent Skills (`SKILL.md`) locations from:
 //! - agentskills.io client guidance (`.agents/skills` + client-specific)
@@ -16,10 +16,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::Error;
-use crate::home::{ensure_inventory_root, skills_stash_path};
+use crate::home::{ensure_inventory_root, skills_library_path};
 use crate::paths::{map_io, refuse_symlink};
 use crate::skills;
-use crate::stash::{self, CreateOnlyWrite};
+use crate::library::{self, CreateOnlyWrite};
 
 /// Relative skill roots under `$HOME` (user/global harness locations).
 ///
@@ -229,11 +229,11 @@ fn map_create_only(write: CreateOnlyWrite) -> (HarvestAction, Option<String>) {
     }
 }
 
-/// Scan harness skill locations and create missing trees in the home stash.
+/// Scan harness skill locations and create missing trees in the library.
 pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
     let (tink_home, _) = ensure_inventory_root(None)?;
-    let stash = skills_stash_path(&tink_home);
-    let stash_canon = stash.canonicalize().unwrap_or_else(|_| stash.clone());
+    let library = skills_library_path(&tink_home);
+    let library_canon = library.canonicalize().unwrap_or_else(|_| library.clone());
 
     let mut skill_paths = Vec::new();
     for root in candidate_roots(cwd)? {
@@ -247,9 +247,9 @@ pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
     let mut report = HarvestReport::default();
 
     for path in skill_paths {
-        // Skip only the stash inventory — not the whole TINK_HOME tree
+        // Skip only the library inventory — not the whole TINK_HOME tree
         // (a workspace nested under TINK_HOME remains harvestable).
-        if is_under(&path, &stash_canon) || is_under(&path, &stash) {
+        if is_under(&path, &library_canon) || is_under(&path, &library) {
             report.events.push(HarvestEvent {
                 name: path
                     .file_name()
@@ -257,7 +257,7 @@ pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
                     .unwrap_or_else(|| path.display().to_string()),
                 source: path,
                 action: HarvestAction::Skipped,
-                detail: Some("under home stash".into()),
+                detail: Some("under library".into()),
             });
             report.skipped += 1;
             continue;
@@ -305,7 +305,7 @@ pub fn harvest(cwd: &Path) -> Result<HarvestReport, Error> {
             continue;
         }
 
-        let (_, write) = stash::deposit_create_only(&skill)?;
+        let (_, write) = library::deposit_create_only(&skill)?;
         let (action, detail) = map_create_only(write);
         match action {
             HarvestAction::Created => {

--- a/src/home.rs
+++ b/src/home.rs
@@ -5,7 +5,7 @@
 
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::Error;
 use crate::paths::{map_io, mkdir_p, refuse_symlink, require_file};
@@ -23,24 +23,52 @@ Tink home directory. This is **not** an agent skill discovery root. Agents load
 skills only from a project's `.agents/skills/`.
 
 Successful installs:
-- stash skill trees under `skills/<name>/` (divergent entries are repaired)
+- copy skill trees into the library under `skills/<name>/` (divergent entries are repaired)
 - record skill **names** under `catalog/by-project/<project>/meta.json`
 
 `skill remove` and `destroy` update that name catalog; they do not delete
-stash trees.
+library trees.
 
-Default location: `~/.tink` (override with `TINK_HOME`).
+Default location: `~/.tink` (override with `TINK_HOME`; relative values
+resolve against the process working directory to an absolute path).
 ";
+
+/// Make `path` absolute without requiring it to exist (no symlink follow).
+/// Collapses `.` / `..` lexically so display and layout stay stable across cwd.
+fn absolutize(path: PathBuf) -> Result<PathBuf, Error> {
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        let cwd = env::current_dir().map_err(|e| Error::msg(format!("current_dir: {e}")))?;
+        cwd.join(path)
+    };
+    Ok(normalize_lexically(&absolute))
+}
+
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::Normal(part) => out.push(part),
+        }
+    }
+    out
+}
 
 /// Resolve the offline inventory root.
 pub fn resolve_home() -> Result<PathBuf, Error> {
     if let Ok(custom) = env::var(TINK_HOME_ENV) {
         if !custom.is_empty() {
-            return Ok(PathBuf::from(custom));
+            return absolutize(PathBuf::from(custom));
         }
     }
     let home = env::var_os("HOME").ok_or_else(|| Error::msg("HOME is not set"))?;
-    Ok(PathBuf::from(home).join(TINK_HOME_NAME))
+    absolutize(PathBuf::from(home).join(TINK_HOME_NAME))
 }
 
 /// Path to `catalog/by-project` under a home root.
@@ -48,18 +76,19 @@ pub fn by_project_path(home: &Path) -> PathBuf {
     home.join("catalog").join(BY_PROJECT)
 }
 
-/// Path to the skill-tree stash root (`skills/`).
-pub fn skills_stash_path(home: &Path) -> PathBuf {
+/// Path to the skill-tree library root (`skills/`).
+pub fn skills_library_path(home: &Path) -> PathBuf {
     home.join("skills")
 }
 
-/// Ensure inventory root + stash dir + catalog + layout marker.
+/// Ensure inventory root + library dir + catalog + layout marker.
 ///
 /// Returns `(path, created)` where `created` is true only when the root
-/// directory did not exist before this call.
+/// directory did not exist before this call. Relative roots are absolutized
+/// against the process cwd before create/refuse checks.
 pub fn ensure_inventory_root(root: Option<&Path>) -> Result<(PathBuf, bool), Error> {
     let root = match root {
-        Some(path) => path.to_path_buf(),
+        Some(path) => absolutize(path.to_path_buf())?,
         None => resolve_home()?,
     };
     refuse_symlink(&root)?;
@@ -71,7 +100,7 @@ pub fn ensure_inventory_root(root: Option<&Path>) -> Result<(PathBuf, bool), Err
         )));
     }
     mkdir_p(&root)?;
-    mkdir_p(&skills_stash_path(&root))?;
+    mkdir_p(&skills_library_path(&root))?;
     migrate_catalog_if_needed(&root)?;
     mkdir_p(&by_project_path(&root))?;
     write_layout_marker(&root)?;
@@ -84,7 +113,7 @@ pub(crate) fn looks_like_legacy_catalog(path: &Path) -> bool {
 }
 
 /// Older homes kept the name catalog at `skills/by-project/`; move it out so
-/// `skills/<name>/` can hold stashed trees.
+/// `skills/<name>/` can hold library trees.
 fn migrate_catalog_if_needed(home: &Path) -> Result<(), Error> {
     let old = home.join("skills").join(BY_PROJECT);
     let new = by_project_path(home);
@@ -103,7 +132,7 @@ fn migrate_catalog_if_needed(home: &Path) -> Result<(), Error> {
             old.display()
         )));
     }
-    // A skill tree mistakenly stashed as by-project has SKILL.md — leave it.
+    // A skill tree mistakenly placed as by-project has SKILL.md — leave it.
     if !looks_like_legacy_catalog(&old) {
         return Ok(());
     }
@@ -163,7 +192,7 @@ mod tests {
         assert_eq!(path, root);
         assert!(root.join("layout.json").is_file());
         assert!(by_project_path(&root).is_dir());
-        assert!(skills_stash_path(&root).is_dir());
+        assert!(skills_library_path(&root).is_dir());
         assert!(!root.join("skills").join(BY_PROJECT).exists());
         let (_, created_again) = ensure_inventory_root(Some(&root)).unwrap();
         assert!(!created_again);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod refresh;
 mod remove;
 mod skills;
 mod sources;
-mod stash;
+mod library;
 mod style;
 mod templates;
 mod update;
@@ -71,7 +71,7 @@ pub enum Command {
         #[command(subcommand)]
         command: SkillCommand,
     },
-    /// Remove `.agents/`, `ZEN.md`, `AGENTS.md`, and this project's catalog entry (not home stash)
+    /// Remove `.agents/`, `ZEN.md`, `AGENTS.md`, and this project's catalog entry (not library)
     Destroy {
         /// Skip the confirmation prompt
         #[arg(long)]
@@ -85,20 +85,20 @@ pub enum Command {
 pub enum SkillCommand {
     /// Copy one complete skill into the project
     Add {
-        /// Local path, `owner/repo`, public GitHub HTTPS URL, or home stash skill name
+        /// Local path, `owner/repo`, public GitHub HTTPS URL, or library skill name
         source: String,
         /// Skill name when the source contains several skills
         #[arg(long)]
         skill: Option<String>,
     },
-    /// List installed project skills, the home by-project catalog, or the home stash
+    /// List installed project skills, the by-project catalog, or the library
     List {
         /// List offline catalog under `$TINK_HOME` / `~/.tink` as `project\\troot\\tskill` TSV
         #[arg(long, group = "list_source")]
-        home: bool,
-        /// List skill names in the home stash (`skills/<name>/`)
+        catalog: bool,
+        /// List skill names in the library (`skills/<name>/`)
         #[arg(long, group = "list_source")]
-        stash: bool,
+        library: bool,
     },
     /// Validate project skills without changing anything
     Check,
@@ -107,12 +107,12 @@ pub enum SkillCommand {
         /// Optional skill name; default refreshes all imported skills
         name: Option<String>,
     },
-    /// Delete one project skill directory and drop it from the by-project catalog (not home stash)
+    /// Delete one project skill directory and drop it from the by-project catalog (not library)
     Remove {
         /// Skill directory name under `.agents/skills/`
         name: String,
     },
-    /// Copy harness skill trees into the home stash (create-only)
+    /// Copy harness skill trees into the library (create-only)
     Harvest,
 }
 
@@ -181,11 +181,11 @@ fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
         SkillCommand::Add { source, skill } => {
             dispatch_skill_add(cwd, &source, skill.as_deref())
         }
-        SkillCommand::List { home, stash } => {
-            if home {
-                dispatch_skill_list_home()
-            } else if stash {
-                dispatch_skill_list_stash()
+        SkillCommand::List { catalog, library } => {
+            if catalog {
+                dispatch_skill_list_catalog()
+            } else if library {
+                dispatch_skill_list_library()
             } else {
                 dispatch_skill_list(cwd)
             }
@@ -299,7 +299,7 @@ fn dispatch_skill_list(cwd: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-fn dispatch_skill_list_home() -> Result<(), Error> {
+fn dispatch_skill_list_catalog() -> Result<(), Error> {
     let style = CliStyle::auto_stdout();
     let entries = catalog::list_catalog(None)?;
     if entries.is_empty() {
@@ -324,11 +324,11 @@ fn dispatch_skill_list_home() -> Result<(), Error> {
     Ok(())
 }
 
-fn dispatch_skill_list_stash() -> Result<(), Error> {
+fn dispatch_skill_list_library() -> Result<(), Error> {
     let style = CliStyle::auto_stdout();
-    let names = stash::list_names(None)?;
+    let names = library::list_names(None)?;
     if names.is_empty() {
-        println!("{}", style.muted("(no stash skills)"));
+        println!("{}", style.muted("(no library skills)"));
     } else {
         for name in &names {
             println!("{}", style.skill(name));

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,34 +1,34 @@
-//! Home skill stash (`$TINK_HOME/skills/<name>/`).
+//! Skill library (`$TINK_HOME/skills/<name>/`).
 //!
-//! Rebuildable dump of skill trees from successful installs. Not an agent
+//! Rebuildable collection of skill trees from successful installs. Not an agent
 //! discovery root — promote into a project with `tink skill add <name>`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::Error;
-use crate::home::{ensure_inventory_root, skills_stash_path, BY_PROJECT};
+use crate::home::{ensure_inventory_root, skills_library_path, BY_PROJECT};
 use crate::paths::{map_io, mkdir_p, refuse_symlink};
 use crate::provenance::{self, Provenance};
 use crate::skills::{self, PreflightOutcome, Skill};
 
-/// Result of writing a skill into the home stash.
+/// Result of writing a skill into the library.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StashWrite {
-    /// Stash entry was missing; tree was created.
+pub enum LibraryWrite {
+    /// Library entry was missing; tree was created.
     Created,
-    /// Stash already matched the incoming tree (including receipt).
+    /// Library already matched the incoming tree (including receipt).
     Unchanged,
-    /// Stash diverged; replaced with the incoming tree.
+    /// Library diverged; replaced with the incoming tree.
     Repaired,
 }
 
-/// Result of a create-only stash write (never repairs).
+/// Result of a create-only library write (never repairs).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CreateOnlyWrite {
-    /// Stash entry was missing; tree was created.
+    /// Library entry was missing; tree was created.
     Created,
-    /// Stash already matched (exact, or body equal except receipt).
+    /// Library already matched (exact, or body equal except receipt).
     Unchanged,
     /// Divergent or unreadable; no write. Optional reason for the caller.
     Skipped(Option<String>),
@@ -44,29 +44,29 @@ fn clear_path(target: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-fn stash_root(home: Option<&Path>) -> Result<PathBuf, Error> {
+fn library_root(home: Option<&Path>) -> Result<PathBuf, Error> {
     let (home, _) = ensure_inventory_root(home)?;
-    let root = skills_stash_path(&home);
+    let root = skills_library_path(&home);
     mkdir_p(&root)?;
     Ok(root)
 }
 
-/// Validated skill trees currently in the stash (skips reserved / unreadable).
-fn iter_stash_skills(stash: &Path) -> Result<Vec<Skill>, Error> {
-    if !stash.exists() {
+/// Validated skill trees currently in the library (skips reserved / unreadable).
+fn iter_library_skills(library: &Path) -> Result<Vec<Skill>, Error> {
+    if !library.exists() {
         return Ok(Vec::new());
     }
-    refuse_symlink(stash)?;
-    if !stash.is_dir() {
+    refuse_symlink(library)?;
+    if !library.is_dir() {
         return Err(Error::msg(format!(
-            "Refusing to read non-directory stash: {}",
-            stash.display()
+            "Refusing to read non-directory library: {}",
+            library.display()
         )));
     }
 
     let mut skills = Vec::new();
-    for entry in fs::read_dir(stash).map_err(|e| map_io(stash, e))? {
-        let entry = entry.map_err(|e| map_io(stash, e))?;
+    for entry in fs::read_dir(library).map_err(|e| map_io(library, e))? {
+        let entry = entry.map_err(|e| map_io(library, e))?;
         let path = entry.path();
         let name = entry.file_name();
         let name = name.to_string_lossy();
@@ -91,34 +91,34 @@ fn iter_stash_skills(stash: &Path) -> Result<Vec<Skill>, Error> {
 pub fn deposit(
     skill: &Skill,
     provenance: Option<&Provenance>,
-) -> Result<(PathBuf, StashWrite), Error> {
-    let stash = stash_root(None)?;
-    match skills::preflight_install(skill, &stash, provenance)? {
+) -> Result<(PathBuf, LibraryWrite), Error> {
+    let library = library_root(None)?;
+    match skills::preflight_install(skill, &library, provenance)? {
         PreflightOutcome::Ready => {
-            let (path, _) = skills::install_local(skill, &stash, provenance)?;
-            Ok((path, StashWrite::Created))
+            let (path, _) = skills::install_local(skill, &library, provenance)?;
+            Ok((path, LibraryWrite::Created))
         }
-        PreflightOutcome::Identical => Ok((stash.join(&skill.name), StashWrite::Unchanged)),
+        PreflightOutcome::Identical => Ok((library.join(&skill.name), LibraryWrite::Unchanged)),
         PreflightOutcome::Divergent => {
-            clear_path(&stash.join(&skill.name))?;
-            let (path, _) = skills::install_local(skill, &stash, provenance)?;
-            Ok((path, StashWrite::Repaired))
+            clear_path(&library.join(&skill.name))?;
+            let (path, _) = skills::install_local(skill, &library, provenance)?;
+            Ok((path, LibraryWrite::Repaired))
         }
     }
 }
 
-/// Copy skill tree into the home stash only when missing or identical.
+/// Copy skill tree into the library only when missing or identical.
 ///
 /// Divergent trees are skipped (no repair). Unreadable/unsafe trees surface as
 /// [`CreateOnlyWrite::Skipped`] with the error detail — same create-only
-/// contract harvest used before this lived in `stash`.
+/// contract harvest used before this lived in `library`.
 pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), Error> {
-    let stash = stash_root(None)?;
-    let target = stash.join(&skill.name);
-    match skills::preflight_install(skill, &stash, None) {
+    let library = library_root(None)?;
+    let target = library.join(&skill.name);
+    match skills::preflight_install(skill, &library, None) {
         Err(err) => Ok((target, CreateOnlyWrite::Skipped(Some(err.to_string())))),
         Ok(PreflightOutcome::Ready) => {
-            let (path, _) = skills::install_local(skill, &stash, None)?;
+            let (path, _) = skills::install_local(skill, &library, None)?;
             Ok((path, CreateOnlyWrite::Created))
         }
         Ok(PreflightOutcome::Identical) => Ok((target, CreateOnlyWrite::Unchanged)),
@@ -134,32 +134,32 @@ pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), 
             } else {
                 Ok((
                     target,
-                    CreateOnlyWrite::Skipped(Some("stash differs; create-only".into())),
+                    CreateOnlyWrite::Skipped(Some("library differs; create-only".into())),
                 ))
             }
         }
     }
 }
 
-/// When the stash already holds the exact tree we would install, return it.
+/// When the library already holds the exact tree we would install, return it.
 pub fn matching(
     skill: &Skill,
     provenance: Option<&Provenance>,
 ) -> Result<Option<Skill>, Error> {
-    let stash = stash_root(None)?;
-    let target = stash.join(&skill.name);
+    let library = library_root(None)?;
+    let target = library.join(&skill.name);
     if !target.is_dir() {
         return Ok(None);
     }
-    match skills::preflight_install(skill, &stash, provenance)? {
+    match skills::preflight_install(skill, &library, provenance)? {
         PreflightOutcome::Identical => Ok(Some(skills::read_skill(&target, true)?)),
         PreflightOutcome::Ready | PreflightOutcome::Divergent => Ok(None),
     }
 }
 
-/// List skill names present in the home stash.
+/// List skill names present in the home library.
 ///
-/// Creates nothing; empty when home or stash root is missing.
+/// Creates nothing; empty when home or library root is missing.
 pub fn list_names(home: Option<&Path>) -> Result<Vec<String>, Error> {
     let home = match home {
         Some(path) => path.to_path_buf(),
@@ -169,17 +169,17 @@ pub fn list_names(home: Option<&Path>) -> Result<Vec<String>, Error> {
         return Ok(Vec::new());
     }
     refuse_symlink(&home)?;
-    let stash = skills_stash_path(&home);
-    Ok(iter_stash_skills(&stash)?
+    let library = skills_library_path(&home);
+    Ok(iter_library_skills(&library)?
         .into_iter()
         .map(|skill| skill.name)
         .collect())
 }
 
-/// Load one skill from the home stash by directory name.
+/// Load one skill from the library by directory name.
 pub fn load(name: &str) -> Result<Skill, Error> {
-    let stash = stash_root(None)?;
-    let path = stash.join(name);
+    let library = library_root(None)?;
+    let path = library.join(name);
     if path.is_symlink() {
         return Err(Error::msg(format!(
             "Refusing to follow symlink: {}",
@@ -187,25 +187,25 @@ pub fn load(name: &str) -> Result<Skill, Error> {
         )));
     }
     if !path.is_dir() {
-        return Err(Error::msg(format!("Stash skill not found: {name}")));
+        return Err(Error::msg(format!("Library skill not found: {name}")));
     }
     skills::read_skill(&path, true)
 }
 
-/// Find a stash skill whose receipt matches this remote URL + revision tip.
+/// Find a library skill whose receipt matches this remote URL + revision tip.
 pub fn for_remote_tip(
     source_url: &str,
     revision: &str,
     selected_name: Option<&str>,
 ) -> Result<Option<Skill>, Error> {
     let (home, _) = ensure_inventory_root(None)?;
-    let stash = skills_stash_path(&home);
-    if !stash.is_dir() {
+    let library = skills_library_path(&home);
+    if !library.is_dir() {
         return Ok(None);
     }
 
     let mut hits = Vec::new();
-    for skill in iter_stash_skills(&stash)? {
+    for skill in iter_library_skills(&library)? {
         if let Some(want) = selected_name {
             if skill.name != want {
                 continue;
@@ -230,37 +230,37 @@ pub fn for_remote_tip(
                 .collect::<Vec<_>>()
                 .join("\n");
             Err(Error::msg(format!(
-                "Stash has multiple skills for this revision. Choose one:\n{commands}"
+                "Library has multiple skills for this revision. Choose one:\n{commands}"
             )))
         }
     }
 }
 
-fn tracks_project(stash_skill: &Path, project_skill: &Path) -> Result<bool, Error> {
-    if skills::skill_contents_equal(stash_skill, project_skill)? {
+fn tracks_project(library_skill: &Path, project_skill: &Path) -> Result<bool, Error> {
+    if skills::skill_contents_equal(library_skill, project_skill)? {
         return Ok(true);
     }
     // Allow a missing/different receipt when the skill body still matches.
-    skills::skill_contents_equal_except(stash_skill, project_skill, &[".tink-source.json"])
+    skills::skill_contents_equal_except(library_skill, project_skill, &[".tink-source.json"])
 }
 
-/// Before refreshing a project skill, ensure the stash can accept `new`
+/// Before refreshing a project skill, ensure the library can accept `new`
 /// (missing, already new, or still equal to the current project install).
 pub fn preflight_refresh(
     project_installed: &Path,
     new_skill: &Skill,
     new_provenance: &Provenance,
 ) -> Result<(), Error> {
-    let stash = stash_root(None)?;
-    match skills::preflight_install(new_skill, &stash, Some(new_provenance))? {
+    let library = library_root(None)?;
+    match skills::preflight_install(new_skill, &library, Some(new_provenance))? {
         PreflightOutcome::Ready | PreflightOutcome::Identical => Ok(()),
         PreflightOutcome::Divergent => {
-            let home_skill = stash.join(&new_skill.name);
+            let home_skill = library.join(&new_skill.name);
             if home_skill.is_dir() && tracks_project(&home_skill, project_installed)? {
                 Ok(())
             } else {
                 Err(Error::msg(format!(
-                    "Refusing to refresh {}: stash diverges",
+                    "Refusing to refresh {}: library diverges",
                     new_skill.name
                 )))
             }
@@ -274,7 +274,7 @@ pub fn sync_from_installed(installed: &Skill) -> Result<(), Error> {
 }
 
 /// After a project refresh passed [`preflight_refresh`], write the new tree
-/// into the stash (create, noop, or repair — same rules as [`deposit`]).
+/// into the library (create, noop, or repair — same rules as [`deposit`]).
 pub fn deposit_refresh(new_skill: &Skill, new_provenance: &Provenance) -> Result<(), Error> {
     deposit(new_skill, Some(new_provenance)).map(|_| ())
 }
@@ -291,7 +291,7 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
-    /// Isolates `TINK_HOME` for in-process stash writes (serialized).
+    /// Isolates `TINK_HOME` for in-process library writes (serialized).
     struct TempHome {
         home: PathBuf,
         root: PathBuf,
@@ -318,8 +318,8 @@ mod tests {
             }
         }
 
-        fn stash_skill(&self, name: &str) -> PathBuf {
-            skills_stash_path(&self.home).join(name)
+        fn library_skill(&self, name: &str) -> PathBuf {
+            skills_library_path(&self.home).join(name)
         }
     }
 
@@ -370,7 +370,7 @@ mod tests {
 
         let (path, write) = deposit_create_only(&skill).unwrap();
         assert_eq!(write, CreateOnlyWrite::Created);
-        assert_eq!(path, home.stash_skill("demo-skill"));
+        assert_eq!(path, home.library_skill("demo-skill"));
         assert!(skill_md(&path).contains("fresh body"));
     }
 
@@ -384,7 +384,7 @@ mod tests {
             deposit_create_only(&skill).unwrap().1,
             CreateOnlyWrite::Created
         );
-        let before = skill_md(&home.stash_skill("demo-skill"));
+        let before = skill_md(&home.library_skill("demo-skill"));
 
         let (path, write) = deposit_create_only(&skill).unwrap();
         assert_eq!(write, CreateOnlyWrite::Unchanged);
@@ -403,7 +403,7 @@ mod tests {
             deposit_create_only(&original).unwrap().1,
             CreateOnlyWrite::Created
         );
-        let before = skill_md(&home.stash_skill("demo-skill"));
+        let before = skill_md(&home.library_skill("demo-skill"));
 
         let (path, write) = deposit_create_only(&incoming).unwrap();
         assert!(
@@ -422,10 +422,10 @@ mod tests {
         let original = write_skill(&first, "demo-skill", "original body");
         let incoming = write_skill(&second, "demo-skill", "incoming body");
 
-        assert_eq!(deposit(&original, None).unwrap().1, StashWrite::Created);
+        assert_eq!(deposit(&original, None).unwrap().1, LibraryWrite::Created);
 
         let (path, write) = deposit(&incoming, None).unwrap();
-        assert_eq!(write, StashWrite::Repaired);
+        assert_eq!(write, LibraryWrite::Repaired);
         assert!(skill_md(&path).contains("incoming body"));
         assert!(!skill_md(&path).contains("original body"));
     }
@@ -439,11 +439,11 @@ mod tests {
 
         assert_eq!(
             deposit(&skill, Some(&provenance)).unwrap().1,
-            StashWrite::Created
+            LibraryWrite::Created
         );
-        let stash = home.stash_skill("demo-skill");
-        assert!(stash.join(".tink-source.json").is_file());
-        let before = skill_md(&stash);
+        let library = home.library_skill("demo-skill");
+        assert!(library.join(".tink-source.json").is_file());
+        let before = skill_md(&library);
 
         // Incoming tree matches body but has no receipt — create-only must not rewrite.
         let (path, write) = deposit_create_only(&skill).unwrap();

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -10,7 +10,7 @@ use crate::git;
 use crate::provenance::{self, Provenance};
 use crate::skills::{self, Skill};
 use crate::sources;
-use crate::stash;
+use crate::library;
 
 fn skill_at(repository: &Path, source_path: &str) -> Result<PathBuf, Error> {
     let mut path = repository.to_path_buf();
@@ -81,8 +81,8 @@ fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
     }
 
     if current_revision == provenance["revision"] {
-        // No upstream move — still keep the home stash honest.
-        stash::sync_from_installed(installed)?;
+        // No upstream move — still keep the library honest.
+        library::sync_from_installed(installed)?;
         return Ok(Some(false));
     }
 
@@ -101,9 +101,9 @@ fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
     next.insert("revision".into(), current_revision);
 
     let tree_changed = !skills::skill_contents_equal(&old_skill.path, &new_skill.path)?;
-    stash::preflight_refresh(&installed.path, &new_skill, &next)?;
+    library::preflight_refresh(&installed.path, &new_skill, &next)?;
     let _installed = skills::replace_verified(&new_skill, &destination_root, &next)?;
-    stash::deposit_refresh(&new_skill, &next)?;
+    library::deposit_refresh(&new_skill, &next)?;
     Ok(Some(tree_changed))
 }
 

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -14,7 +14,7 @@ pub struct RemoveReport {
 }
 
 /// Drop `<name>` from the by-project catalog, then delete
-/// `<project>/.agents/skills/<name>/`. Does not touch `$TINK_HOME` stash trees.
+/// `<project>/.agents/skills/<name>/`. Does not touch `$TINK_HOME` library trees.
 /// Catalog sync runs before disk delete; sync errors leave the skill tree intact.
 pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Error> {
     if !skills::valid_skill_name(name) {

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -51,7 +51,7 @@ impl Workspace {
             .join("meta.json")
     }
 
-    fn stash_skill(&self, skill: &str) -> PathBuf {
+    fn library_skill(&self, skill: &str) -> PathBuf {
         self.inventory.join("skills").join(skill)
     }
 
@@ -63,8 +63,8 @@ impl Workspace {
             "expected {skill} in catalog: {raw}"
         );
         assert!(
-            self.stash_skill(skill).join("SKILL.md").is_file(),
-            "expected home stash at skills/{skill}"
+            self.library_skill(skill).join("SKILL.md").is_file(),
+            "expected library at skills/{skill}"
         );
         assert!(
             !self
@@ -223,6 +223,35 @@ fn i7_init_no_manage_tink_skips_embedded_skill() {
     assert!(!Workspace::skill_path(&project, "manage-tink").exists());
 }
 
+#[test]
+fn i8_relative_tink_home_resolves_absolute_not_nested() {
+    // I8: relative TINK_HOME is absolutized against cwd; must not nest under project.
+    let root = tempfile::TempDir::new().unwrap();
+    let root = root.path().canonicalize().unwrap_or_else(|_| root.path().to_path_buf());
+    let project = root.join("app");
+    fs::create_dir_all(&project).unwrap();
+    let expected_home = root.join("tink-home");
+
+    Command::cargo_bin("tink")
+        .unwrap()
+        .current_dir(&project)
+        .env("TINK_HOME", "../tink-home")
+        .env("HOME", root.join("unused-unix-home"))
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected_home.display().to_string()));
+
+    assert!(
+        expected_home.join("layout.json").is_file(),
+        "home should live at absolutized sibling"
+    );
+    assert!(
+        !project.join("tink-home").exists(),
+        "home must not nest under project cwd"
+    );
+}
+
 // --- A*: local add ---
 
 #[test]
@@ -337,11 +366,11 @@ fn a7_add_refuses_reserved_by_project_name() {
                 .or(predicate::str::contains("by-project")),
         );
     assert!(!Workspace::skill_path(&project, "by-project").exists());
-    assert!(!ws.stash_skill("by-project").exists());
+    assert!(!ws.library_skill("by-project").exists());
 }
 
 #[test]
-fn a6_add_repairs_divergent_home_archive_and_installs_project() {
+fn a6_add_repairs_divergent_library_and_installs_project() {
     let ws = Workspace::new();
     let app = ws.project("app");
     let other = ws.project("other");
@@ -363,7 +392,7 @@ fn a6_add_repairs_divergent_home_archive_and_installs_project() {
         .args(["skill", "add", first.to_str().unwrap()])
         .assert()
         .success();
-    assert!(ws.stash_skill("demo-skill").join("SKILL.md").is_file());
+    assert!(ws.library_skill("demo-skill").join("SKILL.md").is_file());
 
     ws.cmd(&other)
         .args(["skill", "add", second.to_str().unwrap()])
@@ -378,13 +407,13 @@ fn a6_add_repairs_divergent_home_archive_and_installs_project() {
     )
     .unwrap();
     assert!(project.contains("from other"));
-    let archived = fs::read_to_string(ws.stash_skill("demo-skill").join("SKILL.md")).unwrap();
+    let archived = fs::read_to_string(ws.library_skill("demo-skill").join("SKILL.md")).unwrap();
     assert!(archived.contains("from other"));
     assert!(!archived.contains("from app"));
 }
 
 #[test]
-fn a8_add_uses_home_archive_when_remote_tip_matches() {
+fn a8_add_uses_library_when_remote_tip_matches() {
     let ws = Workspace::new();
     let app = ws.project("app");
     let other = ws.project("other");
@@ -419,7 +448,7 @@ fn a8_add_uses_home_archive_when_remote_tip_matches() {
     second
         .assert()
         .success()
-        .stdout(predicate::str::contains("from stash"));
+        .stdout(predicate::str::contains("from library"));
     assert!(Workspace::skill_path(&other, "root-skill")
         .join(".tink-source.json")
         .is_file());
@@ -632,7 +661,7 @@ fn l2_skill_list_fails_without_skills_dir() {
 }
 
 #[test]
-fn l3_skill_list_home_prints_catalog_tsv() {
+fn l3_skill_list_catalog_prints_tsv() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -645,7 +674,7 @@ fn l3_skill_list_home_prints_catalog_tsv() {
     let root = project.canonicalize().unwrap();
     let root_s = root.to_str().unwrap();
     ws.cmd(&project)
-        .args(["skill", "list", "--home"])
+        .args(["skill", "list", "--catalog"])
         .assert()
         .success()
         .stdout(
@@ -655,6 +684,23 @@ fn l3_skill_list_home_prints_catalog_tsv() {
                 .and(predicate::str::contains("demo-skill"))
                 .and(predicate::str::contains("manage-tink")),
         );
+}
+
+#[test]
+fn l5_skill_list_rejects_removed_stash_and_home_flags() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    for flag in ["--stash", "--home"] {
+        ws.cmd(&project)
+            .args(["skill", "list", flag])
+            .assert()
+            .failure()
+            .stderr(
+                predicate::str::contains(flag)
+                    .or(predicate::str::contains("unexpected argument")),
+            );
+    }
 }
 
 #[test]
@@ -690,10 +736,10 @@ fn l4_skill_list_warns_on_zen_without_agents_still_lists() {
         ));
 }
 
-// --- H*: home stash ---
+// --- H*: library ---
 
 #[test]
-fn h1_skill_list_stash_includes_archived_names() {
+fn h1_skill_list_library_includes_archived_names() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project)
@@ -707,14 +753,14 @@ fn h1_skill_list_stash_includes_archived_names() {
         .assert()
         .success();
     ws.cmd(&project)
-        .args(["skill", "list", "--stash"])
+        .args(["skill", "list", "--library"])
         .assert()
         .success()
         .stdout(predicate::str::contains("demo-skill"));
 }
 
 #[test]
-fn h2_skill_add_stash_installs_into_project() {
+fn h2_skill_add_library_installs_into_project() {
     let ws = Workspace::new();
     let donor = ws.project("donor");
     let app = ws.project("app");
@@ -728,7 +774,7 @@ fn h2_skill_add_stash_installs_into_project() {
         .args(["skill", "add", source.to_str().unwrap()])
         .assert()
         .success();
-    assert!(ws.stash_skill("stash-skill").join("SKILL.md").is_file());
+    assert!(ws.library_skill("stash-skill").join("SKILL.md").is_file());
 
     ws.cmd(&app)
         .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
@@ -740,7 +786,7 @@ fn h2_skill_add_stash_installs_into_project() {
         .success()
         .stdout(
             predicate::str::contains("stash-skill")
-                .and(predicate::str::contains("from stash")),
+                .and(predicate::str::contains("from library")),
         );
     assert!(Workspace::skill_path(&app, "stash-skill")
         .join("SKILL.md")
@@ -749,7 +795,7 @@ fn h2_skill_add_stash_installs_into_project() {
 }
 
 #[test]
-fn h3_skill_add_stash_missing_refuses_without_github() {
+fn h3_skill_add_library_missing_refuses_without_github() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project)
@@ -761,13 +807,13 @@ fn h3_skill_add_stash_missing_refuses_without_github() {
         .assert()
         .failure()
         .stderr(
-            predicate::str::contains("Stash skill not found")
+            predicate::str::contains("Library skill not found")
                 .or(predicate::str::contains("not found")),
         );
 }
 
 #[test]
-fn h4_skill_add_stash_refuses_overwrite_when_diverged() {
+fn h4_skill_add_library_refuses_overwrite_when_diverged() {
     let ws = Workspace::new();
     let donor = ws.project("donor");
     let app = ws.project("app");
@@ -802,7 +848,7 @@ fn h4_skill_add_stash_refuses_overwrite_when_diverged() {
 }
 
 #[test]
-fn h5_skill_harvest_copies_harness_skills_into_stash() {
+fn h5_skill_harvest_copies_harness_skills_into_library() {
     let ws = Workspace::new();
     let home = ws.root.join("home");
     let project = ws.project("app");
@@ -839,9 +885,9 @@ fn h5_skill_harvest_copies_harness_skills_into_stash() {
                 .and(predicate::str::contains("nested-skill")),
         );
 
-    assert!(ws.stash_skill("agents-skill").join("SKILL.md").is_file());
-    assert!(ws.stash_skill("claude-skill").join("SKILL.md").is_file());
-    assert!(ws.stash_skill("nested-skill").join("SKILL.md").is_file());
+    assert!(ws.library_skill("agents-skill").join("SKILL.md").is_file());
+    assert!(ws.library_skill("claude-skill").join("SKILL.md").is_file());
+    assert!(ws.library_skill("nested-skill").join("SKILL.md").is_file());
     assert!(
         !project.join(".agents").exists(),
         "harvest must not create project .agents"
@@ -882,9 +928,9 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
         "demo-skill",
         "harness body",
     );
-    // Pre-seed divergent stash.
-    write_skill(ws.stash_skill("demo-skill").as_path(), "demo-skill", "stash body");
-    let before = fs::read_to_string(ws.stash_skill("demo-skill").join("SKILL.md")).unwrap();
+    // Pre-seed divergent library.
+    write_skill(ws.library_skill("demo-skill").as_path(), "demo-skill", "stash body");
+    let before = fs::read_to_string(ws.library_skill("demo-skill").join("SKILL.md")).unwrap();
 
     ws.cmd(&project)
         .env("HOME", &home)
@@ -893,8 +939,8 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
         .success()
         .stderr(predicate::str::contains("Skipped").and(predicate::str::contains("demo-skill")));
 
-    let after = fs::read_to_string(ws.stash_skill("demo-skill").join("SKILL.md")).unwrap();
-    assert_eq!(before, after, "create-only must not repair divergent stash");
+    let after = fs::read_to_string(ws.library_skill("demo-skill").join("SKILL.md")).unwrap();
+    assert_eq!(before, after, "create-only must not repair divergent library");
     assert!(after.contains("stash body"));
 }
 
@@ -926,14 +972,14 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
         .assert()
         .success();
     write_skill(
-        ws.stash_skill("from-home").as_path(),
+        ws.library_skill("from-home").as_path(),
         "from-home",
         "stash resident",
     );
-    // Harness entry that realpaths into the stash — must be skipped as a source.
+    // Harness entry that realpaths into the library — must be skipped as a source.
     fs::create_dir_all(home.join(".cursor").join("skills")).unwrap();
     std::os::unix::fs::symlink(
-        ws.stash_skill("from-home"),
+        ws.library_skill("from-home"),
         home.join(".cursor").join("skills").join("from-home"),
     )
     .unwrap();
@@ -952,10 +998,10 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
                 .and(predicate::str::contains("from-home")),
         );
 
-    assert!(ws.stash_skill("good-skill").join("SKILL.md").is_file());
-    assert!(ws.stash_skill("nested-home-skill").join("SKILL.md").is_file());
-    assert!(!ws.stash_skill("bad-skill").exists());
-    let home_body = fs::read_to_string(ws.stash_skill("from-home").join("SKILL.md")).unwrap();
+    assert!(ws.library_skill("good-skill").join("SKILL.md").is_file());
+    assert!(ws.library_skill("nested-home-skill").join("SKILL.md").is_file());
+    assert!(!ws.library_skill("bad-skill").exists());
+    let home_body = fs::read_to_string(ws.library_skill("from-home").join("SKILL.md")).unwrap();
     assert!(home_body.contains("stash resident"));
 }
 
@@ -1081,7 +1127,7 @@ fn p2_refresh_refuses_local_modifications() {
 }
 
 #[test]
-fn p3_refresh_backfills_missing_home_archive_on_noop() {
+fn p3_refresh_backfills_missing_library_on_noop() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -1103,7 +1149,7 @@ fn p3_refresh_backfills_missing_home_archive_on_noop() {
         add.env(k, v);
     }
     add.assert().success();
-    fs::remove_dir_all(ws.stash_skill("remote-skill")).unwrap();
+    fs::remove_dir_all(ws.library_skill("remote-skill")).unwrap();
 
     let mut refresh = ws.cmd(&project);
     refresh.args(["skill", "refresh", "remote-skill"]);
@@ -1111,7 +1157,7 @@ fn p3_refresh_backfills_missing_home_archive_on_noop() {
         refresh.env(k, v);
     }
     refresh.assert().success();
-    assert!(ws.stash_skill("remote-skill").join("SKILL.md").is_file());
+    assert!(ws.library_skill("remote-skill").join("SKILL.md").is_file());
 }
 
 #[test]
@@ -1137,7 +1183,7 @@ fn p4_refresh_allows_archive_missing_only_receipt() {
         add.env(k, v);
     }
     add.assert().success();
-    fs::remove_file(ws.stash_skill("remote-skill").join(".tink-source.json")).unwrap();
+    fs::remove_file(ws.library_skill("remote-skill").join(".tink-source.json")).unwrap();
 
     write_skill(
         &remote.join("skills").join("remote-skill"),
@@ -1153,14 +1199,14 @@ fn p4_refresh_allows_archive_missing_only_receipt() {
     }
     refresh.assert().success();
     assert!(
-        fs::read_to_string(ws.stash_skill("remote-skill").join("SKILL.md"))
+        fs::read_to_string(ws.library_skill("remote-skill").join("SKILL.md"))
             .unwrap()
             .contains("v2")
     );
 }
 
 #[test]
-fn p5_refresh_refuses_divergent_home_archive() {
+fn p5_refresh_refuses_divergent_library() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -1182,7 +1228,7 @@ fn p5_refresh_refuses_divergent_home_archive() {
         add.env(k, v);
     }
     add.assert().success();
-    write_skill(ws.stash_skill("remote-skill").as_path(), "remote-skill", "other");
+    write_skill(ws.library_skill("remote-skill").as_path(), "remote-skill", "other");
 
     write_skill(
         &remote.join("skills").join("remote-skill"),
@@ -1202,7 +1248,7 @@ fn p5_refresh_refuses_divergent_home_archive() {
     refresh
         .assert()
         .failure()
-        .stderr(predicate::str::contains("stash diverges"));
+        .stderr(predicate::str::contains("library diverges"));
     let after =
         fs::read_to_string(Workspace::skill_path(&project, "remote-skill").join("SKILL.md"))
             .unwrap();
@@ -1247,8 +1293,8 @@ fn p7_refresh_repairs_stale_archive_when_project_already_new() {
     }
     refresh.assert().success();
 
-    // Simulate failed stash deposit: project at v2, stash rolled back to v1.
-    write_skill(ws.stash_skill("remote-skill").as_path(), "remote-skill", "v1");
+    // Simulate failed library deposit: project at v2, library rolled back to v1.
+    write_skill(ws.library_skill("remote-skill").as_path(), "remote-skill", "v1");
 
     let mut repair = ws.cmd(&project);
     repair.args(["skill", "refresh", "remote-skill"]);
@@ -1257,10 +1303,10 @@ fn p7_refresh_repairs_stale_archive_when_project_already_new() {
     }
     repair.assert().success();
     assert!(
-        fs::read_to_string(ws.stash_skill("remote-skill").join("SKILL.md"))
+        fs::read_to_string(ws.library_skill("remote-skill").join("SKILL.md"))
             .unwrap()
             .contains("v2"),
-        "noop refresh must repair stale stash from project"
+        "noop refresh must repair stale library from project"
     );
 }
 
@@ -1311,7 +1357,7 @@ fn p6_refresh_identical_tree_new_revision_bumps_receipts() {
     .unwrap();
     assert!(project_receipt.contains(&new_rev));
     let archive_receipt =
-        fs::read_to_string(ws.stash_skill("remote-skill").join(".tink-source.json")).unwrap();
+        fs::read_to_string(ws.library_skill("remote-skill").join(".tink-source.json")).unwrap();
     assert!(archive_receipt.contains(&new_rev));
 }
 
@@ -1348,15 +1394,15 @@ fn d1_destroy_yes_removes_agents_zen_agents_md() {
     assert!(!project.join("AGENTS.md").exists());
     assert!(ws.inventory.join("layout.json").is_file());
     assert!(
-        ws.stash_skill("manage-tink").join("SKILL.md").is_file(),
-        "home stash must remain after destroy"
+        ws.library_skill("manage-tink").join("SKILL.md").is_file(),
+        "library must remain after destroy"
     );
     assert!(
-        ws.stash_skill("extra-skill").join("SKILL.md").is_file(),
-        "home stash must remain after destroy"
+        ws.library_skill("extra-skill").join("SKILL.md").is_file(),
+        "library must remain after destroy"
     );
     ws.cmd(&project)
-        .args(["skill", "list", "--home"])
+        .args(["skill", "list", "--catalog"])
         .assert()
         .success()
         .stdout(
@@ -1397,7 +1443,7 @@ fn d3_destroy_refuses_agents_symlink() {
 // --- X*: skill remove ---
 
 #[test]
-fn x1_remove_deletes_project_skill_keeps_stash_drops_catalog() {
+fn x1_remove_deletes_project_skill_keeps_library_drops_catalog() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -1423,11 +1469,11 @@ fn x1_remove_deletes_project_skill_keeps_stash_drops_catalog() {
         .success()
         .stdout(predicate::str::contains("demo-skill").not());
     assert!(
-        ws.stash_skill("demo-skill").join("SKILL.md").is_file(),
-        "home stash must remain after project remove"
+        ws.library_skill("demo-skill").join("SKILL.md").is_file(),
+        "library must remain after project remove"
     );
     ws.cmd(&project)
-        .args(["skill", "list", "--home"])
+        .args(["skill", "list", "--catalog"])
         .assert()
         .success()
         .stdout(
@@ -1472,7 +1518,7 @@ fn x3_remove_refuses_agents_symlink() {
 }
 
 #[test]
-fn x4_remove_does_not_delete_home_stash() {
+fn x4_remove_does_not_delete_library() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -1482,14 +1528,14 @@ fn x4_remove_does_not_delete_home_stash() {
         .args(["skill", "add", source.to_str().unwrap()])
         .assert()
         .success();
-    let stash_md = ws.stash_skill("keep-stash").join("SKILL.md");
-    let before = fs::read(&stash_md).unwrap();
+    let library_md = ws.library_skill("keep-stash").join("SKILL.md");
+    let before = fs::read(&library_md).unwrap();
     ws.cmd(&project)
         .args(["skill", "remove", "keep-stash"])
         .assert()
         .success();
     assert!(!Workspace::skill_path(&project, "keep-stash").exists());
-    let after = fs::read(&stash_md).unwrap();
+    let after = fs::read(&library_md).unwrap();
     assert_eq!(before, after);
 }
 
@@ -1514,14 +1560,14 @@ fn x5_manage_tink_documents_remove_and_catalog_sync() {
     );
     assert!(
         skill_md.contains("tink skill add NAME")
-            && skill_md.contains("bare stash")
-            && !skill_md.contains("add --stash"),
-        "manage-tink must teach bare-name stash promote, not add --stash: {skill_md}"
+            && skill_md.contains("bare library")
+            && !skill_md.contains("add --library"),
+        "manage-tink must teach bare-name library promote, not add --library: {skill_md}"
     );
     assert!(
         commands.contains("tink skill add NAME")
-            && !commands.contains("add --stash"),
-        "commands.md must list bare-name stash promote, not add --stash: {commands}"
+            && !commands.contains("add --library"),
+        "commands.md must list bare-name library promote, not add --library: {commands}"
     );
     assert!(
         skill_md.contains("by-project catalog")


### PR DESCRIPTION
## Summary
- Clean-break rename: home skill **library** (`$TINK_HOME/skills/`) and by-project **catalog** with `--library` / `--catalog` (removed `--stash` / `--home`).
- Module rename `stash` → `library`; crate version **0.3.0**.
- Absolutize relative `TINK_HOME` against cwd; I8 + acceptance for old-flag refusal (L5).
- Docs: manage-tink/README break note + how to refresh live manage-tink after major upgrade.

## Test plan
- [x] `cargo test` (29 unit + 58 acceptance)
- [ ] CI green
- [ ] After merge: release/tag 0.3.0 if that is the usual pipeline for install.sh tip

## Follow-up
- Tracking: dedicated `tink library list` surface (issue filed alongside this PR).


Made with [Cursor](https://cursor.com)