### PR TITLE
Repair stale skill receipts without overwriting bodies

### DIFF
--- a/docs/REMOVE-TECHNICAL-DEBT-PLAN.md
+++ b/docs/REMOVE-TECHNICAL-DEBT-PLAN.md
@@ -36,6 +36,7 @@ Optional phases (system-design, ddia-systems, team-topologies) are added as rows
 | 2026-08-07 | Phase 6 | Hardened CLI entrypoint by converting startup `current_dir` panic into an explicit error return path (`src/main.rs`). | Keeps failure-mode handling explicit at process boundaries and avoids hidden crash modes. |
 | 2026-08-07 | Phase 7 | Hardened integration points by adding bounded transport settings, retry budgets, and update-time hardening in `src/git.rs`, `src/update.rs`, and entrypoint startup failure handling. | Adds deterministic failure behavior for outbound/IO boundaries and codifies reliability policy for future updates. |
 | 2026-08-07 | Phase 8 | Introduced catalog-domain aggregate `CatalogMeta` in `src/catalog.rs` to model by-project catalog persistence (`name`, `root`, `skills`) and make ownership / mutation rules explicit while preserving write/read behavior. | Clarifies catalog as a domain aggregate boundary; behavior remains unchanged with existing compatibility contracts. |
+| 2026-08-08 | Validation | Characterized and implemented receipt-only repair for unchanged installed skill bodies with stale or malformed `.tink-source.json` sidecars. | Recovery updates only the reserved receipt; body divergence still preserves the refusal contract. |
 
 ## Next Actions
 - [x] Create `docs/TESTING.md` with phase-1 safety net and characterization matrix.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -32,7 +32,7 @@
 | Module | Pinned behaviors | Test files | Gaps |
 |---|---|---|---|
 | `src/lib.rs` | CLI dispatch is exhaustive by command enum; success prints are constrained and failures return exit code 1 via error pathway. | `tests/acceptance.rs` (`i*`, `a*`, `c*`, `l*`, `x*`) | No unit coverage for exact styled output in each branch (intentional for now). |
-| `src/add.rs` | Add source resolution precedence: local path/remote/library; idempotence and divergence refusal semantics are preserved. | `tests/acceptance.rs` (`a1..a8`, `r*`) | Add-path coverage for malformed local-tree receipt combinations not in scope yet. |
+| `src/add.rs` | Add source resolution precedence: local path/remote/library; idempotence and divergence refusal semantics are preserved. | `tests/acceptance.rs` (`a1..a8`, `r*`) | Receipt-only drift on unchanged local trees is repaired without replacing the skill body (`a3b_add_local_repair_sidecar_only_divergence`). |
 | `src/check.rs` | `skill check` requires `.agents/skills` and validates each installed skill directory/name, and enforces ZEN/AGENTS coupling rule. | `tests/acceptance.rs` (`c1`, `c2`, `c3`, `c4`, `l4`, `l5`) | Add targeted checks for additional malformed installed-skill states (e.g., non-YAML metadata variants, missing required fields). |
 | `src/remove.rs` | `remove` withdraws catalog entry before deleting project tree; never touches library content. | `tests/acceptance.rs` (`x1`, `x2`, `x4`), plus malformed-catalog regression (`x6_remove_fails_when_catalog_meta_is_malformed`) | Explicitly covers malformed catalog state behavior on remove. |
 | `src/refresh.rs` | `refresh_one` computes old/new remote skill repositories and refresh logic without mutating project state until checks pass. | `tests/acceptance.rs` (`p1`, `p2`, `p3`, `p4`, `p5`, `p6`, `p7`) | Refactor extraction added for clarity; now verify this invariant remains covered. |
@@ -50,6 +50,7 @@
 - [x] Add characterization test for a deliberately corrupted installed `SKILL.md` (`c4_check_fails_with_corrupt_installed_skill`).
 - [x] Pin behavior for malformed catalog metadata entries during catalog listing (`l6_skill_list_catalog_skips_malformed_meta_entries`).
 - [x] Pin malformed-catalog behavior for remove (`x6_remove_fails_when_catalog_meta_is_malformed`).
+- [x] Pin receipt-only repair for unchanged local skill bodies (`a3b_add_local_repair_sidecar_only_divergence`).
 
 ## CI Gates
 - `cargo test -- --nocapture`

--- a/src/library.rs
+++ b/src/library.rs
@@ -99,6 +99,10 @@ pub fn deposit(
             Ok((path, LibraryWrite::Created))
         }
         PreflightOutcome::Identical => Ok((library.join(&skill.name), LibraryWrite::Unchanged)),
