### PR TITLE
Add dynamic skill library completions

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -116,6 +116,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | H6 | `skill harvest` when library already identical | Exit 0; summary counts already present; no per-skill already-present lines |
 | H7 | `skill harvest` when library diverges | Exit 0; library unchanged; stderr skip warn |
 | H8 | `skill harvest` skips library sources and unsafe (symlink-inside) skill trees; still harvests cwd skills under `TINK_HOME` outside `skills/` | Library/unsafe omitted; non-library path under home deposited |
+| H9 | Shell completion for `tink skill add <prefix>` | Offers matching names from the current library without creating the home or library |
 
 ### CLI surface
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +279,15 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -486,6 +507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +555,7 @@ dependencies = [
  "anstyle",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "predicates",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 anstyle = "1.0.14"
 clap = { version = "4.6.5", features = ["derive", "color"] }
+clap_complete = { version = "4.6.8", features = ["unstable-dynamic"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.151"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ From a checkout:
 cargo install --path . --root ~/.local --force
 ```
 
+## Tab completion
+
+Tink can complete commands, flags, and live library skill names. Add the line
+for your shell to its startup file, then open a new shell:
+
+```sh
+# zsh (~/.zshrc)
+autoload -Uz compinit
+compinit
+source <(COMPLETE=zsh tink)
+
+# bash (~/.bashrc)
+source <(COMPLETE=bash tink)
+```
+
+For Fish, save this as `~/.config/fish/completions/tink.fish`:
+
+```fish
+COMPLETE=fish tink | source
+```
+
+Then type `tink skill add ` and press Tab. The matches come from the current
+Tink library, including skills added after completion was enabled.
+
 ## First success
 
 In an empty project directory:

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -35,6 +35,12 @@ are hard stops — honor them; do not work around them.
    `tink skill remove manage-tink && tink init --no-zen --no-tink-skills`
    (init installs the manage-tink copy shipped with the binary; it does not
    overwrite a divergent live skill otherwise).
+   Shell Tab completion setup:
+   - Zsh (`~/.zshrc`, after `autoload -Uz compinit` and `compinit`):
+     `source <(COMPLETE=zsh tink)`
+   - Bash (`~/.bashrc`): `source <(COMPLETE=bash tink)`
+   - Fish (`~/.config/fish/completions/tink.fish`):
+     `COMPLETE=fish tink | source`
    - Done when: the chosen command has finished and its stdout/stderr is known.
    - After adding or changing project skills, if `.tink/skills.toml` and `.tink/skills.lock` do not exist, ask the user whether they want Tink to record a reproducible project skill manifest. If they agree, run `tink skill lock`; provide `--source NAME=PATH` mappings for local skills. Do not create the files without user approval.
    - When a project has a manifest and lockfile, use `tink skill sync` to restore missing pinned skills; stop on divergent content rather than overwriting it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,11 @@ mod templates;
 mod update;
 
 use clap::{Parser, Subcommand};
+use clap_complete::{
+    CompletionCandidate,
+    engine::{ArgValueCompleter, PathCompleter, ValueCompleter},
+};
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -87,6 +92,7 @@ pub enum SkillCommand {
     /// Copy one complete skill into the project
     Add {
         /// Local path, `owner/repo`, public GitHub HTTPS URL, or library skill name
+        #[arg(add = ArgValueCompleter::new(add_source_candidates))]
         source: String,
         /// Skill name when the source contains several skills
         #[arg(long)]
@@ -125,6 +131,23 @@ pub enum SkillCommand {
     },
     /// Copy harness skill trees into the library (create-only)
     Harvest,
+}
+
+fn add_source_candidates(current: &OsStr) -> Vec<CompletionCandidate> {
+    let mut candidates = PathCompleter::any().complete(current);
+    let Some(prefix) = current.to_str() else {
+        return candidates;
+    };
+    candidates.extend(
+        library::list_names(None)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|name| name.starts_with(prefix))
+            .map(CompletionCandidate::new),
+    );
+    candidates.sort();
+    candidates.dedup();
+    candidates
 }
 
 fn flag_tri(yes: bool, no: bool) -> Option<bool> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::CompleteEnv;
 
 use tink::{Cli, run};
 
 fn main() -> ExitCode {
+    CompleteEnv::with_factory(Cli::command).complete();
+
     // Parse first so --help / --version work when the process has no cwd
     // (e.g. shell still open after `rm -rf` of the working directory).
     let cli = Cli::parse();

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -1258,6 +1258,80 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
     assert!(home_body.contains("stash resident"));
 }
 
+#[test]
+fn h9_completion_offers_current_library_matches_without_creating_home() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+
+    ws.cmd(&project)
+        .env("COMPLETE", "zsh")
+        .env("_CLAP_COMPLETE_INDEX", "3")
+        .env("_CLAP_IFS", "\n")
+        .args(["--", "tink", "skill", "add", "de"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+    assert!(
+        !ws.inventory.exists(),
+        "completion must not create the Tink home"
+    );
+
+    write_skill(
+        project.join("demo-local").as_path(),
+        "demo-local",
+        "local path fixture",
+    );
+    ws.cmd(&project)
+        .env("COMPLETE", "zsh")
+        .env("_CLAP_COMPLETE_INDEX", "3")
+        .env("_CLAP_IFS", "\n")
+        .args(["--", "tink", "skill", "add", "./de"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("./demo-local/"));
+
+    ws.cmd(&project)
+        .env("COMPLETE", "zsh")
+        .env("_CLAP_COMPLETE_INDEX", "1")
+        .env("_CLAP_IFS", "\n")
+        .args(["--", "tink", "sk"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skill"));
+
+    ws.cmd(&project)
+        .env("COMPLETE", "zsh")
+        .env("_CLAP_COMPLETE_INDEX", "4")
+        .env("_CLAP_IFS", "\n")
+        .args(["--", "tink", "skill", "add", "demo-local", "--s"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--skill"));
+
+    write_skill(
+        ws.library_skill("demo-skill").as_path(),
+        "demo-skill",
+        "completion fixture",
+    );
+    write_skill(
+        ws.library_skill("other-skill").as_path(),
+        "other-skill",
+        "non-matching fixture",
+    );
+
+    ws.cmd(&project)
+        .env("COMPLETE", "zsh")
+        .env("_CLAP_COMPLETE_INDEX", "3")
+        .env("_CLAP_IFS", "\n")
+        .args(["--", "tink", "skill", "add", "de"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("demo-skill")
+                .and(predicate::str::contains("other-skill").not()),
+        );
+}
+
 // --- V*: CLI surface (skill nest) ---
 
 #[test]


### PR DESCRIPTION
## Summary

- add opt-in dynamic shell completion for Tink commands and flags
- complete `tink skill add` from the current skill library while preserving local path candidates
- document Zsh, Bash, and Fish setup in the README and embedded `manage-tink` skill
- add acceptance coverage for read-only library completion, paths, commands, and flags

## Why

Library skills were only discoverable through `tink skill list --library`. This lets users type a prefix and press Tab to insert or select a current library match.

## Validation

- `cargo test --all-targets` (102 tests passed)
- `cargo fmt -- --check`
- `git diff --check`
- clean-Zsh registration smoke test confirmed `_clap_dynamic_completer_tink` is defined

## Review

A structured correctness, standards, testing, and agent-native review found three setup/coverage issues. All were fixed and independently validated before publishing.