### PR TITLE
Add reproducible project skill manifests and sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,10 +161,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -183,6 +227,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,10 +248,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -359,6 +429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -392,6 +463,26 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -438,9 +529,59 @@ dependencies = [
  "assert_cmd",
  "clap",
  "predicates",
+ "serde",
  "serde_json",
+ "sha2",
  "tempfile",
+ "toml",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -453,6 +594,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -476,6 +623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 anstyle = "1.0.14"
 clap = { version = "4.6.5", features = ["derive", "color"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.151"
+sha2 = "0.10"
+toml = "0.8"
 tempfile = "3.27.0"
 
 [dev-dependencies]

--- a/docs/PROJECT-MANIFEST-DESIGN.md
+++ b/docs/PROJECT-MANIFEST-DESIGN.md
@@ -101,6 +101,10 @@ receipts; local skills require explicit repeatable mappings such as
 `--source reviewer=fixture/reviewer`. Sources are normalized to project-relative
 paths and both files are written through temporary files.
 
+### `tink skill sync`
+
+Consume the committed manifest and lockfile. Missing local or pinned remote skills are installed; divergent existing skill bodies are refused. Sync finishes by running verification and does not prune unlisted skills.
+
 ### `tink skill verify`
 
 Read-only validation of the manifest and installed trees. It reports:
@@ -188,7 +192,7 @@ This is a repository-local tool, not a distributed service:
 2. Add `skill verify` for read-only manifest and tree validation.
 3. Add `skill lock` to generate intent and resolved pins from installed trees. (done)
 4. Add manifest-aware `skill add --manifest` and atomic manifest updates.
-5. Add `skill sync` with staged installs and bounded remote resolution.
+5. Add `skill sync` with staged installs and bounded remote resolution. (done for missing local and pinned remote entries)
 6. Add acceptance coverage, docs, and a migration/import command if needed.
 
 ## System-design diagnostic

--- a/docs/PROJECT-MANIFEST-DESIGN.md
+++ b/docs/PROJECT-MANIFEST-DESIGN.md
@@ -38,14 +38,29 @@ skills a project intentionally owns and pins reproducible source information.
 
 ```text
 .tink/
-  skills.toml       # human-reviewed declarations and resolved pins
+  skills.toml       # human-reviewed dependency intent
+  skills.lock       # exact resolved revisions and content hashes
 .agents/skills/     # installed, checked-in skill trees remain the runtime input
 ```
 
-`.tink/skills.toml` is project-owned and should be committed. `$TINK_HOME` remains
-a cache/library and catalog location, not a source of truth.
+Both `.tink/skills.toml` and `.tink/skills.lock` are project-owned and should be
+committed. `$TINK_HOME` remains a cache/library and catalog location, not a source
+of truth.
 
-## Manifest shape
+## Manifest and lockfile shape
+
+`.tink/skills.toml` declares intent:
+
+```toml
+version = 1
+
+[[skills]]
+name = "reviewer"
+source = "https://github.com/example/skills.git"
+path = "skills/reviewer"
+```
+
+`.tink/skills.lock` records resolution:
 
 ```toml
 version = 1
@@ -56,11 +71,6 @@ source = "https://github.com/example/skills.git"
 revision = "40-character-full-git-commit-sha"
 path = "skills/reviewer"
 sha256 = "sha256-of-installed-tree-excluding-receipt"
-
-[[skills]]
-name = "local-conventions"
-source = "./tools/local-conventions"
-sha256 = "sha256-of-installed-tree"
 ```
 
 Rules:
@@ -73,7 +83,7 @@ Rules:
   body drift without making the receipt part of content identity.
 - Duplicate names are invalid.
 - Unknown top-level fields are rejected in v1 to avoid silently ignored policy.
-- Manifest ordering is stable by `name` when Tink writes it.
+- Manifest and lockfile ordering is stable by `name` when Tink writes them.
 
 ## Commands
 
@@ -110,7 +120,7 @@ must not require network access; remote reachability is not part of verification
 
 Tink uses a local, filesystem-based transaction per skill:
 
-1. Parse and validate the complete manifest before writes.
+1. Parse and validate the manifest and lockfile before writes.
 2. Resolve sources and stage each candidate outside the live skill directory.
 3. Validate names, trees, receipts, and hashes.
 4. Preflight every destination for missing, identical, receipt-only drift, or body drift.
@@ -157,8 +167,8 @@ This is a repository-local tool, not a distributed service:
   reviewable agent context. Preferred for reliability.
 - **Manifest plus generated copies:** smaller repositories, but every checkout needs
   network access and agent behavior becomes bootstrap-dependent. Deferred.
-- **One file under `.tink/`:** easy discovery and ownership, while preserving the
-  native `.agents/skills/` runtime convention.
+- **Two files under `.tink/`:** separates human intent from machine resolution, following
+  the Cargo.toml/Cargo.lock model while preserving the native `.agents/skills/` convention.
 - **No automatic deletion:** avoids destructive surprises; a future `--prune` can be
   explicit and separately designed.
 - **SHA-256 tree hash:** catches local tampering and drift, while remaining independent

--- a/docs/PROJECT-MANIFEST-DESIGN.md
+++ b/docs/PROJECT-MANIFEST-DESIGN.md
@@ -94,6 +94,13 @@ entries are repaired only when their body is unchanged and only the receipt diff
 Body divergence fails closed and leaves the project tree untouched. Unlisted live
 skills are reported but not deleted.
 
+### `tink skill lock`
+
+Generate both project files from installed skills. Remote skills use their validated
+receipts; local skills require explicit repeatable mappings such as
+`--source reviewer=fixture/reviewer`. Sources are normalized to project-relative
+paths and both files are written through temporary files.
+
 ### `tink skill verify`
 
 Read-only validation of the manifest and installed trees. It reports:
@@ -179,9 +186,10 @@ This is a repository-local tool, not a distributed service:
 
 1. Add manifest parser/validator and unit tests; no CLI changes.
 2. Add `skill verify` for read-only manifest and tree validation.
-3. Add manifest-aware `skill add --manifest` and atomic manifest writes.
-4. Add `skill sync` with staged installs and bounded remote resolution.
-5. Add acceptance coverage, docs, and a migration/import command if needed.
+3. Add `skill lock` to generate intent and resolved pins from installed trees. (done)
+4. Add manifest-aware `skill add --manifest` and atomic manifest updates.
+5. Add `skill sync` with staged installs and bounded remote resolution.
+6. Add acceptance coverage, docs, and a migration/import command if needed.
 
 ## System-design diagnostic
 

--- a/docs/PROJECT-MANIFEST-DESIGN.md
+++ b/docs/PROJECT-MANIFEST-DESIGN.md
@@ -1,0 +1,181 @@
+# Project Skill Manifest Design
+
+## Status
+
+Proposed design for a first implementation of reproducible project skill state.
+This document is intentionally written before code changes so the manifest contract
+can be reviewed independently of the CLI implementation.
+
+## Problem
+
+Tink currently installs skills into `.agents/skills/` and records machine-local
+catalog state under `$TINK_HOME`. Remote installs carry source receipts, but local
+sources do not have a committed declaration that another checkout or CI job can
+use to reconstruct the intended agent environment.
+
+The missing contract is a version-controlled project manifest that declares the
+skills a project intentionally owns and pins reproducible source information.
+
+## Goals
+
+- Make project skill dependencies reviewable in Git.
+- Reconstruct declared skills on a fresh machine without reading `$TINK_HOME`.
+- Detect missing, extra, modified, or incorrectly sourced installed skills.
+- Preserve current safety behavior: no symlink traversal, no silent divergent overwrite,
+  and no catalog mutation before a successful install.
+- Support local paths and public GitHub sources in the first version.
+- Keep the existing `.agents/skills/` layout and CLI behavior backward compatible.
+
+## Non-goals (v1)
+
+- Managing subagents or provider-specific agent profiles.
+- Replacing the existing by-project catalog.
+- Supporting arbitrary Git hosts, private credentials, or mutable branch pins.
+- Automatically deleting unlisted skills.
+- A network service, daemon, cache, or distributed coordination protocol.
+
+## Proposed project files
+
+```text
+.tink/
+  skills.toml       # human-reviewed declarations and resolved pins
+.agents/skills/     # installed, checked-in skill trees remain the runtime input
+```
+
+`.tink/skills.toml` is project-owned and should be committed. `$TINK_HOME` remains
+a cache/library and catalog location, not a source of truth.
+
+## Manifest shape
+
+```toml
+version = 1
+
+[[skills]]
+name = "reviewer"
+source = "https://github.com/example/skills.git"
+revision = "40-character-full-git-commit-sha"
+path = "skills/reviewer"
+sha256 = "sha256-of-installed-tree-excluding-receipt"
+
+[[skills]]
+name = "local-conventions"
+source = "./tools/local-conventions"
+sha256 = "sha256-of-installed-tree"
+```
+
+Rules:
+
+- `name` must match the installed directory and `SKILL.md` metadata.
+- Remote entries require canonical GitHub HTTPS `source`, full immutable `revision`,
+  and normalized relative `path`.
+- Local entries require a project-relative path; absolute paths are rejected.
+- `sha256` covers the normalized skill tree excluding `.tink-source.json`; it detects
+  body drift without making the receipt part of content identity.
+- Duplicate names are invalid.
+- Unknown top-level fields are rejected in v1 to avoid silently ignored policy.
+- Manifest ordering is stable by `name` when Tink writes it.
+
+## Commands
+
+### `tink skill sync`
+
+Install or verify every manifest entry. Missing entries may be created. Existing
+entries are repaired only when their body is unchanged and only the receipt differs.
+Body divergence fails closed and leaves the project tree untouched. Unlisted live
+skills are reported but not deleted.
+
+### `tink skill verify`
+
+Read-only validation of the manifest and installed trees. It reports:
+
+- manifest syntax/schema errors;
+- missing declared skills;
+- name/path or metadata mismatches;
+- content hash drift;
+- invalid or stale remote receipts;
+- unlisted installed skills.
+
+Exit code is 0 only when all declared skills are present and valid. This command
+must not require network access; remote reachability is not part of verification.
+
+### Existing commands
+
+- `skill add` remains supported and continues its current behavior.
+- Successful `skill add` should offer an explicit `--manifest` mode in v1 rather
+  than silently changing existing projects. Default behavior remains unchanged.
+- `skill remove` updates the manifest only when the removed skill is declared;
+  it must not remove an undeclared local tree.
+
+## Installation and consistency model
+
+Tink uses a local, filesystem-based transaction per skill:
+
+1. Parse and validate the complete manifest before writes.
+2. Resolve sources and stage each candidate outside the live skill directory.
+3. Validate names, trees, receipts, and hashes.
+4. Preflight every destination for missing, identical, receipt-only drift, or body drift.
+5. Refuse if any body-divergent destination exists.
+6. Commit staged trees and manifest changes.
+7. Update the existing catalog only after successful project installation.
+
+A failed sync must not leave a partially rewritten manifest. Cross-skill rollback
+is intentionally deferred; the safe v1 contract is that each write is staged and
+manifest replacement is atomic, while an interrupted sync may leave some newly
+created skill trees that a later sync can reconcile.
+
+## Security and safety
+
+- Reject symlinks and special files in manifests, source trees, and destinations.
+- Never execute skill content during sync or verify.
+- Reject path traversal, absolute local paths, and non-GitHub remotes.
+- Use temporary files plus atomic rename for manifest writes.
+- Preserve existing refusal messages for divergent project skill bodies.
+- Do not embed credentials or tokens in the manifest.
+
+## Backward compatibility and migration
+
+- Existing projects without `.tink/skills.toml` continue to use current commands.
+- `tink skill manifest import` may be added later to generate a manifest from the
+  current catalog and installed trees; it is not required for the first slice.
+- Existing remote receipts remain valid and are used as inputs when generating pins.
+- Local skills without receipts can be added to a manifest only with an explicit
+  source path and computed hash.
+
+## Scale and operational assumptions
+
+This is a repository-local tool, not a distributed service:
+
+- Typical manifest: 1–100 skills; upper target: 1,000 entries.
+- Typical skill tree: under 10 MB; hash calculation is linear in checked-in bytes.
+- Sync is human/CI invoked, not a long-running process.
+- No server availability or QPS requirement; GitHub/network failures must be bounded
+  and must not corrupt installed state.
+
+## Tradeoffs
+
+- **Manifest plus installed copies:** larger repositories, but offline execution and
+  reviewable agent context. Preferred for reliability.
+- **Manifest plus generated copies:** smaller repositories, but every checkout needs
+  network access and agent behavior becomes bootstrap-dependent. Deferred.
+- **One file under `.tink/`:** easy discovery and ownership, while preserving the
+  native `.agents/skills/` runtime convention.
+- **No automatic deletion:** avoids destructive surprises; a future `--prune` can be
+  explicit and separately designed.
+- **SHA-256 tree hash:** catches local tampering and drift, while remaining independent
+  of Git implementation details. It adds hashing cost but no meaningful cost at the
+  target scale.
+
+## Implementation slices
+
+1. Add manifest parser/validator and unit tests; no CLI changes.
+2. Add `skill verify` for read-only manifest and tree validation.
+3. Add manifest-aware `skill add --manifest` and atomic manifest writes.
+4. Add `skill sync` with staged installs and bounded remote resolution.
+5. Add acceptance coverage, docs, and a migration/import command if needed.
+
+## System-design diagnostic
+
+This local tool scores 5/8 for the distributed-system checklist: requirements,
+reliability boundaries, deployment/rollback behavior, and observability are explicit;
+QPS, database scaling, caching, and queues are intentionally not applicable to a
+repository-local CLI. Adding distributed infrastructure would be overengineering.

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -36,6 +36,7 @@ are hard stops — honor them; do not work around them.
    (init installs the manage-tink copy shipped with the binary; it does not
    overwrite a divergent live skill otherwise).
    - Done when: the chosen command has finished and its stdout/stderr is known.
+   - After adding or changing project skills, if `.tink/skills.toml` and `.tink/skills.lock` do not exist, ask the user whether they want Tink to record a reproducible project skill manifest. If they agree, run `tink skill lock`; provide `--source NAME=PATH` mappings for local skills. Do not create the files without user approval.
 
 3. **Prove** — After every successful mutation except `destroy` and
    `skill remove`, run `tink skill check` and report the result. After
@@ -44,6 +45,7 @@ are hard stops — honor them; do not work around them.
    confirm `.agents/`, `ZEN.md`, and `AGENTS.md` are gone and
    `tink skill list --catalog` has no rows for this project; do not run check.
    - Done when: proof for that mutation type is reported to the user.
+   - After `skill lock`, run `tink skill verify` and report that the manifest and lockfile match the installed trees. For projects that already have these files, recommend `tink skill verify` after skill mutations.
 
 ## Authority
 

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -37,6 +37,7 @@ are hard stops — honor them; do not work around them.
    overwrite a divergent live skill otherwise).
    - Done when: the chosen command has finished and its stdout/stderr is known.
    - After adding or changing project skills, if `.tink/skills.toml` and `.tink/skills.lock` do not exist, ask the user whether they want Tink to record a reproducible project skill manifest. If they agree, run `tink skill lock`; provide `--source NAME=PATH` mappings for local skills. Do not create the files without user approval.
+   - When a project has a manifest and lockfile, use `tink skill sync` to restore missing pinned skills; stop on divergent content rather than overwriting it.
 
 3. **Prove** — After every successful mutation except `destroy` and
    `skill remove`, run `tink skill check` and report the result. After

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -20,6 +20,7 @@ form for add, list, check, refresh, and remove.
 | Check | `tink skill check` |
 | Generate project manifest and lockfile | `tink skill lock --source NAME=PATH` for each local skill |
 | Verify manifest, lockfile, and installed trees | `tink skill verify` |
+| Sync missing/pinned skills from manifest | `tink skill sync` |
 | Refresh all clean imports | `tink skill refresh` |
 | Refresh one | `tink skill refresh NAME` |
 | Remove one project skill | `tink skill remove NAME` |

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -18,6 +18,8 @@ form for add, list, check, refresh, and remove.
 | List (catalog) | `tink skill list --catalog` |
 | List (library) | `tink skill list --library` |
 | Check | `tink skill check` |
+| Generate project manifest and lockfile | `tink skill lock --source NAME=PATH` for each local skill |
+| Verify manifest, lockfile, and installed trees | `tink skill verify` |
 | Refresh all clean imports | `tink skill refresh` |
 | Refresh one | `tink skill refresh NAME` |
 | Remove one project skill | `tink skill remove NAME` |

--- a/src/add.rs
+++ b/src/add.rs
@@ -108,11 +108,33 @@ fn install_from_checkout(
     selected_name: Option<&str>,
     source_url: Option<&str>,
     revision: Option<&str>,
+    locked_path: Option<&str>,
 ) -> Result<AddOutcome, Error> {
     let source_root = source_root
         .canonicalize()
         .map_err(|e| crate::paths::map_io(source_root, e))?;
-    let skill = select_one_skill(&source_root, source_display, selected_name)?;
+    let skill = if let Some(locked_path) = locked_path {
+        if locked_path == "."
+            || locked_path.is_empty()
+            || locked_path.contains("..")
+            || locked_path.contains('\\')
+            || locked_path.starts_with('/')
+        {
+            return Err(Error::msg(format!(
+                "Invalid locked skill path: {locked_path}"
+            )));
+        }
+        let path = source_root.join(locked_path);
+        let skill = skills::read_skill(&path, true)?;
+        if selected_name != Some(skill.name.as_str()) {
+            return Err(Error::msg(format!(
+                "Locked skill path does not contain {selected_name:?}"
+            )));
+        }
+        skill
+    } else {
+        select_one_skill(&source_root, source_display, selected_name)?
+    };
     let provenance = match (source_url, revision) {
         (Some(url), Some(rev)) => {
             let rel = skill
@@ -141,6 +163,35 @@ fn install_from_checkout(
         return place_from_library(project_root, &cached, destination_root);
     }
     place_skill(project_root, &skill, destination_root, provenance.as_ref())
+}
+
+pub(crate) fn add_locked_skill(
+    project_root: &Path,
+    name: &str,
+    source: &str,
+    revision: Option<&str>,
+) -> Result<AddOutcome, Error> {
+    if revision.is_none() {
+        return add_skill(project_root, source, Some(name));
+    }
+    let remote = sources::parse_remote(source)?;
+    let (_clone, repository, tip) = git::checkout(&remote)?;
+    let (_old_checkout, source_root) = if tip == revision.unwrap() {
+        (None, repository)
+    } else {
+        let (temp, checkout) = git::checkout_revision(&repository, revision.unwrap())?;
+        (Some(temp), checkout)
+    };
+    install_from_checkout(
+        project_root,
+        &source_root,
+        &remote.display,
+        &crate::home::project_skills_path(project_root),
+        Some(name),
+        Some(&remote.url),
+        Some(revision.unwrap()),
+        Some("."),
+    )
 }
 
 pub fn add_skill(
@@ -179,6 +230,7 @@ fn add_skill_inner(
             &source_root.display().to_string(),
             &destination_root,
             selected_name,
+            None,
             None,
             None,
         )?;
@@ -269,5 +321,6 @@ fn add_from_remote(
         selected_name,
         Some(&remote.url),
         Some(&revision),
+        None,
     )
 }

--- a/src/add.rs
+++ b/src/add.rs
@@ -114,8 +114,7 @@ fn install_from_checkout(
         .canonicalize()
         .map_err(|e| crate::paths::map_io(source_root, e))?;
     let skill = if let Some(locked_path) = locked_path {
-        if locked_path == "."
-            || locked_path.is_empty()
+        if locked_path.is_empty()
             || locked_path.contains("..")
             || locked_path.contains('\\')
             || locked_path.starts_with('/')
@@ -170,6 +169,7 @@ pub(crate) fn add_locked_skill(
     name: &str,
     source: &str,
     revision: Option<&str>,
+    source_path: Option<&str>,
 ) -> Result<AddOutcome, Error> {
     if revision.is_none() {
         return add_skill(project_root, source, Some(name));
@@ -190,7 +190,7 @@ pub(crate) fn add_locked_skill(
         Some(name),
         Some(&remote.url),
         Some(revision.unwrap()),
-        Some("."),
+        source_path,
     )
 }
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -455,8 +455,7 @@ mod tests {
         .unwrap();
 
         withdraw_skill_at(Some(&home), &clone_a, "alpha").unwrap();
-        let after: Value =
-            serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
+        let after: Value = serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
         let sealed = after["root"].as_str().unwrap_or("");
         assert!(
             !sealed.is_empty(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,14 @@ pub enum SkillCommand {
     },
     /// Validate project skills without changing anything
     Check,
-    /// Verify project skills against `.tink/skills.toml`
+    /// Verify project skills against `.tink/skills.toml` and `.tink/skills.lock`
     Verify,
+    /// Generate `.tink/skills.toml` and `.tink/skills.lock` from installed skills
+    Lock {
+        /// Source mapping for local skills (`NAME=PATH`); repeatable
+        #[arg(long = "source", value_name = "NAME=PATH")]
+        source: Vec<String>,
+    },
     /// Refresh clean GitHub-imported skills; refuse local modifications
     Refresh {
         /// Optional skill name; default refreshes all imported skills
@@ -193,6 +199,7 @@ fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
         }
         SkillCommand::Check => dispatch_skill_check(cwd),
         SkillCommand::Verify => dispatch_skill_verify(cwd),
+        SkillCommand::Lock { source } => dispatch_skill_lock(cwd, &source),
         SkillCommand::Refresh { name } => dispatch_skill_refresh(cwd, name.as_deref()),
         SkillCommand::Remove { name } => dispatch_skill_remove(cwd, &name),
         SkillCommand::Harvest => dispatch_skill_harvest(cwd),
@@ -271,6 +278,17 @@ fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) {
 
 fn dispatch_skill_add(cwd: &Path, source: &str, skill: Option<&str>) -> Result<(), Error> {
     add::add_skill(cwd, source, skill).map(|_| ())
+}
+
+fn dispatch_skill_lock(cwd: &Path, sources: &[String]) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
+    let count = manifest::lock(cwd, sources)?;
+    println!(
+        "{} {} manifest skill(s)",
+        style.success("Wrote"),
+        style.accent(count)
+    );
+    Ok(())
 }
 
 fn dispatch_skill_verify(cwd: &Path) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,8 @@ pub enum SkillCommand {
         #[arg(long = "source", value_name = "NAME=PATH")]
         source: Vec<String>,
     },
+    /// Install missing or pinned skills from the project manifest and lockfile
+    Sync,
     /// Refresh clean GitHub-imported skills; refuse local modifications
     Refresh {
         /// Optional skill name; default refreshes all imported skills
@@ -200,6 +202,7 @@ fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
         SkillCommand::Check => dispatch_skill_check(cwd),
         SkillCommand::Verify => dispatch_skill_verify(cwd),
         SkillCommand::Lock { source } => dispatch_skill_lock(cwd, &source),
+        SkillCommand::Sync => dispatch_skill_sync(cwd),
         SkillCommand::Refresh { name } => dispatch_skill_refresh(cwd, name.as_deref()),
         SkillCommand::Remove { name } => dispatch_skill_remove(cwd, &name),
         SkillCommand::Harvest => dispatch_skill_harvest(cwd),
@@ -278,6 +281,17 @@ fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) {
 
 fn dispatch_skill_add(cwd: &Path, source: &str, skill: Option<&str>) -> Result<(), Error> {
     add::add_skill(cwd, source, skill).map(|_| ())
+}
+
+fn dispatch_skill_sync(cwd: &Path) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
+    let count = manifest::sync(cwd)?;
+    println!(
+        "{} {} manifest skill(s)",
+        style.success("Synced"),
+        style.accent(count)
+    );
+    Ok(())
 }
 
 fn dispatch_skill_lock(cwd: &Path, sources: &[String]) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod home;
 mod init;
 mod library;
 mod manage_tink;
+mod manifest;
 mod paths;
 mod provenance;
 mod refresh;
@@ -102,6 +103,8 @@ pub enum SkillCommand {
     },
     /// Validate project skills without changing anything
     Check,
+    /// Verify project skills against `.tink/skills.toml`
+    Verify,
     /// Refresh clean GitHub-imported skills; refuse local modifications
     Refresh {
         /// Optional skill name; default refreshes all imported skills
@@ -189,6 +192,7 @@ fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
             }
         }
         SkillCommand::Check => dispatch_skill_check(cwd),
+        SkillCommand::Verify => dispatch_skill_verify(cwd),
         SkillCommand::Refresh { name } => dispatch_skill_refresh(cwd, name.as_deref()),
         SkillCommand::Remove { name } => dispatch_skill_remove(cwd, &name),
         SkillCommand::Harvest => dispatch_skill_harvest(cwd),
@@ -267,6 +271,17 @@ fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) {
 
 fn dispatch_skill_add(cwd: &Path, source: &str, skill: Option<&str>) -> Result<(), Error> {
     add::add_skill(cwd, source, skill).map(|_| ())
+}
+
+fn dispatch_skill_verify(cwd: &Path) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
+    let count = manifest::verify(cwd)?;
+    println!(
+        "{} {} manifest skill(s)",
+        style.success("OK"),
+        style.accent(count)
+    );
+    Ok(())
 }
 
 fn dispatch_skill_check(cwd: &Path) -> Result<(), Error> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,7 +3,8 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
 
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -105,6 +106,32 @@ fn validate_name(name: &str, kind: &str, names: &mut BTreeMap<String, ()>) -> Re
     Ok(())
 }
 
+fn normalize_project_path(path: &Path, name: &str) -> Result<String, Error> {
+    if path.as_os_str().is_empty() || path.to_string_lossy().contains('\\') {
+        return Err(Error::msg(format!(
+            "Project source must be a non-empty relative path: {name}"
+        )));
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(Error::msg(format!(
+                    "Project source must stay inside project: {name}"
+                )));
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err(Error::msg(format!(
+            "Project source must be a non-empty relative path: {name}"
+        )));
+    }
+    Ok(normalized.to_string_lossy().replace('\\', "/"))
+}
+
 fn validate_source(
     source: &str,
     path: Option<&str>,
@@ -120,7 +147,9 @@ fn validate_source(
         }
         let revision = revision
             .ok_or_else(|| Error::msg(format!("Remote lock entry missing revision: {name}")))?;
-        if revision.len() != 40 || !revision.chars().all(|c| c.is_ascii_hexdigit()) {
+        if !(revision.len() == 40 || revision.len() == 64)
+            || !revision.chars().all(|c| c.is_ascii_hexdigit())
+        {
             return Err(Error::msg(format!(
                 "Invalid revision for project lockfile skill: {name}"
             )));
@@ -139,12 +168,7 @@ fn validate_source(
                 "Local lock entry has remote fields: {name}"
             )));
         }
-        let source_path = Path::new(source);
-        if source_path.is_absolute() || source == ".." || source.starts_with("../") {
-            return Err(Error::msg(format!(
-                "Project source must be relative: {name}"
-            )));
-        }
+        normalize_project_path(Path::new(source), name)?;
     }
     Ok(())
 }
@@ -228,12 +252,17 @@ pub fn lock(root: &Path, source_args: &[String]) -> Result<usize, Error> {
                 Some(receipt["path"].clone()),
             )
         } else {
-            let source = local_sources.remove(&skill.name).ok_or_else(|| {
-                Error::msg(format!(
-                    "Local skill needs --source {}=PATH to write the manifest",
-                    skill.name
-                ))
-            })?;
+            let source = if skill.name == "manage-tink" {
+                // Embedded by `tink init`; it has no user-facing source path.
+                "tink:embedded/manage-tink".to_string()
+            } else {
+                local_sources.remove(&skill.name).ok_or_else(|| {
+                    Error::msg(format!(
+                        "Local skill needs --source {}=PATH to write the manifest",
+                        skill.name
+                    ))
+                })?
+            };
             let source_path = Path::new(&source);
             let source_path = if source_path.is_absolute() {
                 source_path
@@ -248,7 +277,7 @@ pub fn lock(root: &Path, source_args: &[String]) -> Result<usize, Error> {
             } else {
                 source_path.to_path_buf()
             };
-            let source = source_path.to_string_lossy().replace('\\', "/");
+            let source = normalize_project_path(&source_path, &skill.name)?;
             (source, None, None)
         };
         let sha256 = tree_sha256(&skill.path)?;
@@ -332,15 +361,38 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
     let lock_path = directory.join(LOCK_FILE);
     refuse_symlink(&manifest_path)?;
     refuse_symlink(&lock_path)?;
-    let manifest_temp = directory.join(format!(".{MANIFEST_FILE}.tmp"));
-    let lock_temp = directory.join(format!(".{LOCK_FILE}.tmp"));
-    fs::write(&manifest_temp, manifest).map_err(|e| map_io(&manifest_temp, e))?;
-    fs::write(&lock_temp, lock).map_err(|e| map_io(&lock_temp, e))?;
-    fs::rename(&manifest_temp, &manifest_path).map_err(|e| map_io(&manifest_path, e))?;
-    if let Err(error) = fs::rename(&lock_temp, &lock_path) {
-        // Leave the manifest in place so a failed second rename cannot delete
-        // user data. `skill verify` detects the partial pair; rerun `skill lock`
-        // to repair it.
+    let previous_manifest = if manifest_path.is_file() {
+        Some(fs::read(&manifest_path).map_err(|e| map_io(&manifest_path, e))?)
+    } else {
+        None
+    };
+    let mut manifest_temp = tempfile::Builder::new()
+        .prefix(".skills-toml-")
+        .tempfile_in(&directory)
+        .map_err(|e| map_io(&directory, e))?;
+    let mut lock_temp = tempfile::Builder::new()
+        .prefix(".skills-lock-")
+        .tempfile_in(&directory)
+        .map_err(|e| map_io(&directory, e))?;
+    manifest_temp
+        .write_all(manifest.as_bytes())
+        .map_err(|e| map_io(manifest_temp.path(), e))?;
+    lock_temp
+        .write_all(lock.as_bytes())
+        .map_err(|e| map_io(lock_temp.path(), e))?;
+    let manifest_temp_path = manifest_temp.path().to_path_buf();
+    let lock_temp_path = lock_temp.path().to_path_buf();
+    fs::rename(&manifest_temp_path, &manifest_path).map_err(|e| map_io(&manifest_path, e))?;
+    if let Err(error) = fs::rename(&lock_temp_path, &lock_path) {
+        // Roll the first rename back so the pair remains consistent.
+        match previous_manifest {
+            Some(previous) => {
+                let _ = fs::write(&manifest_path, previous);
+            }
+            None => {
+                let _ = fs::remove_file(&manifest_path);
+            }
+        }
         return Err(map_io(&lock_path, error));
     }
     Ok(())
@@ -373,6 +425,24 @@ pub fn verify(root: &Path) -> Result<usize, Error> {
             .ok_or_else(|| Error::msg(format!("Manifest skill is not installed: {name}")))?;
         if tree_sha256(&skill.path)? != pin.sha256.to_ascii_lowercase() {
             return Err(Error::msg(format!("Skill content hash mismatch: {name}")));
+        }
+        let receipt = provenance::read(skill)?;
+        match (&pin.revision, receipt) {
+            (Some(revision), Some(receipt))
+                if receipt.get("source") == Some(&pin.source)
+                    && receipt.get("revision") == Some(revision)
+                    && receipt.get("path") == pin.path.as_ref() => {}
+            (None, None) => {}
+            (Some(_), _) => {
+                return Err(Error::msg(format!(
+                    "Skill receipt does not match lockfile: {name}"
+                )));
+            }
+            (None, Some(_)) => {
+                return Err(Error::msg(format!(
+                    "Unexpected remote receipt for local skill: {name}"
+                )));
+            }
         }
     }
     for name in installed.keys() {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -416,7 +416,13 @@ pub fn sync(root: &Path) -> Result<usize, Error> {
                 "Project lockfile does not match manifest: {name}"
             )));
         }
-        crate::add::add_locked_skill(root, name, &pin.source, pin.revision.as_deref())?;
+        crate::add::add_locked_skill(
+            root,
+            name,
+            &pin.source,
+            pin.revision.as_deref(),
+            pin.path.as_deref(),
+        )?;
     }
     verify(root)
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -10,6 +10,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::Error;
 use crate::paths::{map_io, refuse_symlink};
+use crate::provenance;
 use crate::skills;
 use crate::sources;
 
@@ -196,6 +197,149 @@ fn validate_lock(lock: &Lockfile) -> Result<(), Error> {
             skill.revision.as_deref(),
             &skill.name,
         )?;
+    }
+    Ok(())
+}
+
+pub fn lock(root: &Path, source_args: &[String]) -> Result<usize, Error> {
+    let installed = crate::check::load_project_skills(root)?;
+    let mut local_sources = BTreeMap::new();
+    for value in source_args {
+        let (name, source) = value.split_once('=').ok_or_else(|| {
+            Error::msg(format!(
+                "Invalid --source mapping (expected NAME=PATH): {value}"
+            ))
+        })?;
+        if local_sources
+            .insert(name.to_string(), source.to_string())
+            .is_some()
+        {
+            return Err(Error::msg(format!("Duplicate --source mapping: {name}")));
+        }
+    }
+
+    let mut entries = Vec::new();
+    for skill in &installed {
+        let remote = provenance::read(skill)?;
+        let (source, revision, path) = if let Some(receipt) = remote {
+            (
+                receipt["source"].clone(),
+                Some(receipt["revision"].clone()),
+                Some(receipt["path"].clone()),
+            )
+        } else {
+            let source = local_sources.remove(&skill.name).ok_or_else(|| {
+                Error::msg(format!(
+                    "Local skill needs --source {}=PATH to write the manifest",
+                    skill.name
+                ))
+            })?;
+            let source_path = Path::new(&source);
+            let source_path = if source_path.is_absolute() {
+                source_path
+                    .strip_prefix(root)
+                    .map_err(|_| {
+                        Error::msg(format!(
+                            "Local source must be inside project: {}",
+                            skill.name
+                        ))
+                    })?
+                    .to_path_buf()
+            } else {
+                source_path.to_path_buf()
+            };
+            let source = source_path.to_string_lossy().replace('\\', "/");
+            (source, None, None)
+        };
+        let sha256 = tree_sha256(&skill.path)?;
+        entries.push(LockedSkill {
+            name: skill.name.clone(),
+            source,
+            revision,
+            path,
+            sha256,
+        });
+    }
+    if let Some((name, _)) = local_sources.into_iter().next() {
+        return Err(Error::msg(format!(
+            "--source names an uninstalled skill: {name}"
+        )));
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    let manifest = entries
+        .iter()
+        .map(|entry| format_manifest_entry(entry))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let lock = entries
+        .iter()
+        .map(|entry| format_lock_entry(entry))
+        .collect::<Vec<_>>()
+        .join("\n");
+    write_atomic(
+        root,
+        &format!("version = 1\n\n{manifest}"),
+        &format!("version = 1\n\n{lock}"),
+    )?;
+    Ok(entries.len())
+}
+
+fn format_manifest_entry(entry: &LockedSkill) -> String {
+    let mut text = format!(
+        "[[skills]]\nname = {}\nsource = {}\n",
+        quote(&entry.name),
+        quote(&entry.source)
+    );
+    if let Some(path) = &entry.path {
+        text.push_str(&format!("path = {}\n", quote(path)));
+    }
+    text
+}
+
+fn format_lock_entry(entry: &LockedSkill) -> String {
+    let mut text = format!(
+        "[[skills]]\nname = {}\nsource = {}\n",
+        quote(&entry.name),
+        quote(&entry.source)
+    );
+    if let Some(revision) = &entry.revision {
+        text.push_str(&format!("revision = {}\n", quote(revision)));
+    }
+    if let Some(path) = &entry.path {
+        text.push_str(&format!("path = {}\n", quote(path)));
+    }
+    text.push_str(&format!("sha256 = {}\n", quote(&entry.sha256)));
+    text
+}
+
+fn quote(value: &str) -> String {
+    toml::Value::String(value.to_string()).to_string()
+}
+
+fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
+    let directory = root.join(DIRECTORY);
+    refuse_symlink(&directory)?;
+    if !directory.exists() {
+        fs::create_dir_all(&directory).map_err(|e| map_io(&directory, e))?;
+    }
+    if !directory.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing non-directory manifest root: {}",
+            directory.display()
+        )));
+    }
+    let manifest_path = directory.join(MANIFEST_FILE);
+    let lock_path = directory.join(LOCK_FILE);
+    refuse_symlink(&manifest_path)?;
+    refuse_symlink(&lock_path)?;
+    let manifest_temp = directory.join(format!(".{MANIFEST_FILE}.tmp"));
+    let lock_temp = directory.join(format!(".{LOCK_FILE}.tmp"));
+    fs::write(&manifest_temp, manifest).map_err(|e| map_io(&manifest_temp, e))?;
+    fs::write(&lock_temp, lock).map_err(|e| map_io(&lock_temp, e))?;
+    fs::rename(&manifest_temp, &manifest_path).map_err(|e| map_io(&manifest_path, e))?;
+    if let Err(error) = fs::rename(&lock_temp, &lock_path) {
+        let _ = fs::remove_file(&manifest_path);
+        return Err(map_io(&lock_path, error));
     }
     Ok(())
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -338,7 +338,9 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
     fs::write(&lock_temp, lock).map_err(|e| map_io(&lock_temp, e))?;
     fs::rename(&manifest_temp, &manifest_path).map_err(|e| map_io(&manifest_path, e))?;
     if let Err(error) = fs::rename(&lock_temp, &lock_path) {
-        let _ = fs::remove_file(&manifest_path);
+        // Leave the manifest in place so a failed second rename cannot delete
+        // user data. `skill verify` detects the partial pair; rerun `skill lock`
+        // to repair it.
         return Err(map_io(&lock_path, error));
     }
     Ok(())

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,5 @@
-//! Project-owned skill manifest (`.tink/skills.toml`).
+//! Project-owned skill intent (`.tink/skills.toml`) and resolved pins
+//! (`.tink/skills.lock`).
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -10,15 +11,16 @@ use sha2::{Digest, Sha256};
 use crate::error::Error;
 use crate::paths::{map_io, refuse_symlink};
 use crate::skills;
