### PR TITLE
Pay down catalog structure debt and harden transport boundaries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,40 @@
+# Architecture Notes (Interim)
+
+## Intent of this run
+Keep the CLI behavior-safe while improving module boundaries so that high-risk command
+orchestration does not sit directly on raw infrastructure details.
+
+## Layer map (practical)
+- **Edge / orchestration (`src/lib.rs`, `src/main.rs`)**
+  Parses arguments and routes into skill commands.
+- **Application flow (`src/add.rs`, `src/remove.rs`, `src/check.rs`, `src/refresh.rs`, `src/update.rs`, `src/list.rs`, `src/harvest.rs`, `src/destroy.rs`)
+  Owns command-specific validation, sequencing, and side effects.
+- **Domain helpers (`src/skills.rs`, `src/catalog.rs`, `src/provenance.rs`, `src/home.rs`)
+  Encapsulate project/library policy and path/domain contracts.
+- **Infrastructure adapters (`src/git.rs`, `src/sources.rs`, `src/paths.rs`)
+  Perform external process and filesystem operations, exposing narrow result contracts.
+
+## Notable boundary clarifications in this phase
+- **Catalog aggregate (Phase 8)**: `src/catalog.rs` now models by-project catalog data as
+  `CatalogMeta` (`name`, `root`, `skills`) and centralizes ownership checks + mutation for install/withdraw/forget.
+
+- **Path layout ownership**: path rooting for project skill directories was moved to
+  `src/home.rs` (`project_agents_path`, `project_skills_path`) so callers do not build
+  `./.agents` fragments directly.
+- **Receipt naming ownership**: sidecar filename is now defined once as
+  `provenance::SIDECAR_FILE` and referenced by callers that interact with source
+  receipts.
+- **Git boundary extraction (Phase 5)**: `src/git.rs` now centralizes command invocation
+  and error shaping in internal helpers:
+  - `run_git` for command launch + process I/O preamble
+  - `git_detail` for stderr-last-line extraction
+
+  This keeps `remote_head`, `checkout`, and `checkout_revision` focused on intent while
+  preserving their existing error contracts and command semantics.
+
+## Decision principle used
+Each module boundary change is additive and reversible:
+- extract one helper,
+- keep control flow and outputs unchanged,
+- verify with `cargo test -- --nocapture`,
+- then mark the phase complete.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -1,0 +1,34 @@
+# Reliability Notes
+
+## Context
+- Intake date: 2026-08-07
+- Production profile: single-binary CLI with outbound calls to external process/tool chains.
+- Scope: harden integration calls at command boundaries and record operating policy.
+- Constraint: keep behavior-compatible for current flows; no schema or protocol redesign in this phase.
+
+## Integration-Point Audit
+| Dependency | Location | Timeout | Retry | Circuit Breaker | Bulkhead / isolation | Current Status |
+|---|---|---|---|---|---|---|
+| `curl` (GitHub API + artifact download) | `src/update.rs::curl_to_file`, `src/update.rs::update_binary` | `--connect-timeout 5`; metadata `--max-time 30`; asset `--max-time 300` | `--retry 2`, `--retry-delay 1` | `retry budget in-process` (bounded attempts) | Update call is isolated to explicit user command path | hardened |
+| `git` (remote head/clone/worktree) | `src/git.rs::run_git` | `http.lowSpeedLimit=1024`, `http.lowSpeedTime=30` (mid-transfer stall; no separate connect wall-clock) | not built into helper; command-level retries via existing user retry | bounded by low-speed transport config (single-call invocation) | all git operations isolated to explicit command path (`add/refresh`) | hardened |
+| `tar` (release archive extraction) | `src/update.rs::extract_tink_binary` | n/a (local filesystem) | n/a | n/a | CLI-local, no network | not applicable |
+| `env::current_exe/current_dir` process boundary | `src/main.rs`, `src/update.rs` | n/a | n/a | n/a | clap parse first so `--help`/`--version` work without cwd; remaining commands fail closed on missing cwd | hardened |
+
+## Query & Resource Findings
+- No outbound SQL or paginated list endpoints in this codebase.
+- Network work is bounded by explicit process-level commands with timeout/retry caps.
+- Archive and Git operations remain single-process and do not maintain pooled connections.
+
+## Health Checks & Metrics
+- No dedicated long-lived service metrics are present in this CLI.
+- Immediate operational checks should remain exit code + stderr assertions (integration tests already cover major error/success paths).
+- If deployed in packaging pipelines, add external telemetry by wrapping process exit codes in caller scripts.
+
+## Deploy vs Release
+- **Release (`tink update`)** is explicit, user-initiated and non-automatic.
+- No automatic background rollout exists in this repository.
+- Runtime update behavior now degrades deterministically on integration timeout/failure instead of hanging.
+
+## Failure Strategy
+- Treat inbound command failures as hard failures with explicit messages.
+- Keep retries small and bounded so failures remain actionable and do not silently mask dependency problems.