+        PreflightOutcome::ReceiptMismatch => {
+            let (path, _) = skills::install_local(skill, &library, provenance)?;
+            Ok((path, LibraryWrite::Repaired))
+        }
         PreflightOutcome::Divergent => {
             clear_path(&library.join(&skill.name))?;
             let (path, _) = skills::install_local(skill, &library, provenance)?;
@@ -121,23 +125,14 @@ pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), 
             let (path, _) = skills::install_local(skill, &library, None)?;
             Ok((path, CreateOnlyWrite::Created))
         }
-        Ok(PreflightOutcome::Identical) => Ok((target, CreateOnlyWrite::Unchanged)),
-        Ok(PreflightOutcome::Divergent) => {
-            if target.is_dir()
-                && skills::skill_contents_equal_except(
-                    &target,
-                    &skill.path,
-                    &[provenance::SIDECAR_FILE],
-                )?
-            {
-                Ok((target, CreateOnlyWrite::Unchanged))
-            } else {
-                Ok((
-                    target,
-                    CreateOnlyWrite::Skipped(Some("library differs; create-only".into())),
-                ))
-            }
+        Ok(PreflightOutcome::Identical | PreflightOutcome::ReceiptMismatch) => {
+            // Receipt-only drift: create-only never rewrites; body already matches.
+            Ok((target, CreateOnlyWrite::Unchanged))
         }
+        Ok(PreflightOutcome::Divergent) => Ok((
+            target,
+            CreateOnlyWrite::Skipped(Some("library differs; create-only".into())),
+        )),
     }
 }
 
@@ -150,7 +145,9 @@ pub fn matching(skill: &Skill, provenance: Option<&Provenance>) -> Result<Option
     }
     match skills::preflight_install(skill, &library, provenance)? {
         PreflightOutcome::Identical => Ok(Some(skills::read_skill(&target, true)?)),
-        PreflightOutcome::Ready | PreflightOutcome::Divergent => Ok(None),
+        PreflightOutcome::Ready
+        | PreflightOutcome::ReceiptMismatch
+        | PreflightOutcome::Divergent => Ok(None),
     }
 }
 
@@ -250,7 +247,9 @@ pub fn preflight_refresh(
 ) -> Result<(), Error> {
     let library = library_root(None)?;
     match skills::preflight_install(new_skill, &library, Some(new_provenance))? {
-        PreflightOutcome::Ready | PreflightOutcome::Identical => Ok(()),
+        PreflightOutcome::Ready
+        | PreflightOutcome::Identical
+        | PreflightOutcome::ReceiptMismatch => Ok(()),
         PreflightOutcome::Divergent => {
             let home_skill = library.join(&new_skill.name);
             if home_skill.is_dir() && tracks_project(&home_skill, project_installed)? {

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -83,7 +83,8 @@ fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
                 "Refusing to update missing installed skill: {name}"
             )));
         }