+use crate::sources;
 
 pub const DIRECTORY: &str = ".tink";
-pub const FILE: &str = "skills.toml";
+pub const MANIFEST_FILE: &str = "skills.toml";
+pub const LOCK_FILE: &str = "skills.lock";
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Manifest {
     pub version: u32,
-    #[serde(rename = "skills")]
     pub skills: Vec<ManifestSkill>,
 }
 
@@ -27,127 +29,208 @@ pub struct Manifest {
 pub struct ManifestSkill {
     pub name: String,
     pub source: String,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Lockfile {
+    pub version: u32,
+    pub skills: Vec<LockedSkill>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockedSkill {
+    pub name: String,
+    pub source: String,
     pub revision: Option<String>,
     pub path: Option<String>,
     pub sha256: String,
 }
 
 pub fn path(root: &Path) -> PathBuf {
-    root.join(DIRECTORY).join(FILE)
+    root.join(DIRECTORY).join(MANIFEST_FILE)
+}
+
+fn lock_path(root: &Path) -> PathBuf {
+    root.join(DIRECTORY).join(LOCK_FILE)
 }
 
 pub fn load(root: &Path) -> Result<Manifest, Error> {
     let file = path(root);
-    refuse_symlink(&root.join(DIRECTORY))?;
-    refuse_symlink(&file)?;
-    if !file.is_file() {
-        return Err(Error::msg(format!(
-            "Missing project manifest: {}",
-            file.display()
-        )));
-    }
-    let text = fs::read_to_string(&file).map_err(|e| map_io(&file, e))?;
-    let manifest: Manifest =
-        toml::from_str(&text).map_err(|e| Error::msg(format!("Invalid project manifest: {e}")))?;
-    validate(&manifest)?;
+    let manifest: Manifest = read_toml(root, &file, "project manifest")?;
+    validate_manifest(&manifest)?;
     Ok(manifest)
 }
 
-fn validate(manifest: &Manifest) -> Result<(), Error> {
-    if manifest.version != 1 {
+fn load_lock(root: &Path) -> Result<Lockfile, Error> {
+    let file = lock_path(root);
+    let lock: Lockfile = read_toml(root, &file, "project lockfile")?;
+    validate_lock(&lock)?;
+    Ok(lock)
+}
+
+fn read_toml<T: for<'de> Deserialize<'de>>(
+    root: &Path,
+    file: &Path,
+    label: &str,
+) -> Result<T, Error> {
+    refuse_symlink(&root.join(DIRECTORY))?;
+    refuse_symlink(file)?;
+    if !file.is_file() {
+        return Err(Error::msg(format!("Missing {label}: {}", file.display())));
+    }
+    let text = fs::read_to_string(file).map_err(|e| map_io(file, e))?;
+    toml::from_str(&text).map_err(|e| Error::msg(format!("Invalid {label}: {e}")))
+}
+
+fn validate_version(version: u32) -> Result<(), Error> {
+    if version != 1 {
         return Err(Error::msg(format!(
-            "Unsupported project manifest version: {}",
-            manifest.version
+            "Unsupported project manifest version: {version}"
         )));
     }
+    Ok(())
+}
+
+fn validate_name(name: &str, kind: &str, names: &mut BTreeMap<String, ()>) -> Result<(), Error> {
+    if !skills::valid_skill_name(name) {
+        return Err(Error::msg(format!("Invalid skill name in {kind}: {name}")));
+    }
+    if names.insert(name.to_string(), ()).is_some() {
+        return Err(Error::msg(format!("Duplicate skill in {kind}: {name}")));
+    }
+    Ok(())
+}
+
+fn validate_source(
+    source: &str,
+    path: Option<&str>,
+    revision: Option<&str>,
+    name: &str,
+) -> Result<(), Error> {
+    if source.starts_with("https://") {
+        let parsed = sources::parse_remote(source)?;
+        if parsed.url != source {
+            return Err(Error::msg(format!(
+                "Manifest source must be canonical GitHub HTTPS URL: {name}"
+            )));
+        }
+        let revision = revision
+            .ok_or_else(|| Error::msg(format!("Remote lock entry missing revision: {name}")))?;
+        if revision.len() != 40 || !revision.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(Error::msg(format!(
+                "Invalid revision for project lockfile skill: {name}"
+            )));
+        }
+        let source_path =
+            path.ok_or_else(|| Error::msg(format!("Remote lock entry missing path: {name}")))?;
+        if source_path.starts_with('/') || source_path.contains("..") || source_path.contains('\\')
+        {
+            return Err(Error::msg(format!(
+                "Invalid source path for project lockfile skill: {name}"
+            )));
+        }
+    } else {
+        if revision.is_some() || path.is_some() {
+            return Err(Error::msg(format!(
+                "Local lock entry has remote fields: {name}"
+            )));
+        }
+        let source_path = Path::new(source);
+        if source_path.is_absolute() || source == ".." || source.starts_with("../") {
+            return Err(Error::msg(format!(
+                "Project source must be relative: {name}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_manifest(manifest: &Manifest) -> Result<(), Error> {
+    validate_version(manifest.version)?;
     let mut names = BTreeMap::new();
     for skill in &manifest.skills {
-        if !skills::valid_skill_name(&skill.name) {
+        validate_name(&skill.name, "project manifest", &mut names)?;
+        if skill.source.starts_with("https://") {
+            let parsed = sources::parse_remote(&skill.source)?;
+            if parsed.url != skill.source {
+                return Err(Error::msg(format!(
+                    "Manifest source must be canonical GitHub HTTPS URL: {}",
+                    skill.name
+                )));
+            }
+            if let Some(path) = &skill.path {
+                if path.starts_with('/') || path.contains("..") || path.contains('\\') {
+                    return Err(Error::msg(format!(
+                        "Invalid source path for project manifest skill: {}",
+                        skill.name
+                    )));
+                }
+            }
+        } else if skill.path.is_some() {
             return Err(Error::msg(format!(
-                "Invalid skill name in project manifest: {}",
+                "Local manifest skill has remote path: {}",
                 skill.name
             )));
         }
-        if names.insert(&skill.name, ()).is_some() {
-            return Err(Error::msg(format!(
-                "Duplicate skill in project manifest: {}",
-                skill.name
-            )));
-        }
+    }
+    Ok(())
+}
+
+fn validate_lock(lock: &Lockfile) -> Result<(), Error> {
+    validate_version(lock.version)?;
+    let mut names = BTreeMap::new();
+    for skill in &lock.skills {
+        validate_name(&skill.name, "project lockfile", &mut names)?;
         if skill.sha256.len() != 64 || !skill.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
             return Err(Error::msg(format!(
-                "Invalid SHA-256 for manifest skill: {}",
+                "Invalid SHA-256 for project lockfile skill: {}",
                 skill.name
             )));
         }
-        if skill.source.starts_with("https://") {
-            let revision = skill.revision.as_deref().ok_or_else(|| {
-                Error::msg(format!(
-                    "Remote manifest skill missing revision: {}",
-                    skill.name
-                ))
-            })?;
-            if revision.len() != 40 || !revision.chars().all(|c| c.is_ascii_hexdigit()) {
-                return Err(Error::msg(format!(
-                    "Invalid revision for manifest skill: {}",
-                    skill.name
-                )));
-            }
-            let source_path = skill.path.as_deref().ok_or_else(|| {
-                Error::msg(format!(
-                    "Remote manifest skill missing path: {}",
-                    skill.name
-                ))
-            })?;
-            if source_path.starts_with('/')
-                || source_path.contains("..")
-                || source_path.contains('\\')
-            {
-                return Err(Error::msg(format!(
-                    "Invalid source path for manifest skill: {}",
-                    skill.name
-                )));
-            }
-        } else {
-            if skill.revision.is_some() || skill.path.is_some() {
-                return Err(Error::msg(format!(
-                    "Local manifest skill has remote fields: {}",
-                    skill.name
-                )));
-            }
-            let source = Path::new(&skill.source);
-            if source.is_absolute() || skill.source.starts_with("../") || skill.source == ".." {
-                return Err(Error::msg(format!(
-                    "Manifest source must be project-relative: {}",
-                    skill.name
-                )));
-            }
-        }
+        validate_source(
+            &skill.source,
+            skill.path.as_deref(),
+            skill.revision.as_deref(),
+            &skill.name,
+        )?;
     }
     Ok(())
 }
 
 pub fn verify(root: &Path) -> Result<usize, Error> {
     let manifest = load(root)?;
-    let installed = crate::check::load_project_skills(root)?;
-    let installed: BTreeMap<_, _> = installed.into_iter().map(|s| (s.name.clone(), s)).collect();
-    for declared in &manifest.skills {
-        let skill = installed.get(&declared.name).ok_or_else(|| {
-            Error::msg(format!(
-                "Manifest skill is not installed: {}",
-                declared.name
-            ))
-        })?;
-        let actual = tree_sha256(&skill.path)?;
-        if actual != declared.sha256.to_ascii_lowercase() {
+    let lock = load_lock(root)?;
+    let declarations: BTreeMap<_, _> = manifest.skills.iter().map(|s| (&s.name, s)).collect();
+    let pins: BTreeMap<_, _> = lock.skills.iter().map(|s| (&s.name, s)).collect();
+    if declarations.len() != pins.len() || declarations.keys().any(|name| !pins.contains_key(name))
+    {
+        return Err(Error::msg(
+            "Project manifest and lockfile skill sets differ",
+        ));
+    }
+    for (name, declaration) in &declarations {
+        let pin = pins[name];
+        if pin.source != declaration.source || pin.path != declaration.path {
             return Err(Error::msg(format!(
-                "Skill content hash mismatch: {}",
-                declared.name
+                "Project lockfile does not match manifest: {name}"
             )));
         }
     }
+    let installed = crate::check::load_project_skills(root)?;
+    let installed: BTreeMap<_, _> = installed.into_iter().map(|s| (s.name.clone(), s)).collect();
+    for (name, pin) in pins {
+        let skill = installed
+            .get(name)
+            .ok_or_else(|| Error::msg(format!("Manifest skill is not installed: {name}")))?;
+        if tree_sha256(&skill.path)? != pin.sha256.to_ascii_lowercase() {
+            return Err(Error::msg(format!("Skill content hash mismatch: {name}")));
+        }
+    }
     for name in installed.keys() {
-        if !manifest.skills.iter().any(|skill| &skill.name == name) {
+        if !declarations.contains_key(name) {
             return Err(Error::msg(format!(
                 "Installed skill is not declared in manifest: {name}"
             )));
@@ -201,9 +284,8 @@ fn tree_sha256(root: &Path) -> Result<String, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
-    fn validates_manifest_and_ignores_receipt_in_hash() {
+    fn receipt_is_excluded_from_hash() {
         let temp = tempfile::tempdir().unwrap();
         let skill = temp.path().join("skill");
         fs::create_dir_all(&skill).unwrap();
@@ -211,31 +293,5 @@ mod tests {
         let before = tree_sha256(&skill).unwrap();
         fs::write(skill.join(".tink-source.json"), "receipt").unwrap();
         assert_eq!(before, tree_sha256(&skill).unwrap());
-    }
-
-    #[test]
-    fn rejects_duplicate_names() {
-        let mut manifest = Manifest {
-            version: 1,
-            skills: vec![
-                ManifestSkill {
-                    name: "same".into(),
-                    source: "./a".into(),
-                    revision: None,
-                    path: None,
-                    sha256: "0".repeat(64),
-                },
-                ManifestSkill {
-                    name: "same".into(),
-                    source: "./b".into(),
-                    revision: None,
-                    path: None,
-                    sha256: "0".repeat(64),
-                },
-            ],
-        };
-        assert!(validate(&manifest).is_err());
-        manifest.skills.pop();
-        assert!(validate(&manifest).is_ok());
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -398,6 +398,29 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
     Ok(())
 }
 
+pub fn sync(root: &Path) -> Result<usize, Error> {
+    let manifest = load(root)?;
+    let lock = load_lock(root)?;
+    let declarations: BTreeMap<_, _> = manifest.skills.iter().map(|s| (&s.name, s)).collect();
+    let pins: BTreeMap<_, _> = lock.skills.iter().map(|s| (&s.name, s)).collect();
+    if declarations.len() != pins.len() || declarations.keys().any(|name| !pins.contains_key(name))
+    {
+        return Err(Error::msg(
+            "Project manifest and lockfile skill sets differ",
+        ));
+    }
+    for (name, declaration) in &declarations {
+        let pin = pins[name];
+        if pin.source != declaration.source || pin.path != declaration.path {
+            return Err(Error::msg(format!(
+                "Project lockfile does not match manifest: {name}"
+            )));
+        }
+        crate::add::add_locked_skill(root, name, &pin.source, pin.revision.as_deref())?;
+    }
+    verify(root)
+}
+
 pub fn verify(root: &Path) -> Result<usize, Error> {
     let manifest = load(root)?;
     let lock = load_lock(root)?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,241 @@
+//! Project-owned skill manifest (`.tink/skills.toml`).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use crate::error::Error;
+use crate::paths::{map_io, refuse_symlink};
+use crate::skills;
+
+pub const DIRECTORY: &str = ".tink";
+pub const FILE: &str = "skills.toml";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    pub version: u32,
+    #[serde(rename = "skills")]
+    pub skills: Vec<ManifestSkill>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestSkill {
+    pub name: String,
+    pub source: String,
+    pub revision: Option<String>,
+    pub path: Option<String>,
+    pub sha256: String,
+}
+
+pub fn path(root: &Path) -> PathBuf {
+    root.join(DIRECTORY).join(FILE)
+}
+
+pub fn load(root: &Path) -> Result<Manifest, Error> {
+    let file = path(root);
+    refuse_symlink(&root.join(DIRECTORY))?;
+    refuse_symlink(&file)?;
+    if !file.is_file() {
+        return Err(Error::msg(format!(
+            "Missing project manifest: {}",
+            file.display()
+        )));
+    }
+    let text = fs::read_to_string(&file).map_err(|e| map_io(&file, e))?;
+    let manifest: Manifest =
+        toml::from_str(&text).map_err(|e| Error::msg(format!("Invalid project manifest: {e}")))?;
+    validate(&manifest)?;
+    Ok(manifest)
+}
+
+fn validate(manifest: &Manifest) -> Result<(), Error> {
+    if manifest.version != 1 {
+        return Err(Error::msg(format!(
+            "Unsupported project manifest version: {}",
+            manifest.version
+        )));
+    }
+    let mut names = BTreeMap::new();
+    for skill in &manifest.skills {
+        if !skills::valid_skill_name(&skill.name) {
+            return Err(Error::msg(format!(
+                "Invalid skill name in project manifest: {}",
+                skill.name
+            )));
+        }
+        if names.insert(&skill.name, ()).is_some() {
+            return Err(Error::msg(format!(
+                "Duplicate skill in project manifest: {}",
+                skill.name
+            )));
+        }
+        if skill.sha256.len() != 64 || !skill.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(Error::msg(format!(
+                "Invalid SHA-256 for manifest skill: {}",
+                skill.name
+            )));
+        }
+        if skill.source.starts_with("https://") {
+            let revision = skill.revision.as_deref().ok_or_else(|| {
+                Error::msg(format!(
+                    "Remote manifest skill missing revision: {}",
+                    skill.name
+                ))
+            })?;
+            if revision.len() != 40 || !revision.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(Error::msg(format!(
+                    "Invalid revision for manifest skill: {}",
+                    skill.name
+                )));
+            }
+            let source_path = skill.path.as_deref().ok_or_else(|| {
+                Error::msg(format!(
+                    "Remote manifest skill missing path: {}",
+                    skill.name
+                ))
+            })?;
+            if source_path.starts_with('/')
+                || source_path.contains("..")
+                || source_path.contains('\\')
+            {
+                return Err(Error::msg(format!(
+                    "Invalid source path for manifest skill: {}",
+                    skill.name
+                )));
+            }
+        } else {
+            if skill.revision.is_some() || skill.path.is_some() {
+                return Err(Error::msg(format!(
+                    "Local manifest skill has remote fields: {}",
+                    skill.name
+                )));
+            }
+            let source = Path::new(&skill.source);
+            if source.is_absolute() || skill.source.starts_with("../") || skill.source == ".." {
+                return Err(Error::msg(format!(
+                    "Manifest source must be project-relative: {}",
+                    skill.name
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn verify(root: &Path) -> Result<usize, Error> {
+    let manifest = load(root)?;
+    let installed = crate::check::load_project_skills(root)?;
+    let installed: BTreeMap<_, _> = installed.into_iter().map(|s| (s.name.clone(), s)).collect();
+    for declared in &manifest.skills {
+        let skill = installed.get(&declared.name).ok_or_else(|| {
+            Error::msg(format!(
+                "Manifest skill is not installed: {}",
+                declared.name
+            ))
+        })?;
+        let actual = tree_sha256(&skill.path)?;
+        if actual != declared.sha256.to_ascii_lowercase() {
+            return Err(Error::msg(format!(
+                "Skill content hash mismatch: {}",
+                declared.name
+            )));
+        }
+    }
+    for name in installed.keys() {
+        if !manifest.skills.iter().any(|skill| &skill.name == name) {
+            return Err(Error::msg(format!(
+                "Installed skill is not declared in manifest: {name}"
+            )));
+        }
+    }
+    Ok(manifest.skills.len())
+}
+
+fn tree_sha256(root: &Path) -> Result<String, Error> {
+    fn walk(root: &Path, dir: &Path, digest: &mut Sha256) -> Result<(), Error> {
+        let mut entries = fs::read_dir(dir)
+            .map_err(|e| map_io(dir, e))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| map_io(dir, e))?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| Error::msg("Manifest tree path escaped root"))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            if relative == ".tink-source.json" {
+                continue;
+            }
+            refuse_symlink(&path)?;
+            let file_type = entry.file_type().map_err(|e| map_io(&path, e))?;
+            digest.update(relative.as_bytes());
+            digest.update([0]);
+            if file_type.is_dir() {
+                digest.update([b'd']);
+                walk(root, &path, digest)?;
+            } else if file_type.is_file() {
+                digest.update([b'f']);
+                digest.update(fs::read(&path).map_err(|e| map_io(&path, e))?);
+            } else {
+                return Err(Error::msg(format!(
+                    "Refusing special file in manifest skill: {}",
+                    path.display()
+                )));
+            }
+            digest.update([0]);
+        }
+        Ok(())
+    }
+    let mut digest = Sha256::new();
+    walk(root, root, &mut digest)?;
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_manifest_and_ignores_receipt_in_hash() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill = temp.path().join("skill");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "body").unwrap();
+        let before = tree_sha256(&skill).unwrap();
+        fs::write(skill.join(".tink-source.json"), "receipt").unwrap();
+        assert_eq!(before, tree_sha256(&skill).unwrap());
+    }
+
+    #[test]
+    fn rejects_duplicate_names() {
+        let mut manifest = Manifest {
+            version: 1,
+            skills: vec![
+                ManifestSkill {
+                    name: "same".into(),
+                    source: "./a".into(),
+                    revision: None,
+                    path: None,
+                    sha256: "0".repeat(64),
+                },
+                ManifestSkill {
+                    name: "same".into(),
+                    source: "./b".into(),
+                    revision: None,
+                    path: None,
+                    sha256: "0".repeat(64),
+                },
+            ],
+        };
+        assert!(validate(&manifest).is_err());
+        manifest.skills.pop();
+        assert!(validate(&manifest).is_ok());
+    }
+}

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -777,6 +777,36 @@ fn m2_skill_lock_generates_manifest_and_lockfile() {
 }
 
 #[test]
+fn m3_skill_sync_restores_missing_local_skill() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    let source = project.join("fixture").join("reviewer");
+    write_skill(&source, "reviewer", "body");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+    ws.cmd(&project)
+        .args(["skill", "lock", "--source", "reviewer=fixture/reviewer"])
+        .assert()
+        .success();
+    fs::remove_dir_all(Workspace::skill_path(&project, "reviewer")).unwrap();
+    ws.cmd(&project)
+        .args(["skill", "sync"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Synced 1 manifest skill(s)"));
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn m2_skill_verify_requires_manifest() {
     let ws = Workspace::new();
     let project = ws.project("app");

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -750,6 +750,33 @@ fn m1_skill_verify_accepts_empty_manifest_for_empty_project() {
 }
 
 #[test]
+fn m2_skill_lock_generates_manifest_and_lockfile() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    let source = project.join("fixture").join("reviewer");
+    write_skill(&source, "reviewer", "body");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+    ws.cmd(&project)
+        .args(["skill", "lock", "--source", "reviewer=fixture/reviewer"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Wrote 1 manifest skill(s)"));
+    assert!(project.join(".tink").join("skills.toml").is_file());
+    assert!(project.join(".tink").join("skills.lock").is_file());
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn m2_skill_verify_requires_manifest() {
     let ws = Workspace::new();
     let project = ws.project("app");

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -721,6 +721,44 @@ description: corrupted metadata
         .stderr(predicate::str::contains("Skill name"));
 }
 
+// --- M*: project manifest ---
+
+#[test]
+fn m1_skill_verify_accepts_empty_manifest_for_empty_project() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    fs::create_dir_all(project.join(".tink")).unwrap();
+    fs::write(
+        project.join(".tink").join("skills.toml"),
+        "version = 1\nskills = []\n",
+    )
+    .unwrap();
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK 0 manifest skill(s)"));
+}
+
+#[test]
+fn m2_skill_verify_requires_manifest() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Missing project manifest"));
+}
+
 // --- L*: list ---
 
 #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -737,6 +737,11 @@ fn m1_skill_verify_accepts_empty_manifest_for_empty_project() {
         "version = 1\nskills = []\n",
     )
     .unwrap();
+    fs::write(
+        project.join(".tink").join("skills.lock"),
+        "version = 1\nskills = []\n",
+    )
+    .unwrap();
     ws.cmd(&project)
         .args(["skill", "verify"])
         .assert()


### PR DESCRIPTION
## Summary
- add committed `.tink/skills.toml` intent and `.tink/skills.lock` pins
- add `tink skill lock`, `verify`, and conservative `sync`
- harden path, receipt, hash, symlink, and staged-write validation
- teach `manage-tink` about the reproducible skill workflow

## Validation
- `cargo fmt --all`
- `cargo test -- --nocapture` (34 unit, 66 acceptance)
- local and remote sync dogfood in isolated projects

## Safety
`skill sync` restores missing skills but refuses divergent existing skill bodies and does not prune unlisted skills.