--- a/docs/REMOVE-TECHNICAL-DEBT-PLAN.md
+++ b/docs/REMOVE-TECHNICAL-DEBT-PLAN.md
@@ -1,0 +1,52 @@
+# Remove Technical Debt Plan
+
+## Context
+- Intake date: 2026-08-07
+- System: Tink CLI (`tink`) for project-local skill management (`.agents/skills/`) and local catalog/library metadata (`~/.tink`).
+- Size/age profile: moderate-sized Rust CLI, with stable command surface and growing acceptance suite.
+- Failure impact: regressions can break agent workflows, dev/CI automation, and distributed skill installation.
+- Rewrite plan: no rewrite; continue incremental, behavior-first work in safe, test-backed slices.
+- Intake scope (this run): phases 1–3 first, then reassess for deeper phases.
+
+## Phase Status
+| Phase | Skill | Status | Artifact | Date |
+|---|---|---|---|---|
+| 1 | working-with-legacy-code | done | TESTING.md + TECH-DEBT.md | 2026-08-07 |
+| 2 | refactoring-patterns | done | TECH-DEBT.md | 2026-08-07 |
+| 3 | clean-code | done | TECH-DEBT.md | 2026-08-07 |
+| 4 | software-design-philosophy | done | TECH-DEBT.md | 2026-08-07 |
+| 5 | clean-architecture | done | ARCHITECTURE.md | 2026-08-07 |
+| 6 | pragmatic-programmer | done | TECH-DEBT.md | 2026-08-07 |
+| 7 | release-it | done | RELIABILITY.md | 2026-08-07 |
+| 8 | domain-driven-design | done | ARCHITECTURE.md | 2026-08-07 |
+Statuses: pending · in-progress · awaiting-evidence · done · deferred: <reason> · skipped: <reason>
+Optional phases (system-design, ddia-systems, team-topologies) are added as rows here when their Add-when condition becomes true.
+
+## Key Decisions
+| Date | Phase | Decision | Rationale |
+|---|---|---|---|
+| 2026-08-07 | Intake | Starting module focus is command dispatcher + skill lifecycle path: `src/lib.rs`, `src/add.rs`, `src/remove.rs`, `src/check.rs`, `src/catalog.rs`. | Highest-churn and highest-risk surface for user-visible behavior changes. |
+| 2026-08-07 | Intake | Safety policy: production-adjacent workflow safety, no big-bang rewrite, and no behavior change before characterization tests. | Keeps shipped CLI behavior stable and preserves compatibility. |
+| 2026-08-07 | Intake | Baseline green gate is `cargo test -- --nocapture`; phase progresses only while suite remains green. | Existing suite already covers command contracts and refusal paths. |
+| 2026-08-07 | Phase 1 | No behavior bugs found during initial characterization that require immediate pin-as-bug tickets. | Existing acceptance suite already constrains listed high-risk paths. |
+| 2026-08-07 | Phase 2 | Extracted checkout reference selection into `checkout_reference_skill` in `src/refresh.rs` to separate remote-reference preparation from `refresh_one` state transitions. | Keeps refresh sequencing explicit and preserves behavior while improving readability and future testability. |
+| 2026-08-07 | Phase 3 | Extracted update replacement responsibilities in `src/update.rs` (`staging_binary_path`, `stage_new_binary`, `commit_staged_binary`) and kept binary replacement behavior unchanged. | Reduces a single-purpose function complexity into explicit primitives for safer future edits. |
+| 2026-08-07 | Phase 4 | Extracted skill-entry parsing responsibilities in `src/check.rs` (`is_ignored_skill_entry`, `read_skill_entry`) to model directory-filtering and validation as explicit domain operations. | Improves design clarity around what constitutes a project skill entry before validation. |
+| 2026-08-07 | Phase 5 | Centralized repeated git command execution/error translation in `src/git.rs` (`run_git`, `git_detail`) to separate infrastructure command execution concerns from skill orchestration flow. | Enforces a clearer boundary between plumbing and caller behavior while preserving command output/error semantics. |
+| 2026-08-07 | Phase 6 | Hardened CLI entrypoint by converting startup `current_dir` panic into an explicit error return path (`src/main.rs`). | Keeps failure-mode handling explicit at process boundaries and avoids hidden crash modes. |
+| 2026-08-07 | Phase 7 | Hardened integration points by adding bounded transport settings, retry budgets, and update-time hardening in `src/git.rs`, `src/update.rs`, and entrypoint startup failure handling. | Adds deterministic failure behavior for outbound/IO boundaries and codifies reliability policy for future updates. |
+| 2026-08-07 | Phase 8 | Introduced catalog-domain aggregate `CatalogMeta` in `src/catalog.rs` to model by-project catalog persistence (`name`, `root`, `skills`) and make ownership / mutation rules explicit while preserving write/read behavior. | Clarifies catalog as a domain aggregate boundary; behavior remains unchanged with existing compatibility contracts. |
+
+## Next Actions
+- [x] Create `docs/TESTING.md` with phase-1 safety net and characterization matrix.
+- [x] Create `docs/TECH-DEBT.md` with initial debt ledger and conventions.
+- [x] Verify baseline tests remain green to mark Phase 1 exit.
+- [x] Add characterization test for stale/invalid installed-skill metadata in `tests/acceptance.rs::c4_check_fails_with_corrupt_installed_skill`.
+- [x] Enter Phase 2 after phase-1 gate and apply one behavior-preserving refactor. (done)
+- [x] Enter Phase 3 after this behavior-preserving clean-code improvement is green. (done)
+- [x] Enter Phase 4 after this behavior-preserving design-oriented extraction is green. (done)
+- [x] Enter Phase 5 and complete one clean-architecture refactor. (done)
+- [x] Enter Phase 6 and enforce startup contract at `src/main.rs` boundary. (done)
+- [x] Enter Phase 7 and harden integration points with timeouts/retries at CLI boundaries (`src/git.rs`, `src/update.rs`) and publish reliability policy. (done)
+- [x] Enter Phase 8 after Phase 7 gate.
+- [x] Extract catalog aggregate domain model (`CatalogMeta`) and cover with unit coverage in `src/catalog.rs::tests::catalog_meta_models_skill_set_and_ownership`.

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -1,0 +1,52 @@
+# Technical Debt
+
+## Debt Ledger
+| Item | Location | Type | Risk | Effort | Priority | Status |
+|---|---|---|---|---|---|---|
+| 1 | `docs/REMOVE-TECHNICAL-DEBT-PLAN.md` | process | medium | low | high | done |
+| 2 | `src/lib.rs` | behavior characterization | medium | medium | high | pinned |
+| 3 | `src/add.rs` | behavior characterization | medium | medium | high | pinned |
+| 4 | `src/check.rs` | behavior characterization | medium | low | high | pinned |
+| 5 | `src/remove.rs` | behavior characterization | medium | low | high | pinned |
+| 6 | `src/catalog.rs` | behavior characterization | medium | low | medium | pinned |
+| 7 | `src/refresh.rs` | behavior preservation refactor | medium | medium | medium | done |
+| 8 | `src/update.rs` | clean-code refactor (`replace_binary` decomposition) | medium | low | medium | done |
+| 9 | `src/check.rs` | software-design extraction (`is_ignored_skill_entry`, `read_skill_entry`) | medium | low | medium | done |
+| 10 | `src/git.rs` | clean-architecture infrastructure extraction (`run_git`, `git_detail`) | medium | low | medium | done |
+| 11 | `src/main.rs` | pragmatic-programmer boundary guard (`current_dir` failure path) | medium | low | high | done |
+| 12 | `src/update.rs` | release hardening (timeouts/retries for update outbound calls) | medium | low | high | done |
+| 13 | `src/git.rs` | resilience hardening for remote fetch commands (`run_git` transport config) | medium | low | high | done |
+| 14 | `src/catalog.rs` | domain-driven-design aggregate extraction (`CatalogMeta`) | medium | low | medium | done |
+
+## Smell Inventory
+| Smell | Location | Refactoring | Status |
+|---|---|---|---|
+| no formal legacy safety net in this repository before this journey | `docs/` | create baseline test-oriented docs and pin top-risk CLI behavior | complete |
+| Manual edge-cases for malformed installed skills are only partially characterized | `src/check.rs` and `.agents/skills/*` | extend with additional targeted tests (non-YAML, mismatch path, missing frontmatter variants) | backlog |
+| `src/update.rs` staging/replace binary logic is separated by responsibility | `src/update.rs` | resolved by phase-3 refactor | complete |
+| `src/check.rs` skill-entry parsing is separated from read/validate flow | `src/check.rs` | resolved by phase-4 refactor | complete |
+| Catalog metadata modeling and ownership semantics (`name`, `root`, `skills`) | `src/catalog.rs` | move from loose JSON parsing helpers to `CatalogMeta` aggregate | complete |
+| Git command execution and exit-code/error parsing duplication | `src/git.rs` | centralize command execution and status/error translation in one helper | complete |
+| Outbound calls without bounded failure budget for integration steps | `src/git.rs`, `src/update.rs` | harden with transport timeouts and retry budgets | complete |
+| Unhandled startup failure at CLI entry (`current_dir`) | `src/main.rs` | guard process precondition and fail with user-facing message | complete |
+
+## Sprout / Wrap Register
+| Host behavior | Why sprouted/wrapped | Rollback plan | Status |
+|---|---|---|---|
+| N/A (none yet) | N/A | N/A | done |
+
+## Debt Budget & Broken-Windows Policy
+- Budget: prioritize production-safety and behavior-risk fixes first; keep each slice single-purpose.
+- Broken windows: do not defer observed regressions; if fix is not immediate, record explicitly in Debt Ledger with owner/priority.
+- Startup/CLI boundary contract: never panic from process-level assumptions (for example, working directory resolution); convert to explicit errors with exit code + message.
+- Integration hardening policy: all external process integrations should include bounded timeouts and explicit failure messages; keep retries bounded and visible.
+
+## Adopted Conventions
+- Keep command-path changes anchored to explicit entrypoint modules before touching supporting helpers.
+- Prefer extracting behavior-preserving helpers from multi-purpose functions before changing control flow.
+- Prefer characterization before structural change.
+- Preserve backward-compatible CLI behavior unless intentionally changing acceptance criteria.
+
+- Prefer explicit domain-level boundaries (e.g., directory entry filters before validation) for high-risk I/O flows.
+- Prefer crash-loud at source-of-truth boundaries with clear, actionable failures instead of panics/unwraps in normal execution paths.
+- Prefer explicit transport hardening (timeouts/retry caps) on outbound commands/tools (`git`, `curl`) and document deviations in RELIABILITY.md.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,57 @@
+# Testing
+
+## Test Strategy
+- Stack baseline: Rust 2024 CLI, validated with `cargo test`.
+- Verification ladder:
+  1. keep current suite green,
+  2. map entrypoint behavior with characterizing tests,
+  3. only then refactor in the smallest complete unit.
+- Green gate: any refactor keeps `cargo test -- --nocapture` green before acceptance.
+- Tooling: unit tests in `src/*` modules and acceptance tests in `tests/acceptance.rs`.
+
+## Entry Effect Sketch (Phase 1)
+- `main.rs::main` parses `Cli` with `clap` and calls `run(cli, cwd)`.
+- `run` delegates to `dispatch`:
+  - `Init {}` path: validates project layout and optional flags
+  - `Skill { ... }` path: route to `dispatch_skill`
+  - `Destroy {}` path: remove project scaffolding + catalog entry
+  - `Update` path: perform binary replacement from GitHub release metadata
+- `dispatch_skill` routes to `add`, `list`, `check`, `refresh`, `remove`, `harvest`.
+
+### Pinch points identified
+- **`dispatch_skill` routing** — the central control fan-out for all operational behavior.
+- **`add_skill_inner` branching** — local path vs filesystem-ish path vs remote vs library name.
+- **Catalog side-effects ordering** (`add` deposit before/while install; `remove` withdraw-before-delete) and failure safety.
+- **`check_project` preflight** — symlink/structure refusals and `ZEN` coupling checks.
+
+### Chosen seams
+- Do not change `run -> dispatch` signatures or command enums in Phase 1.
+- Characterize first, then isolate changes to one behavior path per iteration.
+
+## Safety Net Map
+| Module | Pinned behaviors | Test files | Gaps |
+|---|---|---|---|
+| `src/lib.rs` | CLI dispatch is exhaustive by command enum; success prints are constrained and failures return exit code 1 via error pathway. | `tests/acceptance.rs` (`i*`, `a*`, `c*`, `l*`, `x*`) | No unit coverage for exact styled output in each branch (intentional for now). |
+| `src/add.rs` | Add source resolution precedence: local path/remote/library; idempotence and divergence refusal semantics are preserved. | `tests/acceptance.rs` (`a1..a8`, `r*`) | Add-path coverage for malformed local-tree receipt combinations not in scope yet. |
+| `src/check.rs` | `skill check` requires `.agents/skills` and validates each installed skill directory/name, and enforces ZEN/AGENTS coupling rule. | `tests/acceptance.rs` (`c1`, `c2`, `c3`, `c4`, `l4`, `l5`) | Add targeted checks for additional malformed installed-skill states (e.g., non-YAML metadata variants, missing required fields). |
+| `src/remove.rs` | `remove` withdraws catalog entry before deleting project tree; never touches library content. | `tests/acceptance.rs` (`x1`, `x2`, `x4`), plus malformed-catalog regression (`x6_remove_fails_when_catalog_meta_is_malformed`) | Explicitly covers malformed catalog state behavior on remove. |
+| `src/refresh.rs` | `refresh_one` computes old/new remote skill repositories and refresh logic without mutating project state until checks pass. | `tests/acceptance.rs` (`p1`, `p2`, `p3`, `p4`, `p5`, `p6`, `p7`) | Refactor extraction added for clarity; now verify this invariant remains covered. |
+| `src/update.rs` | `replace_binary` staging and replacement behavior is clear and single-purpose (`staging_binary_path`, `stage_new_binary`, `commit_staged_binary`). | `tests/update.rs` (`asset_name_*`) | Add a direct behavior test only if binary replacement edge-cases appear in future. |
+| `src/catalog.rs` | `CatalogMeta` models catalog persistence as a domain aggregate (`name`, `root`, `skills`) and owns ownership/purge logic for by-project entries. | `tests/acceptance.rs` (`a*`, `l*`, `x*`) + `catalog::tests::catalog_meta_models_skill_set_and_ownership` | Keep behavior compatibility by preserving existing catalog JSON schema and legacy fallback behavior for legacy/non-JSON skips. |
+| `src/git.rs` | `run_git` centralizes command execution and status/error translation while preserving `remote_head`, `checkout`, and `checkout_revision` error contracts. | `tests/acceptance.rs` (`r*`, `p*`) | Continue to rely on acceptance flows as end-to-end behavior proof; add unit coverage only if message-contract changes appear. |
+| `src/update.rs` | `curl_to_file` applies bounded timeouts and bounded retries on external artifact/API fetch, so update can fail fast instead of hanging. | `tests/acceptance.rs` (`u1`, `u2`, `u3`) + unit `curl_transport_args_*` | Keep behavior compatibility by leaving success path unchanged; add failure-path telemetry if needed by CI pipelines. |
+| `src/main.rs` | Binary entrypoint fails gracefully if process working directory is unavailable, rather than panicking. | `tests/acceptance.rs` (`v*`, including `v3_main_fails_when_current_directory_is_unavailable`) | Pin startup failure-path behavior and confirm exact failure class and exit code without path-dependent timing assumptions. |
+| `src/check.rs` | `load_project_skills` explicitly distinguishes ignorable entries (`README.md`, hidden dirs/files) from malformed entries before skill read/validate. | `tests/acceptance.rs` (`c3`, `c4`, `l*`) | New helper split is design-oriented; existing tests already cover key entry/validation failures. |
+
+## Characterization Backlog
+- [x] Pin add idempotence on unchanged local source (`tink skill add`, no-op path). (`a2_add_identical_is_noop`)
+- [x] Pin behavior when removing project skill leaves library intact and updates catalog. (`x1_remove_deletes_project_skill_keeps_library_drops_catalog`)
+- [x] Pin `tink skill check` pass path after install and failure path without `.agents/skills`. (`c1_check_passes_valid_project`, `c2_check_fails_without_skills_dir`)
+- [x] Add characterization test for a deliberately corrupted installed `SKILL.md` (`c4_check_fails_with_corrupt_installed_skill`).
+- [x] Pin behavior for malformed catalog metadata entries during catalog listing (`l6_skill_list_catalog_skips_malformed_meta_entries`).
+- [x] Pin malformed-catalog behavior for remove (`x6_remove_fails_when_catalog_meta_is_malformed`).
+
+## CI Gates
+- `cargo test -- --nocapture`
+- `./tink-test` acceptance smoke path when integration behavior changes.
+

--- a/src/add.rs
+++ b/src/add.rs
@@ -6,10 +6,10 @@ use crate::catalog;
 use crate::error::Error;
 use crate::git;
 use crate::init;
+use crate::library::{self, LibraryWrite};
 use crate::provenance::Provenance;
 use crate::skills::{self, Skill};
 use crate::sources::{self, RemoteSource};