-        skills::PreflightOutcome::Identical => {}
+        // Receipt drift alone is not a content edit; refresh rewrites receipts later.
+        skills::PreflightOutcome::Identical | skills::PreflightOutcome::ReceiptMismatch => {}
         skills::PreflightOutcome::Divergent => {
             return Err(Error::msg(format!(
                 "Refusing to update {name}: local modifications are present"

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -305,12 +305,14 @@ pub enum PreflightOutcome {
     Ready,
     /// Target already matches (including optional receipt) — noop.
     Identical,
-    /// Target exists and differs — caller decides refuse vs repair.
+    /// Skill body matches; only `.tink-source.json` presence or bytes differ.
+    ReceiptMismatch,
+    /// Target exists and body differs — caller decides refuse vs repair.
     Divergent,
 }
 
 impl PreflightOutcome {
-    /// Project installs refuse divergence; keep the historical error text.
+    /// Project installs refuse body divergence; receipt-only drift may repair.
     pub fn require_compatible(
         self,
         skill_name: &str,
@@ -326,12 +328,10 @@ impl PreflightOutcome {
     }
 }
 
-/// Compare candidate skill to `destination_root/<name>` without writing.
-pub fn preflight_install(
+fn expected_install_tree(
     skill: &Skill,
-    destination_root: &Path,
     provenance: Option<&Provenance>,
-) -> Result<PreflightOutcome, Error> {
+) -> Result<BTreeMap<String, EntryKind>, Error> {
     let mut expected = require_safe_tree(&skill.path)?;
     if let Some(provenance) = provenance {
         if expected.contains_key(provenance::SIDECAR_FILE) {
@@ -345,6 +345,52 @@ pub fn preflight_install(
             EntryKind::File(provenance::to_bytes(provenance)?),
         );
     }
+    Ok(expected)
+}
+
+fn equal_except_receipt(
+    left: &BTreeMap<String, EntryKind>,
+    right: &BTreeMap<String, EntryKind>,
+) -> bool {
+    left.iter()
+        .filter(|(key, _)| key.as_str() != provenance::SIDECAR_FILE)
+        .eq(right
+            .iter()
+            .filter(|(key, _)| key.as_str() != provenance::SIDECAR_FILE))
+}
+
+/// Align destination receipt to `expected` without rewriting skill body files.
+fn repair_receipt(target: &Path, expected: &BTreeMap<String, EntryKind>) -> Result<(), Error> {
+    refuse_symlink(target)?;
+    let sidecar = target.join(provenance::SIDECAR_FILE);
+    match expected.get(provenance::SIDECAR_FILE) {
+        Some(EntryKind::File(bytes)) => {
+            refuse_symlink(&sidecar)?;
+            fs::write(&sidecar, bytes).map_err(|e| map_io(&sidecar, e))?;
+        }
+        Some(EntryKind::Dir) => {
+            return Err(Error::msg(format!(
+                "Invalid receipt entry (directory): {}",
+                sidecar.display()
+            )));
+        }
+        None => {
+            if sidecar.exists() || sidecar.is_symlink() {
+                refuse_symlink(&sidecar)?;
+                fs::remove_file(&sidecar).map_err(|e| map_io(&sidecar, e))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Compare candidate skill to `destination_root/<name>` without writing.
+pub fn preflight_install(
+    skill: &Skill,
+    destination_root: &Path,
+    provenance: Option<&Provenance>,
+) -> Result<PreflightOutcome, Error> {
+    let expected = expected_install_tree(skill, provenance)?;
     let target = destination_root.join(&skill.name);
     if !target.exists() && !target.is_symlink() {
         return Ok(PreflightOutcome::Ready);
@@ -353,6 +399,9 @@ pub fn preflight_install(
         if let Some(existing) = tree_contents(&target)? {
             if existing == expected {
                 return Ok(PreflightOutcome::Identical);
+            }
+            if equal_except_receipt(&existing, &expected) {
+                return Ok(PreflightOutcome::ReceiptMismatch);
             }
         }
     }
@@ -368,20 +417,28 @@ pub fn install_local(
     let outcome = preflight_install(skill, destination_root, provenance)?
         .require_compatible(&skill.name, destination_root)?;
     let target = destination_root.join(&skill.name);
-    if outcome == PreflightOutcome::Identical {
-        return Ok((target, false));
+    match outcome {
+        PreflightOutcome::Identical => Ok((target, false)),
+        PreflightOutcome::ReceiptMismatch => {
+            let expected = expected_install_tree(skill, provenance)?;
+            repair_receipt(&target, &expected)?;
+            Ok((target, false))
+        }
+        PreflightOutcome::Ready => {
+            let staging = tempfile::Builder::new()
+                .prefix(".tink-stage-")
+                .tempdir_in(destination_root)
+                .map_err(|e| Error::msg(format!("staging dir: {e}")))?;
+            let staged = staging.path().join(&skill.name);
+            copy_skill_tree(&skill.path, &staged, &[".git"])?;
+            if let Some(provenance) = provenance {
+                provenance::write_file(&staged.join(provenance::SIDECAR_FILE), provenance)?;
+            }
+            fs::rename(&staged, &target).map_err(|e| map_io(&target, e))?;
+            Ok((target, true))
+        }
+        PreflightOutcome::Divergent => unreachable!("require_compatible rejects Divergent"),
     }
-    let staging = tempfile::Builder::new()
-        .prefix(".tink-stage-")
-        .tempdir_in(destination_root)
-        .map_err(|e| Error::msg(format!("staging dir: {e}")))?;
-    let staged = staging.path().join(&skill.name);
-    copy_skill_tree(&skill.path, &staged, &[".git"])?;
-    if let Some(provenance) = provenance {
-        provenance::write_file(&staged.join(provenance::SIDECAR_FILE), provenance)?;
-    }
-    fs::rename(&staged, &target).map_err(|e| map_io(&target, e))?;
-    Ok((target, true))
 }
 
 /// Replace an existing imported skill after dirty-tree preflight elsewhere.

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -322,6 +322,28 @@ fn a3_add_refuses_overwrite_when_diverged() {
 }
 
 #[test]
+fn a3b_add_local_repair_sidecar_only_divergence() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    let source = ws.root.join("demo-skill");
+    write_skill(&source, "demo-skill", "content");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let installed = Workspace::skill_path(&project, "demo-skill");
+    fs::write(installed.join(".tink-source.json"), "{\"bad\": true}\n").expect("stale sidecar");
+
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+    assert!(!installed.join(".tink-source.json").exists());
+}
+
+#[test]
 fn a4_add_refuses_symlink_in_skill_tree() {
     let ws = Workspace::new();
     let project = ws.project("app");


### PR DESCRIPTION
## Summary
- classify receipt-only drift separately from skill-body divergence
- repair stale or malformed `.tink-source.json` without overwriting unchanged skill bodies
- preserve refusal behavior for real content divergence
- document and characterize the recovery path

## Validation
- `cargo fmt --all`
- `cargo test -- --nocapture` (34 unit, 67 acceptance)
- `git diff --check`