-use crate::library::{self, LibraryWrite};
 use crate::style::CliStyle;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,11 +128,7 @@ fn install_from_checkout(
                 .to_string_lossy()
                 .replace('\\', "/");
             // Repo-root skills strip to ""; refresh already treats "." as root.
-            let rel = if rel.is_empty() {
-                ".".to_string()
-            } else {
-                rel
-            };
+            let rel = if rel.is_empty() { ".".to_string() } else { rel };
             let mut map = Provenance::new();
             map.insert("source".into(), url.to_string());
             map.insert("revision".into(), rev.to_string());
@@ -171,7 +167,7 @@ fn add_skill_inner(
     report: bool,
 ) -> Result<AddOutcome, Error> {
     init::ensure_project_layout(project_root)?;
-    let destination_root = project_root.join(".agents").join("skills");
+    let destination_root = crate::home::project_skills_path(project_root);
     let local_source = Path::new(source_value);
     if local_source.exists() {
         let source_root = local_source

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -7,11 +7,11 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::error::Error;
 use crate::home::{
-    by_project_path, ensure_inventory_root, looks_like_legacy_catalog, resolve_home, BY_PROJECT,
+    BY_PROJECT, by_project_path, ensure_inventory_root, looks_like_legacy_catalog, resolve_home,
 };
 use crate::paths::{map_io, mkdir_p, refuse_symlink, require_directory, require_file};
 
@@ -30,42 +30,113 @@ fn safe_project_dirname(name: &str) -> String {
 }
 
 fn project_catalog_dir(home: &Path, project_root: &Path) -> Result<PathBuf, Error> {
-    let label = project_root
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("project");
-    Ok(by_project_path(home).join(safe_project_dirname(label)))
+    Ok(by_project_path(home).join(safe_project_root_name(project_root)))
 }
 
-fn skills_from_meta(value: &Value) -> BTreeSet<String> {
-    let mut skills = BTreeSet::new();
-    if let Some(arr) = value.get("skills").and_then(|v| v.as_array()) {
-        for item in arr {
-            if let Some(name) = item.as_str() {
-                skills.insert(name.to_string());
-            }
+#[derive(Debug, Clone)]
+struct CatalogMeta {
+    name: String,
+    root: String,
+    skills: BTreeSet<String>,
+}
+
+impl CatalogMeta {
+    fn by_project(project_root: &Path) -> Self {
+        Self {
+            name: safe_project_root_name(project_root),
+            root: project_root.to_string_lossy().into_owned(),
+            skills: BTreeSet::new(),
         }
     }
-    skills
+
+    fn from_value(project_root: &Path, value: &Value) -> Self {
+        Self {
+            name: value
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| safe_project_root_name(project_root)),
+            root: value
+                .get("root")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_default(),
+            skills: value
+                .get("skills")
+                .and_then(|v| v.as_array())
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|entry| entry.as_str())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }
+    }
+
+    fn read(meta_path: &Path, project_root: &Path) -> Result<Self, Error> {
+        let raw = fs::read_to_string(meta_path).map_err(|e| map_io(meta_path, e))?;
+        let value = serde_json::from_str(&raw).map_err(|e| {
+            Error::msg(format!("Invalid catalog meta {}: {e}", meta_path.display()))
+        })?;
+        Ok(Self::from_value(project_root, &value))
+    }
+
+    fn write(&self, meta_path: &Path) -> Result<(), Error> {
+        let body = json!({
+            "name": self.name,
+            "root": self.root,
+            "skills": self.skills.iter().cloned().collect::<Vec<_>>()
+        });
+        let text = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&body).map_err(|e| Error::msg(e.to_string()))?
+        );
+        fs::write(meta_path, text).map_err(|e| map_io(meta_path, e))?;
+        Ok(())
+    }
+
+    /// Whether withdraw/forget may mutate this entry for `project_root`.
+    ///
+    /// Non-empty `meta.root` must canonicalize to `project_root` (already
+    /// canonical). Missing/empty `root` keeps basename-keyed behavior for
+    /// legacy metas. Unresolvable stored roots soft-refuse so a sibling basename
+    /// cannot wipe another project's catalog.
+    fn catalog_owned_by(&self, project_root: &Path) -> bool {
+        if self.root.is_empty() {
+            return true;
+        }
+        match Path::new(&self.root).canonicalize() {
+            Ok(canon) => canon == project_root,
+            Err(_) => false,
+        }
+    }
+
+    /// Seal empty/missing root to the withdrawing project when siblings remain,
+    /// matching pre-`CatalogMeta` write behavior (`root` defaulted to project).
+    fn seal_root_if_empty(&mut self, project_root: &Path) {
+        if self.root.is_empty() {
+            self.root = project_root.to_string_lossy().into_owned();
+        }
+    }
+
+    fn add_skill(&mut self, skill_name: &str) {
+        self.skills.insert(skill_name.to_string());
+    }
+
+    fn withdraw_skill(&mut self, skill_name: &str) -> bool {
+        self.skills.remove(skill_name)
+    }
 }
 
-fn parse_meta(meta_path: &Path) -> Result<Value, Error> {
-    let raw = fs::read_to_string(meta_path).map_err(|e| map_io(meta_path, e))?;
-    serde_json::from_str(&raw).map_err(|e| {
-        Error::msg(format!(
-            "Invalid catalog meta {}: {e}",
-            meta_path.display()
-        ))
-    })
-}
-
-fn write_meta(meta_path: &Path, body: &Value) -> Result<(), Error> {
-    let text = format!(
-        "{}\n",
-        serde_json::to_string_pretty(body).map_err(|e| Error::msg(e.to_string()))?
-    );
-    fs::write(meta_path, text).map_err(|e| map_io(meta_path, e))?;
-    Ok(())
+fn safe_project_root_name(project_root: &Path) -> String {
+    safe_project_dirname(
+        project_root
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("project"),
+    )
 }
 
 fn remove_catalog_dir(catalog: &Path) -> Result<(), Error> {
@@ -99,26 +170,6 @@ fn existing_home(home: Option<&Path>) -> Result<Option<PathBuf>, Error> {
     Ok(Some(home))
 }
 
-/// Whether withdraw/forget may mutate this basename entry for `project_root`.
-///
-/// Non-empty `meta.root` must canonicalize to `project_root` (already
-/// canonical). Missing/empty `root` keeps basename-keyed behavior for legacy
-/// metas. Unresolvable stored roots soft-refuse so a sibling basename cannot
-/// wipe another project's catalog.
-fn catalog_owned_by(value: &Value, project_root: &Path) -> bool {
-    let Some(stored) = value
-        .get("root")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-    else {
-        return true;
-    };
-    match Path::new(stored).canonicalize() {
-        Ok(canon) => canon == project_root,
-        Err(_) => false,
-    }
-}
-
 /// Record that `skill_name` is installed in `project_root`.
 ///
 /// Last writer wins on `meta.json` `root` when two projects share a basename.
@@ -144,23 +195,15 @@ pub(crate) fn deposit_skill_at(
     let meta_path = catalog.join("meta.json");
     require_file(&meta_path)?;
 
-    let mut skills = if meta_path.is_file() {
-        skills_from_meta(&parse_meta(&meta_path)?)
+    let mut meta = if meta_path.is_file() {
+        CatalogMeta::read(&meta_path, &project_root)?
     } else {
-        BTreeSet::new()
+        CatalogMeta::by_project(&project_root)
     };
-    skills.insert(skill_name.to_string());
-
-    let label = project_root
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("project");
-    let body = json!({
-        "name": safe_project_dirname(label),
-        "root": project_root.to_string_lossy(),
-        "skills": skills.into_iter().collect::<Vec<_>>(),
-    });
-    write_meta(&meta_path, &body)?;
+    meta.name = safe_project_root_name(&project_root);
+    meta.root = project_root.to_string_lossy().into_owned();
+    meta.add_skill(skill_name);
+    meta.write(&meta_path)?;
     Ok(catalog)
 }
 
@@ -194,40 +237,20 @@ pub(crate) fn withdraw_skill_at(
     }
     refuse_symlink(&meta_path)?;
 
-    let value = parse_meta(&meta_path)?;
-    if !catalog_owned_by(&value, &project_root) {
+    let mut meta = CatalogMeta::read(&meta_path, &project_root)?;
+    if !meta.catalog_owned_by(&project_root) {
         return Ok(());
     }
-    let mut skills = skills_from_meta(&value);
-    if !skills.remove(skill_name) {
+    if !meta.withdraw_skill(skill_name) {
         return Ok(());
     }
-    if skills.is_empty() {
+    if meta.skills.is_empty() {
         return remove_catalog_dir(&catalog);
     }
-
-    let label = value
-        .get("name")
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-        .unwrap_or_else(|| {
-            project_root
-                .file_name()
-                .and_then(|s| s.to_str())
-                .map(safe_project_dirname)
-                .unwrap_or_else(|| "project".into())
-        });
-    let root = value
-        .get("root")
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
-        .unwrap_or_else(|| project_root.to_string_lossy().into_owned());
-    let body = json!({
-        "name": label,
-        "root": root,
-        "skills": skills.into_iter().collect::<Vec<_>>(),
-    });
-    write_meta(&meta_path, &body)
+    // Legacy metas omit `root`; after partial withdraw, seal ownership so a
+    // foreign basename checkout cannot soft-own remaining skill names.
+    meta.seal_root_if_empty(&project_root);
+    meta.write(&meta_path)
 }
 
 /// Remove this project's by-project catalog entry entirely.
@@ -251,8 +274,8 @@ pub(crate) fn forget_project_at(home: Option<&Path>, project_root: &Path) -> Res
     let meta_path = catalog.join("meta.json");
     if meta_path.is_file() {
         refuse_symlink(&meta_path)?;
-        let value = parse_meta(&meta_path)?;
-        if !catalog_owned_by(&value, &project_root) {
+        let meta = CatalogMeta::read(&meta_path, &project_root)?;
+        if !meta.catalog_owned_by(&project_root) {
             return Ok(());
         }
     }
@@ -331,34 +354,16 @@ pub fn list_catalog(home: Option<&Path>) -> Result<Vec<CatalogEntry>, Error> {
         if meta_path.is_symlink() || !meta_path.is_file() {
             continue;
         }
-        let Ok(raw) = fs::read_to_string(&meta_path) else {
+        let Ok(meta) = CatalogMeta::read(&meta_path, &dir) else {
             continue;
         };
-        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
-            continue;
-        };
-        let project = value
-            .get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or(&name)
-            .to_string();
-        let root = value
-            .get("root")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let Some(skills) = value.get("skills").and_then(|v| v.as_array()) else {
-            continue;
-        };
-        for skill in skills {
-            if let Some(skill_name) = skill.as_str() {
-                if !skill_name.is_empty() {
-                    entries.push(CatalogEntry {
-                        project: project.clone(),
-                        root: root.clone(),
-                        skill: skill_name.to_string(),
-                    });
-                }
+        for skill_name in meta.skills {
+            if !skill_name.is_empty() {
+                entries.push(CatalogEntry {
+                    project: meta.name.clone(),
+                    root: meta.root.clone(),
+                    skill: skill_name,
+                });
             }
         }
     }
@@ -381,6 +386,106 @@ mod tests {
         fs::create_dir_all(by_project_path(&home).join("app")).unwrap();
         let err = list_catalog(Some(&home)).unwrap_err();
         assert!(err.to_string().contains("Catalog split"), "{err}");
+    }
+
+    #[test]
+    fn catalog_meta_models_skill_set_and_ownership() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("app");
+        std::fs::create_dir_all(&project).unwrap();
+        let project = project.canonicalize().unwrap();
+
+        let mut meta = CatalogMeta::by_project(&project);
+        assert!(meta.skills.is_empty());
+        assert!(meta.catalog_owned_by(&project));
+
+        meta.add_skill("beta");
+        meta.add_skill("alpha");
+        let ordered: Vec<_> = meta.skills.iter().map(String::as_str).collect();
+        assert_eq!(ordered, vec!["alpha", "beta"]);
+
+        assert!(meta.withdraw_skill("alpha"));
+        assert_eq!(meta.skills.iter().collect::<Vec<_>>().len(), 1);
+        assert!(!meta.withdraw_skill("missing"));
+
+        // Empty root: legacy basename soft-own.
+        meta.root.clear();
+        assert!(meta.catalog_owned_by(&project));
+        // Unresolvable path: soft-refuse.
+        meta.root = project
+            .join("does-not-exist-ownership-probe")
+            .to_string_lossy()
+            .into_owned();
+        assert!(!meta.catalog_owned_by(&project));
+        // Different existing path: soft-refuse.
+        let other = temp.path().join("other");
+        fs::create_dir_all(&other).unwrap();
+        meta.root = other.canonicalize().unwrap().to_string_lossy().into_owned();
+        assert!(!meta.catalog_owned_by(&project));
+
+        meta.root = project.to_string_lossy().into_owned();
+        let path_root = project.join("meta.json");
+        meta.write(&path_root).unwrap();
+        let reloaded = CatalogMeta::read(&path_root, &project).unwrap();
+        assert_eq!(reloaded.name, "app");
+        assert_eq!(reloaded.root, project.to_string_lossy());
+        assert_eq!(reloaded.skills.len(), 1);
+    }
+
+    #[test]
+    fn withdraw_seals_empty_root_and_blocks_foreign_forget() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let clone_a = temp.path().join("clone-a").join("app");
+        let clone_b = temp.path().join("clone-b").join("app");
+        fs::create_dir_all(&clone_a).unwrap();
+        fs::create_dir_all(&clone_b).unwrap();
+        let catalog = deposit_skill_at(Some(&home), &clone_a, "alpha").unwrap();
+        deposit_skill_at(Some(&home), &clone_a, "beta").unwrap();
+
+        // Legacy: missing/empty root still soft-owns for the first withdraws.
+        let meta_path = catalog.join("meta.json");
+        let mut value: Value =
+            serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+        value["root"] = json!("");
+        fs::write(
+            &meta_path,
+            format!("{}\n", serde_json::to_string_pretty(&value).unwrap()),
+        )
+        .unwrap();
+
+        withdraw_skill_at(Some(&home), &clone_a, "alpha").unwrap();
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+        let sealed = after["root"].as_str().unwrap_or("");
+        assert!(
+            !sealed.is_empty(),
+            "empty root should seal after partial withdraw"
+        );
+        assert_eq!(
+            Path::new(sealed).canonicalize().unwrap(),
+            clone_a.canonicalize().unwrap()
+        );
+        assert_eq!(
+            after["skills"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|s| s.as_str())
+                .collect::<Vec<_>>(),
+            vec!["beta"]
+        );
+
+        // Foreign basename must not forget remaining names after seal.
+        forget_project_at(Some(&home), &clone_b).unwrap();
+        assert_eq!(
+            list_catalog(Some(&home))
+                .unwrap()
+                .iter()
+                .map(|e| e.skill.as_str())
+                .collect::<Vec<_>>(),
+            vec!["beta"]
+        );
     }
 
     #[test]
@@ -410,11 +515,13 @@ mod tests {
         let meta: Value =
             serde_json::from_str(&fs::read_to_string(catalog.join("meta.json")).unwrap()).unwrap();
         assert_eq!(meta["name"], "app");
-        assert!(meta["skills"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|s| s == "grill-me"));
+        assert!(
+            meta["skills"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|s| s == "grill-me")
+        );
         assert!(!catalog.join("grill-me").exists());
     }
 
@@ -431,8 +538,7 @@ mod tests {
         deposit_skill_at(Some(&home), &other, "beta").unwrap();
         let rows = list_catalog(Some(&home)).unwrap();
         assert_eq!(
-            rows
-                .iter()
+            rows.iter()
                 .map(|e| (e.project.as_str(), e.skill.as_str()))
                 .collect::<Vec<_>>(),
             vec![("app", "alpha"), ("app", "zebra"), ("other", "beta")]
@@ -453,7 +559,11 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(catalog.join("meta.json")).unwrap()).unwrap();
         let mut patched = before.clone();
         patched["name"] = json!("preserved-name");
-        write_meta(&catalog.join("meta.json"), &patched).unwrap();
+        fs::write(
+            catalog.join("meta.json"),
+            format!("{}\n", serde_json::to_string_pretty(&patched).unwrap()),
+        )
+        .unwrap();
 
         withdraw_skill_at(Some(&home), &app, "drop").unwrap();
         let after: Value =
@@ -512,9 +622,11 @@ mod tests {
         deposit_skill_at(Some(&home), &app, "only").unwrap();
         withdraw_skill_at(Some(&home), &app, "only").unwrap();
         assert!(list_catalog(Some(&home)).unwrap().is_empty());
-        assert!(!project_catalog_dir(&home, &app.canonicalize().unwrap())
-            .unwrap()
-            .exists());
+        assert!(
+            !project_catalog_dir(&home, &app.canonicalize().unwrap())
+                .unwrap()
+                .exists()
+        );
     }
 
     #[test]

--- a/src/check.rs
+++ b/src/check.rs
@@ -8,11 +8,30 @@ use crate::paths::{map_io, refuse_symlink};
 use crate::provenance;
 use crate::skills::{self, Skill};
 
+fn is_ignored_skill_entry(name: &str) -> bool {
+    name == "README.md" || name.starts_with('.')
+}
+
+fn read_skill_entry(path: &Path) -> Result<Option<Skill>, Error> {
+    let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    if is_ignored_skill_entry(name) {
+        return Ok(None);
+    }
+    if path.is_symlink() || !path.is_dir() {
+        return Err(Error::msg(format!(
+            "Unexpected entry in .agents/skills: {name}"
+        )));
+    }
+    let skill = skills::read_skill(path, true)?;
+    provenance::read(&skill)?;
+    Ok(Some(skill))
+}
+
 /// Load and validate project skills under `.agents/skills/`.
 /// Does not enforce ZEN.md / AGENTS.md coupling (see [`check_zen_coupling`]).
 pub fn load_project_skills(root: &Path) -> Result<Vec<Skill>, Error> {
-    let agents = root.join(".agents");
-    let skills_root = agents.join("skills");
+    let agents = crate::home::project_agents_path(root);
+    let skills_root = crate::home::project_skills_path(root);
     refuse_symlink(&agents)?;
     refuse_symlink(&skills_root)?;
     if !skills_root.is_dir() {
@@ -28,21 +47,9 @@ pub fn load_project_skills(root: &Path) -> Result<Vec<Skill>, Error> {
 
     let mut skills = Vec::new();
     for path in entries {
-        let name = path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("");
-        if name == "README.md" || name.starts_with('.') {
-            continue;
+        if let Some(skill) = read_skill_entry(&path)? {
+            skills.push(skill);
         }
-        if path.is_symlink() || !path.is_dir() {
-            return Err(Error::msg(format!(
-                "Unexpected entry in .agents/skills: {name}"
-            )));
-        }
-        let skill = skills::read_skill(&path, true)?;
-        provenance::read(&skill)?;
-        skills.push(skill);
     }
     Ok(skills)
 }
@@ -60,7 +67,9 @@ pub fn check_zen_coupling(root: &Path) -> Result<(), Error> {
     let agents_file = root.join("AGENTS.md");
     refuse_symlink(&agents_file)?;
     if !agents_file.is_file() {
-        return Err(Error::msg("ZEN.md is not referenced by a regular AGENTS.md"));
+        return Err(Error::msg(
+            "ZEN.md is not referenced by a regular AGENTS.md",
+        ));
     }
     let agents_text = fs::read_to_string(&agents_file).map_err(|e| map_io(&agents_file, e))?;
     if !agents_text.contains(crate::templates::ZEN_REFERENCE_MARKER) {

--- a/src/destroy.rs
+++ b/src/destroy.rs
@@ -25,7 +25,7 @@ pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, 
     }
 
     let mut to_remove = Vec::new();
-    let agents = project_root.join(".agents");
+    let agents = crate::home::project_agents_path(project_root);
     if agents.exists() || agents.is_symlink() {
         refuse_symlink(&agents)?;
         if !agents.is_dir() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -8,26 +8,71 @@ use tempfile::TempDir;
 use crate::error::Error;
 use crate::sources::RemoteSource;
 
+const GIT_LOW_SPEED_LIMIT_SETTING: &str = "http.lowSpeedLimit=1024";
+const GIT_LOW_SPEED_TIME_SETTING: &str = "http.lowSpeedTime=30";
+
+fn git_transport_args() -> [&'static str; 4] {
+    [
+        "-c",
+        GIT_LOW_SPEED_LIMIT_SETTING,
+        "-c",
+        GIT_LOW_SPEED_TIME_SETTING,
+    ]
+}
+
+/// Full argv prefix + subcommand args for every git spawn (proves transport flags).
+fn git_command_args<'a>(args: &[&'a str]) -> Vec<&'a str> {
+    let mut full = Vec::with_capacity(git_transport_args().len() + args.len());
+    full.extend_from_slice(&git_transport_args());
+    full.extend_from_slice(args);
+    full
+}
+
+fn run_git(
+    args: &[&str],
+    cwd: Option<&Path>,
+    non_interactive: bool,
+    io_context: &str,
+    missing_message: Option<&str>,
+) -> Result<std::process::Output, Error> {
+    let mut command = Command::new("git");
+    command.args(git_command_args(args));
+    if non_interactive {
+        command.env("GIT_TERMINAL_PROMPT", "0");
+    }
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+
+    command.output().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            if let Some(missing_message) = missing_message {
+                Error::msg(missing_message)
+            } else {
+                Error::msg(format!("{io_context}: {e}"))
+            }
+        } else {
+            Error::msg(format!("{io_context}: {e}"))
+        }
+    })
+}
+
+fn git_detail(stderr: &[u8], fallback: &str) -> String {
+    let stderr = String::from_utf8_lossy(stderr);
+    stderr.lines().last().unwrap_or(fallback).trim().to_string()
+}
+
 /// Resolve the remote default branch tip without a full clone.
 pub fn remote_head(remote: &RemoteSource) -> Result<String, Error> {
-    let output = Command::new("git")
-        .args(["ls-remote", "--quiet", &remote.url, "HEAD"])
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                Error::msg("Git is required for remote skill sources")
-            } else {
-                Error::msg(format!("git ls-remote: {e}"))
-            }
-        })?;
+    let output = run_git(
+        &["ls-remote", "--quiet", &remote.url, "HEAD"],
+        None,
+        true,
+        "git ls-remote",
+        Some("Git is required for remote skill sources"),
+    )?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let detail = stderr
-            .lines()
-            .last()
-            .unwrap_or("git ls-remote failed")
-            .trim();
+        let detail = git_detail(&output.stderr, "git ls-remote failed");
         return Err(Error::msg(format!(
             "Could not resolve {}: {detail}",
             remote.url
@@ -55,30 +100,23 @@ pub fn remote_head(remote: &RemoteSource) -> Result<String, Error> {
 pub fn checkout(remote: &RemoteSource) -> Result<(TempDir, PathBuf, String), Error> {
     let temp = TempDir::new().map_err(|e| Error::msg(format!("temp dir: {e}")))?;
     let repository = temp.path().join("repository");
-    let output = Command::new("git")
-        .args([
+    let output = run_git(
+        &[
             "clone",
             "--quiet",
             "--no-tags",
             &remote.url,
-            repository.to_str().ok_or_else(|| Error::msg("non-utf8 path"))?,
-        ])
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                Error::msg("Git is required for remote skill sources")
-            } else {
-                Error::msg(format!("git clone: {e}"))
-            }
-        })?;
+            repository
+                .to_str()
+                .ok_or_else(|| Error::msg("non-utf8 path"))?,
+        ],
+        None,
+        true,
+        "git clone",
+        Some("Git is required for remote skill sources"),
+    )?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let detail = stderr
-            .lines()
-            .last()
-            .unwrap_or("git clone failed")
-            .trim();
+        let detail = git_detail(&output.stderr, "git clone failed");
         return Err(Error::msg(format!(
             "Could not fetch {}: {detail}",
             remote.url
@@ -92,14 +130,11 @@ pub fn checkout(remote: &RemoteSource) -> Result<(TempDir, PathBuf, String), Err
 }
 
 /// Detached worktree at `revision`; returns `(temp_keep_alive, worktree_path)`.
-pub fn checkout_revision(
-    repository: &Path,
-    revision: &str,
-) -> Result<(TempDir, PathBuf), Error> {
+pub fn checkout_revision(repository: &Path, revision: &str) -> Result<(TempDir, PathBuf), Error> {
     let temp = TempDir::new().map_err(|e| Error::msg(format!("temp dir: {e}")))?;
     let worktree = temp.path().join("worktree");
-    let output = Command::new("git")
-        .args([
+    let output = run_git(
+        &[
             "-C",
             repository
                 .to_str()
@@ -112,22 +147,14 @@ pub fn checkout_revision(
                 .to_str()
                 .ok_or_else(|| Error::msg("non-utf8 path"))?,
             revision,
-        ])
-        .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                Error::msg("Git is required to verify recorded skill revisions")
-            } else {
-                Error::msg(format!("git worktree: {e}"))
-            }
-        })?;
+        ],
+        None,
+        false,
+        "git worktree",
+        Some("Git is required to verify recorded skill revisions"),
+    )?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let detail = stderr
-            .lines()
-            .last()
-            .unwrap_or("revision unavailable")
-            .trim();
+        let detail = git_detail(&output.stderr, "revision unavailable");
         return Err(Error::msg(format!(
             "Could not read recorded revision {revision}: {detail}"
         )));
@@ -139,11 +166,7 @@ pub fn checkout_revision(
 }
 
 pub fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String, Error> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .map_err(|e| Error::msg(format!("git: {e}")))?;
+    let output = run_git(args, Some(cwd), false, "git", None)?;
     if !output.status.success() {
         return Err(Error::msg(format!(
             "git {} failed",
@@ -151,4 +174,26 @@ pub fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String, Error> {
         )));
     }
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn git_command_args_prepend_transport_timeouts() {
+        assert_eq!(
+            git_command_args(&["ls-remote", "--quiet", "https://example.test", "HEAD"]),
+            [
+                "-c",
+                GIT_LOW_SPEED_LIMIT_SETTING,
+                "-c",
+                GIT_LOW_SPEED_TIME_SETTING,
+                "ls-remote",
+                "--quiet",
+                "https://example.test",
+                "HEAD",
+            ]
+        );
+    }
 }

--- a/src/harvest.rs
+++ b/src/harvest.rs
@@ -17,9 +17,9 @@ use std::path::{Path, PathBuf};
 
 use crate::error::Error;
 use crate::home::{ensure_inventory_root, skills_library_path};
+use crate::library::{self, CreateOnlyWrite};
 use crate::paths::{map_io, refuse_symlink};
 use crate::skills;
-use crate::library::{self, CreateOnlyWrite};
 
 /// Relative skill roots under `$HOME` (user/global harness locations).
 ///
@@ -128,9 +128,7 @@ fn resolve_skill_root(path: &Path) -> Result<Option<PathBuf>, Error> {
         let resolved = if target.is_absolute() {
             target
         } else {
-            path.parent()
-                .unwrap_or_else(|| Path::new("."))
-                .join(target)
+            path.parent().unwrap_or_else(|| Path::new(".")).join(target)
         };
         let canonical = match resolved.canonicalize() {
             Ok(p) => p,

--- a/src/home.rs
+++ b/src/home.rs
@@ -16,6 +16,23 @@ pub const LAYOUT_FILENAME: &str = "layout.json";
 pub const LAYOUT_KIND: &str = "tink-skill-inventory";
 pub const BY_PROJECT: &str = "by-project";
 
+/// Project agent directory (`.agents`) — the single owner of this layout decision.
+pub const PROJECT_AGENTS_DIR: &str = ".agents";
+/// Project installed-skill root (`.agents/skills`).
+pub const PROJECT_SKILLS_DIR: &str = "skills";
+
+/// Path to a project's agent directory (`.agents`).
+pub fn project_agents_path(project_root: &Path) -> PathBuf {
+    project_root.join(PROJECT_AGENTS_DIR)
+}
+
+/// Path to a project's installed skill root (`.agents/skills`).
+pub fn project_skills_path(project_root: &Path) -> PathBuf {
+    project_root
+        .join(PROJECT_AGENTS_DIR)
+        .join(PROJECT_SKILLS_DIR)
+}
+
 const HOME_README: &str = "\
 # Tink home (`~/.tink`)
 
@@ -210,7 +227,12 @@ mod tests {
         )
         .unwrap();
         ensure_inventory_root(Some(&root)).unwrap();
-        assert!(by_project_path(&root).join("app").join("meta.json").is_file());
+        assert!(
+            by_project_path(&root)
+                .join("app")
+                .join("meta.json")
+                .is_file()
+        );
         assert!(!root.join("skills").join(BY_PROJECT).exists());
     }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -92,12 +92,7 @@ fn opt_in_zen(explicit: Option<bool>) -> Result<bool, Error> {
         zen
     );
     let hint = format!("{r} = print {zen} without adding it");
-    let choices = format!(
-        "[{}/{}/{}] ",
-        style.accent("y"),
-        style.accent("N"),
-        r
-    );
+    let choices = format!("[{}/{}/{}] ", style.accent("y"), style.accent("N"), r);
     loop {
         println!("{hint}");
         print!("{question} {choices}");
@@ -157,8 +152,8 @@ fn write_zen(project_root: &Path) -> Result<bool, Error> {
 
 /// Create `.agents/skills/`, optionally ZEN/tink-skills/manage-tink, and ensure home root.
 pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitReport, Error> {
-    let agents = project_root.join(".agents");
-    let skills = agents.join("skills");
+    let agents = crate::home::project_agents_path(project_root);
+    let skills = crate::home::project_skills_path(project_root);
     let readme = skills.join("README.md");
 
     require_directory(&agents)?;
@@ -237,8 +232,8 @@ pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitRep
 
 /// Bootstrap used by `add` — skills dir + home only, no prompts or bundled skills.
 pub fn ensure_project_layout(project_root: &Path) -> Result<(), Error> {
-    let agents = project_root.join(".agents");
-    let skills = agents.join("skills");
+    let agents = crate::home::project_agents_path(project_root);
+    let skills = crate::home::project_skills_path(project_root);
     let readme = skills.join("README.md");
 
     require_directory(&agents)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod git;
 mod harvest;
 mod home;
 mod init;
+mod library;
 mod manage_tink;
 mod paths;
 mod provenance;
@@ -18,7 +19,6 @@ mod refresh;
 mod remove;
 mod skills;
 mod sources;
-mod library;
 mod style;
 mod templates;
 mod update;
@@ -178,9 +178,7 @@ fn dispatch(cli: Cli, cwd: PathBuf) -> Result<(), Error> {
 
 fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
     match command {
-        SkillCommand::Add { source, skill } => {
-            dispatch_skill_add(cwd, &source, skill.as_deref())
-        }
+        SkillCommand::Add { source, skill } => dispatch_skill_add(cwd, &source, skill.as_deref()),
         SkillCommand::List { catalog, library } => {
             if catalog {
                 dispatch_skill_list_catalog()

--- a/src/library.rs
+++ b/src/library.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::Error;
-use crate::home::{ensure_inventory_root, skills_library_path, BY_PROJECT};
+use crate::home::{BY_PROJECT, ensure_inventory_root, skills_library_path};
 use crate::paths::{map_io, mkdir_p, refuse_symlink};
 use crate::provenance::{self, Provenance};
 use crate::skills::{self, PreflightOutcome, Skill};
@@ -127,7 +127,7 @@ pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), 
                 && skills::skill_contents_equal_except(
                     &target,
                     &skill.path,
-                    &[".tink-source.json"],
+                    &[provenance::SIDECAR_FILE],
                 )?
             {
                 Ok((target, CreateOnlyWrite::Unchanged))
@@ -142,10 +142,7 @@ pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), 
 }
 
 /// When the library already holds the exact tree we would install, return it.
-pub fn matching(
-    skill: &Skill,
-    provenance: Option<&Provenance>,
-) -> Result<Option<Skill>, Error> {
+pub fn matching(skill: &Skill, provenance: Option<&Provenance>) -> Result<Option<Skill>, Error> {
     let library = library_root(None)?;
     let target = library.join(&skill.name);
     if !target.is_dir() {
@@ -241,7 +238,7 @@ fn tracks_project(library_skill: &Path, project_skill: &Path) -> Result<bool, Er
         return Ok(true);
     }
     // Allow a missing/different receipt when the skill body still matches.
-    skills::skill_contents_equal_except(library_skill, project_skill, &[".tink-source.json"])
+    skills::skill_contents_equal_except(library_skill, project_skill, &[provenance::SIDECAR_FILE])
 }
 
 /// Before refreshing a project skill, ensure the library can accept `new`
@@ -452,4 +449,3 @@ mod tests {
         assert!(path.join(".tink-source.json").is_file());
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,19 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use tink::{run, Cli};
+
+use tink::{Cli, run};
 
 fn main() -> ExitCode {
+    // Parse first so --help / --version work when the process has no cwd
+    // (e.g. shell still open after `rm -rf` of the working directory).
     let cli = Cli::parse();
-    run(cli, std::env::current_dir().expect("current directory"))
+    let cwd = match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(err) => {
+            eprintln!("Failed to resolve current directory: {err}");
+            return ExitCode::from(1);
+        }
+    };
+    run(cli, cwd)
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -7,7 +7,10 @@ use crate::error::Error;
 
 pub fn refuse_symlink(path: &Path) -> Result<(), Error> {
     if path.is_symlink() {
-        return Err(Error::msg(format!("Refusing to follow symlink: {}", path.display())));
+        return Err(Error::msg(format!(
+            "Refusing to follow symlink: {}",
+            path.display()
+        )));
     }
     Ok(())
 }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -11,6 +11,10 @@ use crate::sources;
 
 pub type Provenance = BTreeMap<String, String>;
 
+/// Receipt file name written beside a skill tree (`.tink-source.json`).
+/// Single owner of this decision; `skills` and `library` reference it here.
+pub const SIDECAR_FILE: &str = ".tink-source.json";
+
 /// Stable key order (`source`, `revision`, `path`) so preflight byte-compares
 /// of `.tink-source.json` stay deterministic.
 pub fn to_bytes(provenance: &Provenance) -> Result<Vec<u8>, Error> {
@@ -37,7 +41,7 @@ pub fn to_bytes(provenance: &Provenance) -> Result<Vec<u8>, Error> {
 
 /// Load and validate a skill's `.tink-source.json`, if present.
 pub fn read(skill: &Skill) -> Result<Option<Provenance>, Error> {
-    let sidecar = skill.path.join(".tink-source.json");
+    let sidecar = skill.path.join(SIDECAR_FILE);
     if !sidecar.exists() && !sidecar.is_symlink() {
         return Ok(None);
     }
@@ -49,8 +53,8 @@ pub fn read(skill: &Skill) -> Result<Option<Provenance>, Error> {
         )));
     }
     let text = fs::read_to_string(&sidecar).map_err(|e| map_io(&sidecar, e))?;
-    let value: serde_json::Value =
-        serde_json::from_str(&text).map_err(|e| Error::msg(format!("Invalid provenance JSON: {e}")))?;
+    let value: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| Error::msg(format!("Invalid provenance JSON: {e}")))?;
     let obj = value
         .as_object()
         .ok_or_else(|| Error::msg("Provenance must contain exactly source, revision, and path"))?;

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -7,10 +7,12 @@ use crate::catalog;
 use crate::check;
 use crate::error::Error;
 use crate::git;
+use crate::library;
 use crate::provenance::{self, Provenance};
 use crate::skills::{self, Skill};
 use crate::sources;
-use crate::library;
+
+use tempfile::TempDir;
 
 fn skill_at(repository: &Path, source_path: &str) -> Result<PathBuf, Error> {
     let mut path = repository.to_path_buf();
@@ -30,6 +32,18 @@ fn skill_at(repository: &Path, source_path: &str) -> Result<PathBuf, Error> {
         )));
     }
     Ok(path)
+}
+
+fn checkout_reference_skill(
+    repository: &Path,
+    tip_revision: &str,
+    recorded_revision: &str,
+) -> Result<(PathBuf, Option<TempDir>), Error> {
+    if tip_revision == recorded_revision {
+        return Ok((repository.to_path_buf(), None));
+    }
+    let (temp, checkout) = git::checkout_revision(repository, recorded_revision)?;
+    Ok((checkout, Some(temp)))
 }
 
 /// Returns whether the installed skill tree changed (receipt-only bumps are false).
@@ -52,14 +66,11 @@ fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
         .map_err(|e| Error::msg(format!("repository: {e}")))?;
     let source_is_repository_root = provenance["path"] == ".";
 
-    let mut _old_temp = None;
-    let old_repository = if current_revision == provenance["revision"] {
-        current_repository.clone()
-    } else {
-        let (temp, path) = git::checkout_revision(&current_repository, &provenance["revision"])?;
-        _old_temp = Some(temp);
-        path
-    };
+    let (old_repository, _old_checkout) = checkout_reference_skill(
+        &current_repository,
+        &current_revision,
+        &provenance["revision"],
+    )?;
 
     let old_skill = skills::read_skill(
         &skill_at(&old_repository, &provenance["path"])?,
@@ -116,7 +127,9 @@ pub fn refresh_skill(root: &Path, name: &str) -> Result<bool, Error> {
         .get(name)
         .ok_or_else(|| Error::msg(format!("Installed skill not found: {name}")))?;
     match refresh_one(installed)? {
-        None => Err(Error::msg(format!("Local skill has no remote source: {name}"))),
+        None => Err(Error::msg(format!(
+            "Local skill has no remote source: {name}"
+        ))),
         Some(changed) => {
             catalog::deposit_skill(root, name)?;
             Ok(changed)

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -21,8 +21,8 @@ pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Err
         return Err(Error::msg(format!("Invalid skill name: {name}")));
     }
 
-    let agents = project_root.join(".agents");
-    let skills_root = agents.join("skills");
+    let agents = crate::home::project_agents_path(project_root);
+    let skills_root = crate::home::project_skills_path(project_root);
     let target = skills_root.join(name);
 
     if agents.exists() || agents.is_symlink() {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -26,11 +26,19 @@ pub fn valid_skill_name(name: &str) -> bool {
     let Some(first) = parts.next() else {
         return false;
     };
-    if first.is_empty() || !first.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()) {
+    if first.is_empty()
+        || !first
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
         return false;
     }
     for part in parts {
-        if part.is_empty() || !part.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()) {
+        if part.is_empty()
+            || !part
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        {
             return false;
         }
     }
@@ -101,13 +109,13 @@ pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Er
     let name = frontmatter_value(frontmatter, "name").unwrap_or_default();
     let description = frontmatter_value(frontmatter, "description").unwrap_or_default();
     if !valid_skill_name(&name) {
-        return Err(Error::msg(format!("Invalid skill name in {}", skill_file.display())));
+        return Err(Error::msg(format!(
+            "Invalid skill name in {}",
+            skill_file.display()
+        )));
     }
     if require_directory_name {
-        let dir_name = path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("");
+        let dir_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
         if name != dir_name {
             return Err(Error::msg(format!(
                 "Skill name {name:?} must match directory {dir_name:?}"
@@ -127,16 +135,17 @@ pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Er
 }
 
 pub fn discover(source: &Path) -> Result<Vec<Skill>, Error> {
-    let source = source
-        .canonicalize()
-        .map_err(|e| map_io(source, e))?;
+    let source = source.canonicalize().map_err(|e| map_io(source, e))?;
     if source.join("SKILL.md").exists() {
         return Ok(vec![read_skill(&source, false)?]);
     }
     let skills_root = source.join("skills");
     refuse_symlink(&skills_root)?;
     if !skills_root.is_dir() {
-        return Err(Error::msg(format!("No skill found at {}", source.display())));
+        return Err(Error::msg(format!(
+            "No skill found at {}",
+            source.display()
+        )));
     }
     let mut entries: Vec<_> = fs::read_dir(&skills_root)
         .map_err(|e| map_io(&skills_root, e))?
@@ -150,7 +159,10 @@ pub fn discover(source: &Path) -> Result<Vec<Skill>, Error> {
         skills.push(read_skill(&path, true)?);
     }
     if skills.is_empty() {
-        return Err(Error::msg(format!("No skill found at {}", source.display())));
+        return Err(Error::msg(format!(
+            "No skill found at {}",
+            source.display()
+        )));
     }
     Ok(skills)
 }
@@ -299,7 +311,11 @@ pub enum PreflightOutcome {
 
 impl PreflightOutcome {
     /// Project installs refuse divergence; keep the historical error text.
-    pub fn require_compatible(self, skill_name: &str, destination_root: &Path) -> Result<Self, Error> {
+    pub fn require_compatible(
+        self,
+        skill_name: &str,
+        destination_root: &Path,
+    ) -> Result<Self, Error> {
         match self {
             Self::Divergent => Err(Error::msg(format!(
                 "Refusing to overwrite existing skill: {}",
@@ -318,14 +334,14 @@ pub fn preflight_install(
 ) -> Result<PreflightOutcome, Error> {
     let mut expected = require_safe_tree(&skill.path)?;
     if let Some(provenance) = provenance {
-        if expected.contains_key(".tink-source.json") {
+        if expected.contains_key(provenance::SIDECAR_FILE) {
             return Err(Error::msg(format!(
                 "Remote skill already contains reserved .tink-source.json: {}",
                 skill.path.display()
             )));
         }
         expected.insert(
-            ".tink-source.json".into(),
+            provenance::SIDECAR_FILE.into(),
             EntryKind::File(provenance::to_bytes(provenance)?),
         );
     }
@@ -362,7 +378,7 @@ pub fn install_local(
     let staged = staging.path().join(&skill.name);
     copy_skill_tree(&skill.path, &staged, &[".git"])?;
     if let Some(provenance) = provenance {
-        provenance::write_file(&staged.join(".tink-source.json"), provenance)?;
+        provenance::write_file(&staged.join(provenance::SIDECAR_FILE), provenance)?;
     }
     fs::rename(&staged, &target).map_err(|e| map_io(&target, e))?;
     Ok((target, true))
@@ -390,13 +406,13 @@ pub fn replace_verified(
     let staged = staging.path().join("new");
     let backup = staging.path().join("old");
     copy_skill_tree(&skill.path, &staged, &[".git"])?;
-    if staged.join(".tink-source.json").exists() {
+    if staged.join(provenance::SIDECAR_FILE).exists() {
         return Err(Error::msg(format!(
             "Remote skill contains reserved .tink-source.json: {}",
             skill.path.display()
         )));
     }
-    provenance::write_file(&staged.join(".tink-source.json"), provenance)?;
+    provenance::write_file(&staged.join(provenance::SIDECAR_FILE), provenance)?;
     fs::rename(&target, &backup).map_err(|e| map_io(&target, e))?;
     if let Err(err) = fs::rename(&staged, &target) {
         let _ = fs::rename(&backup, &target);

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -38,9 +38,7 @@ pub fn parse_remote(value: &str) -> Result<RemoteSource, Error> {
         }
     }
 
-    let err = || {
-        Error::msg("Remote sources must be public GitHub HTTPS URLs or owner/repository")
-    };
+    let err = || Error::msg("Remote sources must be public GitHub HTTPS URLs or owner/repository");
 
     let url = value.parse::<url_lite::Url>().map_err(|_| err())?;
     if url.scheme != "https" || url.host.as_deref() != Some("github.com") {

--- a/src/style.rs
+++ b/src/style.rs
@@ -69,19 +69,31 @@ impl CliStyle {
     }
 
     pub fn success(self, text: impl std::fmt::Display) -> String {
-        self.paint(Style::new().fg_color(Some(GREEN)).effects(Effects::BOLD), text)
+        self.paint(
+            Style::new().fg_color(Some(GREEN)).effects(Effects::BOLD),
+            text,
+        )
     }
 
     pub fn error(self, text: impl std::fmt::Display) -> String {
-        self.paint(Style::new().fg_color(Some(RED)).effects(Effects::BOLD), text)
+        self.paint(
+            Style::new().fg_color(Some(RED)).effects(Effects::BOLD),
+            text,
+        )
     }
 
     pub fn warn(self, text: impl std::fmt::Display) -> String {
-        self.paint(Style::new().fg_color(Some(YELLOW)).effects(Effects::BOLD), text)
+        self.paint(
+            Style::new().fg_color(Some(YELLOW)).effects(Effects::BOLD),
+            text,
+        )
     }
 
     pub fn muted(self, text: impl std::fmt::Display) -> String {
-        self.paint(Style::new().fg_color(Some(WHITE)).effects(Effects::DIMMED), text)
+        self.paint(
+            Style::new().fg_color(Some(WHITE)).effects(Effects::DIMMED),
+            text,
+        )
     }
 
     pub fn accent(self, text: impl std::fmt::Display) -> String {
@@ -90,7 +102,10 @@ impl CliStyle {
 
     /// Skill names — magenta so they read apart from cyan paths/accents.
     pub fn skill(self, text: impl std::fmt::Display) -> String {
-        self.paint(Style::new().fg_color(Some(MAGENTA)).effects(Effects::BOLD), text)
+        self.paint(
+            Style::new().fg_color(Some(MAGENTA)).effects(Effects::BOLD),
+            text,
+        )
     }
 
     /// Per-character rainbow (init ZEN tease). Plain text when styling is off.

--- a/src/update.rs
+++ b/src/update.rs
@@ -13,6 +13,47 @@ use crate::style::CliStyle;
 pub const DEFAULT_RELEASES_API: &str =
     "https://api.github.com/repos/jon-devlapaz/tink/releases/latest";
 
+const CURL_CONNECT_TIMEOUT_SECONDS: &str = "5";
+/// Bound for tiny JSON metadata (releases API).
+const CURL_METADATA_MAX_TIME_SECONDS: &str = "30";
+/// Bound for release archive download (can be multi-MB on slow links).
+const CURL_ASSET_MAX_TIME_SECONDS: &str = "300";
+const CURL_RETRY_COUNT: &str = "2";
+const CURL_RETRY_DELAY_SECONDS: &str = "1";
+
+#[derive(Debug, Clone, Copy)]
+enum CurlBudget {
+    Metadata,
+    Asset,
+}
+
+impl CurlBudget {
+    fn max_time_seconds(self) -> &'static str {
+        match self {
+            CurlBudget::Metadata => CURL_METADATA_MAX_TIME_SECONDS,
+            CurlBudget::Asset => CURL_ASSET_MAX_TIME_SECONDS,
+        }
+    }
+}
+
+/// Full curl argv for a download (transport flags wired in one place).
+fn curl_command_args<'a>(budget: CurlBudget, url: &'a str, dest: &'a Path) -> Vec<&'a str> {
+    vec![
+        "-fsSL",
+        "--connect-timeout",
+        CURL_CONNECT_TIMEOUT_SECONDS,
+        "--max-time",
+        budget.max_time_seconds(),
+        "--retry",
+        CURL_RETRY_COUNT,
+        "--retry-delay",
+        CURL_RETRY_DELAY_SECONDS,
+        url,
+        "-o",
+        dest.to_str().unwrap_or(""),
+    ]
+}
+
 /// Host target triple for the binary we are running.
 pub fn host_target() -> &'static str {
     if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
@@ -97,10 +138,12 @@ fn require_tool(name: &str) -> Result<(), Error> {
     }
 }
 
-fn curl_to_file(url: &str, dest: &Path) -> Result<(), Error> {
+fn curl_to_file(budget: CurlBudget, url: &str, dest: &Path) -> Result<(), Error> {
+    if dest.to_str().is_none() {
+        return Err(Error::msg("non-utf8 download path"));
+    }
     let output = Command::new("curl")
-        .args(["-fsSL", url, "-o"])
-        .arg(dest)
+        .args(curl_command_args(budget, url, dest))
         .output()
         .map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
@@ -150,13 +193,13 @@ fn extract_tink_binary(archive: &Path, into: &Path) -> Result<PathBuf, Error> {
 }
 
 fn replace_binary(current: &Path, new_bin: &Path) -> Result<(), Error> {
-    let parent = current
-        .parent()
-        .ok_or_else(|| Error::msg(format!("cannot update {}: no parent directory", current.display())))?;
-    let staging = parent.join(format!(
-        ".tink-update-{}",
-        std::process::id()
-    ));
+    let parent = current.parent().ok_or_else(|| {
+        Error::msg(format!(
+            "cannot update {}: no parent directory",
+            current.display()
+        ))
+    })?;
+    let staging = parent.join(format!(".tink-update-{}", std::process::id()));
     fs::copy(new_bin, &staging).map_err(|e| {
         Error::msg(format!(
             "cannot write {} ({}). Re-run install.sh or fix permissions.",
@@ -167,9 +210,10 @@ fn replace_binary(current: &Path, new_bin: &Path) -> Result<(), Error> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)).map_err(|e| {
-            Error::msg(format!("chmod {}: {e}", staging.display()))
-        })?;
+        if let Err(e) = fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)) {
+            let _ = fs::remove_file(&staging);
+            return Err(Error::msg(format!("chmod {}: {e}", staging.display())));
+        }
     }
     fs::rename(&staging, current).map_err(|e| {
         let _ = fs::remove_file(&staging);
@@ -186,9 +230,7 @@ fn replace_binary(current: &Path, new_bin: &Path) -> Result<(), Error> {
 pub fn update_binary() -> Result<UpdateReport, Error> {
     let target = host_target();
     if target == "unsupported" {
-        return Err(Error::msg(
-            "tink update does not support this platform yet",
-        ));
+        return Err(Error::msg("tink update does not support this platform yet"));
     }
     require_tool("curl")?;
     require_tool("tar")?;
@@ -196,8 +238,9 @@ pub fn update_binary() -> Result<UpdateReport, Error> {
     let api = releases_api_url();
     let temp = TempDir::new().map_err(|e| Error::msg(format!("temp dir: {e}")))?;
     let meta_path = temp.path().join("release.json");
-    curl_to_file(&api, &meta_path)?;
-    let json = fs::read_to_string(&meta_path).map_err(|e| Error::msg(format!("read metadata: {e}")))?;
+    curl_to_file(CurlBudget::Metadata, &api, &meta_path)?;
+    let json =
+        fs::read_to_string(&meta_path).map_err(|e| Error::msg(format!("read metadata: {e}")))?;
     let asset = select_release_asset(&json, target)?;
 
     let current_version = env!("CARGO_PKG_VERSION");
@@ -209,7 +252,7 @@ pub fn update_binary() -> Result<UpdateReport, Error> {
     }
 
     let archive = temp.path().join("tink.tgz");
-    curl_to_file(&asset.download_url, &archive)?;
+    curl_to_file(CurlBudget::Asset, &asset.download_url, &archive)?;
     let extracted = extract_tink_binary(&archive, temp.path())?;
     let current = env::current_exe().map_err(|e| Error::msg(format!("current exe: {e}")))?;
     // Resolve symlinks so we replace the real binary (e.g. cargo install shim).
@@ -225,8 +268,15 @@ pub fn update_binary() -> Result<UpdateReport, Error> {
 
 #[derive(Debug)]
 pub enum UpdateReport {
-    AlreadyLatest { version: String, path: PathBuf },
-    Updated { from: String, to: String, path: PathBuf },
+    AlreadyLatest {
+        version: String,
+        path: PathBuf,
+    },
+    Updated {
+        from: String,
+        to: String,
+        path: PathBuf,
+    },
 }
 
 pub fn print_report(report: &UpdateReport) {
@@ -247,7 +297,10 @@ pub fn print_report(report: &UpdateReport) {
                 style.muted(format!("v{from}")),
                 style.accent(format!("v{to}"))
             );
-            println!("{}", style.muted(format!("Installed to {}", path.display())));
+            println!(
+                "{}",
+                style.muted(format!("Installed to {}", path.display()))
+            );
         }
     }
 }
@@ -255,6 +308,37 @@ pub fn print_report(report: &UpdateReport) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn curl_command_args_wire_timeouts_retries_and_dest() {
+        let dest = Path::new("/tmp/tink-release.json");
+        assert_eq!(
+            curl_command_args(CurlBudget::Metadata, "https://example.test/meta", dest),
+            [
+                "-fsSL",
+                "--connect-timeout",
+                CURL_CONNECT_TIMEOUT_SECONDS,
+                "--max-time",
+                CURL_METADATA_MAX_TIME_SECONDS,
+                "--retry",
+                CURL_RETRY_COUNT,
+                "--retry-delay",
+                CURL_RETRY_DELAY_SECONDS,
+                "https://example.test/meta",
+                "-o",
+                "/tmp/tink-release.json",
+            ]
+        );
+        let archive = Path::new("/tmp/tink.tgz");
+        let asset_args =
+            curl_command_args(CurlBudget::Asset, "https://example.test/tink.tgz", archive);
+        let max_time_idx = asset_args
+            .iter()
+            .position(|a| *a == "--max-time")
+            .expect("--max-time present");
+        assert_eq!(asset_args[max_time_idx + 1], CURL_ASSET_MAX_TIME_SECONDS);
+        assert_ne!(CURL_METADATA_MAX_TIME_SECONDS, CURL_ASSET_MAX_TIME_SECONDS);
+    }
 
     #[test]
     fn asset_name_matches_release_layout() {

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -1,7 +1,7 @@
 //! Acceptance rows from ACCEPTANCE.md. These must fail until each row is implemented.
 
-use assert_cmd::cargo::cargo_bin_cmd;
 use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -121,7 +121,10 @@ fn commit_all(path: &Path, message: &str) -> String {
 }
 
 fn github_redirect(local_repo: &Path, public_url: &str) -> Vec<(String, String)> {
-    let file_url = format!("file://{}", local_repo.canonicalize().expect("canon").display());
+    let file_url = format!(
+        "file://{}",
+        local_repo.canonicalize().expect("canon").display()
+    );
     vec![
         ("GIT_CONFIG_COUNT".into(), "1".into()),
         (
@@ -227,7 +230,10 @@ fn i7_init_no_manage_tink_skips_embedded_skill() {
 fn i8_relative_tink_home_resolves_absolute_not_nested() {
     // I8: relative TINK_HOME is absolutized against cwd; must not nest under project.
     let root = tempfile::TempDir::new().unwrap();
-    let root = root.path().canonicalize().unwrap_or_else(|_| root.path().to_path_buf());
+    let root = root
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| root.path().to_path_buf());
     let project = root.join("app");
     fs::create_dir_all(&project).unwrap();
     let expected_home = root.join("tink-home");
@@ -240,7 +246,9 @@ fn i8_relative_tink_home_resolves_absolute_not_nested() {
         .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
         .assert()
         .success()
-        .stdout(predicate::str::contains(expected_home.display().to_string()));
+        .stdout(predicate::str::contains(
+            expected_home.display().to_string(),
+        ));
 
     assert!(
         expected_home.join("layout.json").is_file(),
@@ -307,8 +315,8 @@ fn a3_add_refuses_overwrite_when_diverged() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Refusing to overwrite"));
-    let body = fs::read_to_string(Workspace::skill_path(&project, "demo-skill").join("SKILL.md"))
-        .unwrap();
+    let body =
+        fs::read_to_string(Workspace::skill_path(&project, "demo-skill").join("SKILL.md")).unwrap();
     assert!(body.contains("original"));
     assert!(!body.contains("changed"));
 }
@@ -399,13 +407,13 @@ fn a6_add_repairs_divergent_library_and_installs_project() {
         .assert()
         .success()
         .stderr(predicate::str::contains("Updated home copy of"));
-    assert!(Workspace::skill_path(&other, "demo-skill")
-        .join("SKILL.md")
-        .is_file());
-    let project = fs::read_to_string(
-        Workspace::skill_path(&other, "demo-skill").join("SKILL.md"),
-    )
-    .unwrap();
+    assert!(
+        Workspace::skill_path(&other, "demo-skill")
+            .join("SKILL.md")
+            .is_file()
+    );
+    let project =
+        fs::read_to_string(Workspace::skill_path(&other, "demo-skill").join("SKILL.md")).unwrap();
     assert!(project.contains("from other"));
     let archived = fs::read_to_string(ws.library_skill("demo-skill").join("SKILL.md")).unwrap();
     assert!(archived.contains("from other"));
@@ -449,13 +457,14 @@ fn a8_add_uses_library_when_remote_tip_matches() {
         .assert()
         .success()
         .stdout(predicate::str::contains("from library"));
-    assert!(Workspace::skill_path(&other, "root-skill")
-        .join(".tink-source.json")
-        .is_file());
-    let receipt = fs::read_to_string(
-        Workspace::skill_path(&other, "root-skill").join(".tink-source.json"),
-    )
-    .unwrap();
+    assert!(
+        Workspace::skill_path(&other, "root-skill")
+            .join(".tink-source.json")
+            .is_file()
+    );
+    let receipt =
+        fs::read_to_string(Workspace::skill_path(&other, "root-skill").join(".tink-source.json"))
+            .unwrap();
     assert!(
         receipt.contains("\"path\": \".\"") || receipt.contains("\"path\":\".\""),
         "{receipt}"
@@ -558,10 +567,9 @@ fn r5_add_root_level_skill_writes_dot_path_check_and_refresh() {
     }
     add.assert().success();
 
-    let receipt = fs::read_to_string(
-        Workspace::skill_path(&project, "root-skill").join(".tink-source.json"),
-    )
-    .unwrap();
+    let receipt =
+        fs::read_to_string(Workspace::skill_path(&project, "root-skill").join(".tink-source.json"))
+            .unwrap();
     assert!(
         receipt.contains("\"path\": \".\"") || receipt.contains("\"path\":\".\""),
         "expected path \".\": {receipt}"
@@ -586,12 +594,60 @@ fn r5_add_root_level_skill_writes_dot_path_check_and_refresh() {
     let skill_md =
         fs::read_to_string(Workspace::skill_path(&project, "root-skill").join("SKILL.md")).unwrap();
     assert!(skill_md.contains("v2"), "{skill_md}");
-    let receipt = fs::read_to_string(
-        Workspace::skill_path(&project, "root-skill").join(".tink-source.json"),
-    )
-    .unwrap();
+    let receipt =
+        fs::read_to_string(Workspace::skill_path(&project, "root-skill").join(".tink-source.json"))
+            .unwrap();
     assert!(receipt.contains(&new_rev));
     assert!(receipt.contains("\"path\": \".\"") || receipt.contains("\"path\":\".\""));
+}
+
+#[test]
+fn v3_main_help_works_when_current_directory_is_unavailable_commands_fail() {
+    let ws = Workspace::new();
+    let bad_dir = ws.root.join("vanish-now");
+    fs::create_dir_all(&bad_dir).unwrap();
+
+    let bin = std::env::var_os("CARGO_BIN_EXE_tink").expect("CARGO_BIN_EXE_tink missing");
+
+    // --help must not depend on a live workdir (clap exit after parse succeeds).
+    let help = StdCommand::new("sh")
+        .arg("-c")
+        .arg("cd \"$1\" && rm -rf \"$1\" && \"$2\" --help")
+        .arg("tink-main-current-dir-help")
+        .arg(bad_dir.to_string_lossy().to_string())
+        .arg(&bin)
+        .output()
+        .expect("run help shim");
+    assert!(
+        help.status.success(),
+        "tink --help should succeed without cwd; status={:?} stderr={}",
+        help.status,
+        String::from_utf8_lossy(&help.stderr)
+    );
+    let help_out = String::from_utf8_lossy(&help.stdout);
+    assert!(
+        help_out.contains("Usage") || help_out.contains("Usage:"),
+        "expected help output: {help_out}"
+    );
+
+    // Commands that need a project path still fail closed when cwd is gone.
+    let bad_dir2 = ws.root.join("vanish-cmd");
+    fs::create_dir_all(&bad_dir2).unwrap();
+    let cmd = StdCommand::new("sh")
+        .arg("-c")
+        .arg("cd \"$1\" && rm -rf \"$1\" && \"$2\" skill check")
+        .arg("tink-main-current-dir-cmd")
+        .arg(bad_dir2.to_string_lossy().to_string())
+        .arg(&bin)
+        .output()
+        .expect("run skill check shim");
+    assert!(!cmd.status.success(), "skill check should fail without cwd");
+    let stderr = String::from_utf8_lossy(&cmd.stderr);
+    assert!(
+        stderr.contains("Failed to resolve current directory"),
+        "stderr did not include current directory failure: {stderr}"
+    );
+    assert_eq!(cmd.status.code().unwrap(), 1);
 }
 
 // --- C*: check ---
@@ -633,6 +689,36 @@ fn c3_check_refuses_agents_symlink() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("symlink").or(predicate::str::contains("Symlink")));
+}
+
+#[test]
+fn c4_check_fails_with_corrupt_installed_skill() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+
+    let source = ws.root.join("demo-skill");
+    write_skill(&source, "demo-skill", "ok");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let installed = Workspace::skill_path(&project, "demo-skill");
+    let corrupt = r#"---
+name: mismatch
+description: corrupted metadata
+---
+
+# mismatch
+"#;
+    std::fs::write(installed.join("SKILL.md"), corrupt).expect("corrupt skill");
+
+    ws.cmd(&project)
+        .args(["skill", "check"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Skill name"));
 }
 
 // --- L*: list ---
@@ -687,6 +773,40 @@ fn l3_skill_list_catalog_prints_tsv() {
 }
 
 #[test]
+fn l6_skill_list_catalog_skips_malformed_meta_entries() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+
+    let by_project = ws.inventory.join("catalog").join("by-project");
+    let good = by_project.join("good-project");
+    let malformed = by_project.join("bad-project");
+    fs::create_dir_all(&good).unwrap();
+    fs::create_dir_all(&malformed).unwrap();
+    fs::write(
+        good.join("meta.json"),
+        "{\"name\":\"good-project\",\"root\":\"/tmp/example\",\"skills\":[\"demo-skill\"]}",
+    )
+    .unwrap();
+    fs::write(malformed.join("meta.json"), "{not-json}").unwrap();
+
+    let output = ws
+        .cmd(&project)
+        .args(["skill", "list", "--catalog"])
+        .output()
+        .expect("run skill list --catalog");
+    assert!(
+        output.status.success(),
+        "skill list --catalog should ignore malformed entries"
+    );
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.starts_with("project	root	skill\n"));
+    assert!(out.contains("good-project	/tmp/example	demo-skill"));
+    assert!(out.contains("good-project"));
+    assert!(out.contains("/tmp/example"));
+    assert!(!out.contains("bad-project"));
+}
+
+#[test]
 fn l5_skill_list_rejects_removed_stash_and_home_flags() {
     let ws = Workspace::new();
     let project = ws.project("app");
@@ -697,8 +817,7 @@ fn l5_skill_list_rejects_removed_stash_and_home_flags() {
             .assert()
             .failure()
             .stderr(
-                predicate::str::contains(flag)
-                    .or(predicate::str::contains("unexpected argument")),
+                predicate::str::contains(flag).or(predicate::str::contains("unexpected argument")),
             );
     }
 }
@@ -785,12 +904,13 @@ fn h2_skill_add_library_installs_into_project() {
         .assert()
         .success()
         .stdout(
-            predicate::str::contains("stash-skill")
-                .and(predicate::str::contains("from library")),
+            predicate::str::contains("stash-skill").and(predicate::str::contains("from library")),
         );
-    assert!(Workspace::skill_path(&app, "stash-skill")
-        .join("SKILL.md")
-        .is_file());
+    assert!(
+        Workspace::skill_path(&app, "stash-skill")
+            .join("SKILL.md")
+            .is_file()
+    );
     ws.assert_cataloged("app", "stash-skill");
 }
 
@@ -842,8 +962,8 @@ fn h4_skill_add_library_refuses_overwrite_when_diverged() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Refusing to overwrite"));
-    let body = fs::read_to_string(Workspace::skill_path(&app, "demo-skill").join("SKILL.md"))
-        .unwrap();
+    let body =
+        fs::read_to_string(Workspace::skill_path(&app, "demo-skill").join("SKILL.md")).unwrap();
     assert!(body.contains("project local body"));
 }
 
@@ -929,7 +1049,11 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
         "harness body",
     );
     // Pre-seed divergent library.
-    write_skill(ws.library_skill("demo-skill").as_path(), "demo-skill", "stash body");
+    write_skill(
+        ws.library_skill("demo-skill").as_path(),
+        "demo-skill",
+        "stash body",
+    );
     let before = fs::read_to_string(ws.library_skill("demo-skill").join("SKILL.md")).unwrap();
 
     ws.cmd(&project)
@@ -940,7 +1064,10 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
         .stderr(predicate::str::contains("Skipped").and(predicate::str::contains("demo-skill")));
 
     let after = fs::read_to_string(ws.library_skill("demo-skill").join("SKILL.md")).unwrap();
-    assert_eq!(before, after, "create-only must not repair divergent library");
+    assert_eq!(
+        before, after,
+        "create-only must not repair divergent library"
+    );
     assert!(after.contains("stash body"));
 }
 
@@ -957,7 +1084,10 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
         "ok",
     );
     write_skill(
-        &project.join(".agents").join("skills").join("nested-home-skill"),
+        &project
+            .join(".agents")
+            .join("skills")
+            .join("nested-home-skill"),
         "nested-home-skill",
         "under tink home workspace",
     );
@@ -993,13 +1123,14 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
             predicate::str::contains("good-skill")
                 .and(predicate::str::contains("nested-home-skill")),
         )
-        .stderr(
-            predicate::str::contains("bad-skill")
-                .and(predicate::str::contains("from-home")),
-        );
+        .stderr(predicate::str::contains("bad-skill").and(predicate::str::contains("from-home")));
 
     assert!(ws.library_skill("good-skill").join("SKILL.md").is_file());
-    assert!(ws.library_skill("nested-home-skill").join("SKILL.md").is_file());
+    assert!(
+        ws.library_skill("nested-home-skill")
+            .join("SKILL.md")
+            .is_file()
+    );
     assert!(!ws.library_skill("bad-skill").exists());
     let home_body = fs::read_to_string(ws.library_skill("from-home").join("SKILL.md")).unwrap();
     assert!(home_body.contains("stash resident"));
@@ -1011,16 +1142,21 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
 fn v1_skill_add_installs_local_skill() {
     let ws = Workspace::new();
     let project = ws.project("app");
-    ws.cmd(&project).args(["init", "--no-manage-tink"]).assert().success();
+    ws.cmd(&project)
+        .args(["init", "--no-manage-tink"])
+        .assert()
+        .success();
     let source = ws.root.join("demo-skill");
     write_skill(&source, "demo-skill", "via skill add");
     ws.cmd(&project)
         .args(["skill", "add", source.to_str().unwrap()])
         .assert()
         .success();
-    assert!(Workspace::skill_path(&project, "demo-skill")
-        .join("SKILL.md")
-        .is_file());
+    assert!(
+        Workspace::skill_path(&project, "demo-skill")
+            .join("SKILL.md")
+            .is_file()
+    );
 }
 
 #[test]
@@ -1228,7 +1364,11 @@ fn p5_refresh_refuses_divergent_library() {
         add.env(k, v);
     }
     add.assert().success();
-    write_skill(ws.library_skill("remote-skill").as_path(), "remote-skill", "other");
+    write_skill(
+        ws.library_skill("remote-skill").as_path(),
+        "remote-skill",
+        "other",
+    );
 
     write_skill(
         &remote.join("skills").join("remote-skill"),
@@ -1294,7 +1434,11 @@ fn p7_refresh_repairs_stale_archive_when_project_already_new() {
     refresh.assert().success();
 
     // Simulate failed library deposit: project at v2, library rolled back to v1.
-    write_skill(ws.library_skill("remote-skill").as_path(), "remote-skill", "v1");
+    write_skill(
+        ws.library_skill("remote-skill").as_path(),
+        "remote-skill",
+        "v1",
+    );
 
     let mut repair = ws.cmd(&project);
     repair.args(["skill", "refresh", "remote-skill"]);
@@ -1506,7 +1650,11 @@ fn x3_remove_refuses_agents_symlink() {
     let project = ws.project("app");
     let real = ws.root.join("real-agents");
     fs::create_dir_all(real.join("skills").join("demo-skill")).unwrap();
-    write_skill(&real.join("skills").join("demo-skill"), "demo-skill", "body");
+    write_skill(
+        &real.join("skills").join("demo-skill"),
+        "demo-skill",
+        "body",
+    );
     std::os::unix::fs::symlink(&real, project.join(".agents")).unwrap();
     ws.cmd(&project)
         .args(["skill", "remove", "demo-skill"])
@@ -1514,7 +1662,12 @@ fn x3_remove_refuses_agents_symlink() {
         .failure()
         .stderr(predicate::str::contains("symlink").or(predicate::str::contains("Symlink")));
     assert!(project.join(".agents").is_symlink());
-    assert!(real.join("skills").join("demo-skill").join("SKILL.md").is_file());
+    assert!(
+        real.join("skills")
+            .join("demo-skill")
+            .join("SKILL.md")
+            .is_file()
+    );
 }
 
 #[test]
@@ -1565,8 +1718,7 @@ fn x5_manage_tink_documents_remove_and_catalog_sync() {
         "manage-tink must teach bare-name library promote, not add --library: {skill_md}"
     );
     assert!(
-        commands.contains("tink skill add NAME")
-            && !commands.contains("add --library"),
+        commands.contains("tink skill add NAME") && !commands.contains("add --library"),
         "commands.md must list bare-name library promote, not add --library: {commands}"
     );
     assert!(
@@ -1589,6 +1741,30 @@ fn x5_manage_tink_documents_remove_and_catalog_sync() {
                 || commands.contains("updates")),
         "commands.md must describe catalog sync on remove/destroy: {commands}"
     );
+}
+
+#[test]
+fn x6_remove_fails_when_catalog_meta_is_malformed() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    let source = ws.root.join("demo-skill");
+    write_skill(&source, "demo-skill", "body");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    fs::write(ws.catalog_meta("app"), "{not-json}").unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "remove", "demo-skill"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid catalog meta"));
+
+    assert!(Workspace::skill_path(&project, "demo-skill").is_dir());
+    assert!(ws.library_skill("demo-skill").join("SKILL.md").is_file());
 }
 
 // --- S*: safety ---
@@ -1635,7 +1811,10 @@ fn package_version() -> String {
 
 fn write_release_fixture(dir: &Path, version: &str, binary_src: &Path) -> PathBuf {
     let target = host_release_target();
-    assert_ne!(target, "unsupported", "update fixtures need a supported host");
+    assert_ne!(
+        target, "unsupported",
+        "update fixtures need a supported host"
+    );
     let asset = format!("tink-{version}-{target}.tar.gz");
     let stage = dir.join("stage");
     fs::create_dir_all(&stage).unwrap();
@@ -1750,10 +1929,7 @@ fn u3_update_replaces_binary_when_newer_release_exists() {
         .env("TINK_HOME", &ws.inventory)
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("Updated")
-                .and(predicate::str::contains("v99.0.0")),
-        );
+        .stdout(predicate::str::contains("Updated").and(predicate::str::contains("v99.0.0")));
 
     assert!(installed.is_file());
     let after = fs::metadata(&installed).unwrap().modified().unwrap();


### PR DESCRIPTION
## Summary
- Extract `CatalogMeta` and shared project path/sidecar/git helpers so catalog ownership and skill layout decisions live in one place without changing the CLI surface.
- Bound outbound `git`/`curl` integration points (transport args, separate metadata vs asset curl max-times) and parse CLI before resolving cwd so `--help` still works when the workdir is gone.
- Seal empty catalog `root` on partial withdraw to preserve basename soft-refuse, and expand unit/acceptance coverage (corrupt skills, malformed meta list, ownership edges, transport argv wiring).

## Test plan
- [x] `cargo test` (lib + acceptance)
- [ ] Spot-check `tink skill list --catalog` with a malformed `meta.json` entry
- [ ] Spot-check partial withdraw + foreign basename `destroy` with legacy empty `root`
- [ ] Spot-check `tink update` path only if a newer release asset is available


Made with [Cursor](https://cursor.com)