### PR TITLE
Fix typed source resolution for skill sync

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -9,7 +9,7 @@ use crate::init;
 use crate::library::{self, LibraryWrite};
 use crate::provenance::Provenance;
 use crate::skills::{self, Skill};
-use crate::sources::{self, RemoteSource};
+use crate::sources::{self, AddSource, LockedSource, RemoteSource};
 use crate::style::CliStyle;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -167,31 +167,63 @@ fn install_from_checkout(
 pub(crate) fn add_locked_skill(
     project_root: &Path,
     name: &str,
-    source: &str,
-    revision: Option<&str>,
-    source_path: Option<&str>,
+    source: LockedSource,
 ) -> Result<AddOutcome, Error> {
-    if revision.is_none() {
-        return add_skill(project_root, source, Some(name));
+    match source {
+        LockedSource::LocalPath { path, .. } => {
+            init::ensure_project_layout(project_root)?;
+            if !path.exists() {
+                return Err(Error::msg(format!(
+                    "Path does not exist: {}",
+                    path.display()
+                )));
+            }
+            let source_root = path
+                .canonicalize()
+                .map_err(|e| crate::paths::map_io(&path, e))?;
+            let outcome = install_from_checkout(
+                project_root,
+                &source_root,
+                &source_root.display().to_string(),
+                &crate::home::project_skills_path(project_root),
+                Some(name),
+                None,
+                None,
+                None,
+            )?;
+            report_add(&outcome);
+            Ok(outcome)
+        }
+        LockedSource::Github {
+            remote,
+            revision,
+            path,
+        } => {
+            let (_clone, repository, tip) = git::checkout(&remote)?;
+            let (_old_checkout, source_root) = if tip == revision {
+                (None, repository)
+            } else {
+                let (temp, checkout) = git::checkout_revision(&repository, &revision)?;
+                (Some(temp), checkout)
+            };
+            install_from_checkout(
+                project_root,
+                &source_root,
+                &remote.display,
+                &crate::home::project_skills_path(project_root),
+                Some(name),
+                Some(&remote.url),
+                Some(&revision),
+                Some(&path),
+            )
+        }
+        LockedSource::EmbeddedManageTink if name == "manage-tink" => {
+            crate::manage_tink::install_manage_tink(project_root)
+        }
+        LockedSource::EmbeddedManageTink => Err(Error::msg(format!(
+            "Embedded source does not provide skill: {name}"
+        ))),
     }
-    let remote = sources::parse_remote(source)?;
-    let (_clone, repository, tip) = git::checkout(&remote)?;
-    let (_old_checkout, source_root) = if tip == revision.unwrap() {
-        (None, repository)
-    } else {
-        let (temp, checkout) = git::checkout_revision(&repository, revision.unwrap())?;
-        (Some(temp), checkout)
-    };
-    install_from_checkout(
-        project_root,
-        &source_root,
-        &remote.display,
-        &crate::home::project_skills_path(project_root),
-        Some(name),
-        Some(&remote.url),
-        Some(revision.unwrap()),
-        source_path,
-    )
 }
 
 pub fn add_skill(
@@ -219,62 +251,47 @@ fn add_skill_inner(
 ) -> Result<AddOutcome, Error> {
     init::ensure_project_layout(project_root)?;
     let destination_root = crate::home::project_skills_path(project_root);
-    let local_source = Path::new(source_value);
-    if local_source.exists() {
-        let source_root = local_source
-            .canonicalize()
-            .map_err(|e| crate::paths::map_io(local_source, e))?;
-        let outcome = install_from_checkout(
-            project_root,
-            &source_root,
-            &source_root.display().to_string(),
-            &destination_root,
-            selected_name,
-            None,
-            None,
-            None,
-        )?;
-        if report {
-            report_add(&outcome);
+    match sources::classify_add_input(source_value)? {
+        AddSource::LocalPath(local_source) => {
+            let source_root = local_source
+                .canonicalize()
+                .map_err(|e| crate::paths::map_io(&local_source, e))?;
+            let outcome = install_from_checkout(
+                project_root,
+                &source_root,
+                &source_root.display().to_string(),
+                &destination_root,
+                selected_name,
+                None,
+                None,
+                None,
+            )?;
+            if report {
+                report_add(&outcome);
+            }
+            Ok(outcome)
         }
-        return Ok(outcome);
-    }
-    if looks_like_filesystem_path(source_value) {
-        return Err(Error::msg(format!("Path does not exist: {source_value}")));
-    }
-    // Slash or URL → remote only. Bare name → library promote.
-    if looks_like_remote_source(source_value) {
-        let remote = sources::parse_remote(source_value)?;
-        let outcome = add_from_remote(project_root, &destination_root, &remote, selected_name)?;
-        if report {
-            report_add(&outcome);
+        AddSource::Github(remote) => {
+            let outcome = add_from_remote(project_root, &destination_root, &remote, selected_name)?;
+            if report {
+                report_add(&outcome);
+            }
+            Ok(outcome)
         }
-        return Ok(outcome);
+        AddSource::LibraryName(name) => {
+            if selected_name.is_some() {
+                return Err(Error::msg(
+                    "Do not combine --skill with a library skill name; pass only the library name",
+                ));
+            }
+            let skill = library::load(&name)?;
+            let outcome = place_from_library(project_root, &skill, &destination_root)?;
+            if report {
+                report_add(&outcome);
+            }
+            Ok(outcome)
+        }
     }
-    if selected_name.is_some() {
-        return Err(Error::msg(
-            "Do not combine --skill with a library skill name; pass only the library name",
-        ));
-    }
-    let skill = library::load(source_value)?;
-    let outcome = place_from_library(project_root, &skill, &destination_root)?;
-    if report {
-        report_add(&outcome);
-    }
-    Ok(outcome)
-}
-
-fn looks_like_remote_source(value: &str) -> bool {
-    value.contains('/') || value.contains("://")
-}
-
-fn looks_like_filesystem_path(value: &str) -> bool {
-    let path = Path::new(value);
-    path.is_absolute()
-        || value.starts_with("./")
-        || value.starts_with("../")
-        || value.starts_with("~/")
-        || value.contains('\\')
 }
 
 fn report_add(outcome: &AddOutcome) {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -51,6 +51,16 @@ pub struct LockedSkill {
     pub sha256: String,
 }
 
+struct ResolvedLockfile {
+    skills: Vec<ResolvedLockedSkill>,
+}
+
+struct ResolvedLockedSkill {
+    name: String,
+    source: sources::LockedSource,
+    sha256: String,
+}
+
 pub fn path(root: &Path) -> PathBuf {
     root.join(DIRECTORY).join(MANIFEST_FILE)
 }
@@ -66,11 +76,10 @@ pub fn load(root: &Path) -> Result<Manifest, Error> {
     Ok(manifest)
 }
 
-fn load_lock(root: &Path) -> Result<Lockfile, Error> {
+fn load_lock(root: &Path) -> Result<ResolvedLockfile, Error> {
     let file = lock_path(root);
     let lock: Lockfile = read_toml(root, &file, "project lockfile")?;
-    validate_lock(&lock)?;
-    Ok(lock)
+    resolve_lock(root, lock)
 }
 
 fn read_toml<T: for<'de> Deserialize<'de>>(
@@ -106,108 +115,21 @@ fn validate_name(name: &str, kind: &str, names: &mut BTreeMap<String, ()>) -> Re
     Ok(())
 }
 
-fn normalize_project_path(path: &Path, name: &str) -> Result<String, Error> {
-    if path.as_os_str().is_empty() || path.to_string_lossy().contains('\\') {
-        return Err(Error::msg(format!(
-            "Project source must be a non-empty relative path: {name}"
-        )));
-    }
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::Normal(part) => normalized.push(part),
-            Component::CurDir => {}
-            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                return Err(Error::msg(format!(
-                    "Project source must stay inside project: {name}"
-                )));
-            }
-        }
-    }
-    if normalized.as_os_str().is_empty() {
-        return Err(Error::msg(format!(
-            "Project source must be a non-empty relative path: {name}"
-        )));
-    }
-    Ok(normalized.to_string_lossy().replace('\\', "/"))
-}
-
-fn validate_source(
-    source: &str,
-    path: Option<&str>,
-    revision: Option<&str>,
-    name: &str,
-) -> Result<(), Error> {
-    if source.starts_with("https://") {
-        let parsed = sources::parse_remote(source)?;
-        if parsed.url != source {
-            return Err(Error::msg(format!(
-                "Manifest source must be canonical GitHub HTTPS URL: {name}"
-            )));
-        }
-        let revision = revision
-            .ok_or_else(|| Error::msg(format!("Remote lock entry missing revision: {name}")))?;
-        if !(revision.len() == 40 || revision.len() == 64)
-            || !revision.chars().all(|c| c.is_ascii_hexdigit())
-        {
-            return Err(Error::msg(format!(
-                "Invalid revision for project lockfile skill: {name}"
-            )));
-        }
-        let source_path =
-            path.ok_or_else(|| Error::msg(format!("Remote lock entry missing path: {name}")))?;
-        if source_path.starts_with('/') || source_path.contains("..") || source_path.contains('\\')
-        {
-            return Err(Error::msg(format!(
-                "Invalid source path for project lockfile skill: {name}"
-            )));
-        }
-    } else {
-        if revision.is_some() || path.is_some() {
-            return Err(Error::msg(format!(
-                "Local lock entry has remote fields: {name}"
-            )));
-        }
-        normalize_project_path(Path::new(source), name)?;
-    }
-    Ok(())
-}
-
 fn validate_manifest(manifest: &Manifest) -> Result<(), Error> {
     validate_version(manifest.version)?;
     let mut names = BTreeMap::new();
     for skill in &manifest.skills {
         validate_name(&skill.name, "project manifest", &mut names)?;
-        if skill.source.starts_with("https://") {
-            let parsed = sources::parse_remote(&skill.source)?;
-            if parsed.url != skill.source {
-                return Err(Error::msg(format!(
-                    "Manifest source must be canonical GitHub HTTPS URL: {}",
-                    skill.name
-                )));
-            }
-            if let Some(path) = &skill.path {
-                if path.starts_with('/') || path.contains("..") || path.contains('\\') {
-                    return Err(Error::msg(format!(
-                        "Invalid source path for project manifest skill: {}",
-                        skill.name
-                    )));
-                }
-            }
-        } else if skill.path.is_some() {
-            return Err(Error::msg(format!(
-                "Local manifest skill has remote path: {}",
-                skill.name
-            )));
-        }
+        sources::validate_manifest_source(&skill.name, &skill.source, skill.path.as_deref())?;
     }
     Ok(())
 }
 
-fn validate_lock(lock: &Lockfile) -> Result<(), Error> {
+fn resolve_lock(root: &Path, lock: Lockfile) -> Result<ResolvedLockfile, Error> {
     validate_version(lock.version)?;
     let mut names = BTreeMap::new();
-    for skill in &lock.skills {
+    let mut skills = Vec::with_capacity(lock.skills.len());
+    for skill in lock.skills {
         validate_name(&skill.name, "project lockfile", &mut names)?;
         if skill.sha256.len() != 64 || !skill.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
             return Err(Error::msg(format!(
@@ -215,14 +137,20 @@ fn validate_lock(lock: &Lockfile) -> Result<(), Error> {
                 skill.name
             )));
         }
-        validate_source(
-            &skill.source,
-            skill.path.as_deref(),
-            skill.revision.as_deref(),
+        let source = sources::classify_locked(
+            root,
             &skill.name,
+            &skill.source,
+            skill.revision.as_deref(),
+            skill.path.as_deref(),
         )?;
+        skills.push(ResolvedLockedSkill {
+            name: skill.name,
+            source,
+            sha256: skill.sha256,
+        });
     }
-    Ok(())
+    Ok(ResolvedLockfile { skills })
 }
 
 pub fn lock(root: &Path, source_args: &[String]) -> Result<usize, Error> {
@@ -254,7 +182,7 @@ pub fn lock(root: &Path, source_args: &[String]) -> Result<usize, Error> {
         } else {
             let source = if skill.name == "manage-tink" {
                 // Embedded by `tink init`; it has no user-facing source path.
-                "tink:embedded/manage-tink".to_string()
+                sources::EMBEDDED_MANAGE_TINK.to_string()
             } else {
                 local_sources.remove(&skill.name).ok_or_else(|| {
                     Error::msg(format!(
@@ -277,7 +205,7 @@ pub fn lock(root: &Path, source_args: &[String]) -> Result<usize, Error> {
             } else {
                 source_path.to_path_buf()
             };
-            let source = normalize_project_path(&source_path, &skill.name)?;
+            let source = sources::normalize_project_path(&source_path, &skill.name)?;
             (source, None, None)
         };
         let sha256 = tree_sha256(&skill.path)?;
@@ -411,18 +339,14 @@ pub fn sync(root: &Path) -> Result<usize, Error> {
     }
     for (name, declaration) in &declarations {
         let pin = pins[name];
-        if pin.source != declaration.source || pin.path != declaration.path {
+        if pin.source.declared() != declaration.source
+            || pin.source.source_path() != declaration.path.as_deref()
+        {
             return Err(Error::msg(format!(
                 "Project lockfile does not match manifest: {name}"
             )));
         }
-        crate::add::add_locked_skill(
-            root,
-            name,
-            &pin.source,
-            pin.revision.as_deref(),
-            pin.path.as_deref(),
-        )?;
+        crate::add::add_locked_skill(root, name, pin.source.clone())?;
     }
     verify(root)
 }
@@ -440,7 +364,9 @@ pub fn verify(root: &Path) -> Result<usize, Error> {
     }
     for (name, declaration) in &declarations {
         let pin = pins[name];
-        if pin.source != declaration.source || pin.path != declaration.path {
+        if pin.source.declared() != declaration.source
+            || pin.source.source_path() != declaration.path.as_deref()
+        {
             return Err(Error::msg(format!(
                 "Project lockfile does not match manifest: {name}"
             )));
@@ -456,11 +382,11 @@ pub fn verify(root: &Path) -> Result<usize, Error> {
             return Err(Error::msg(format!("Skill content hash mismatch: {name}")));
         }
         let receipt = provenance::read(skill)?;
-        match (&pin.revision, receipt) {
+        match (pin.source.revision(), receipt) {
             (Some(revision), Some(receipt))
-                if receipt.get("source") == Some(&pin.source)
-                    && receipt.get("revision") == Some(revision)
-                    && receipt.get("path") == pin.path.as_ref() => {}
+                if receipt.get("source").map(String::as_str) == Some(pin.source.declared())
+                    && receipt.get("revision").map(String::as_str) == Some(revision)
+                    && receipt.get("path").map(String::as_str) == pin.source.source_path() => {}
             (None, None) => {}
             (Some(_), _) => {
                 return Err(Error::msg(format!(

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1,11 +1,219 @@
-//! Remote source parsing (public GitHub only).
+//! Source classification and remote parsing.
+
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::Error;
+
+pub const EMBEDDED_MANAGE_TINK: &str = "tink:embedded/manage-tink";
+
+#[derive(Debug)]
+pub enum AddSource {
+    LocalPath(PathBuf),
+    Github(RemoteSource),
+    LibraryName(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum LockedSource {
+    LocalPath {
+        declared: String,
+        path: PathBuf,
+    },
+    Github {
+        remote: RemoteSource,
+        revision: String,
+        path: String,
+    },
+    EmbeddedManageTink,
+}
+
+impl LockedSource {
+    pub fn declared(&self) -> &str {
+        match self {
+            Self::LocalPath { declared, .. } => declared,
+            Self::Github { remote, .. } => &remote.url,
+            Self::EmbeddedManageTink => EMBEDDED_MANAGE_TINK,
+        }
+    }
+
+    pub fn revision(&self) -> Option<&str> {
+        match self {
+            Self::Github { revision, .. } => Some(revision),
+            _ => None,
+        }
+    }
+
+    pub fn source_path(&self) -> Option<&str> {
+        match self {
+            Self::Github { path, .. } => Some(path),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct RemoteSource {
     pub display: String,
     pub url: String,
+}
+
+/// Classify ambiguous command-line input once, using the documented add precedence.
+pub fn classify_add_input(value: &str) -> Result<AddSource, Error> {
+    let path = Path::new(value);
+    if path.exists() {
+        return Ok(AddSource::LocalPath(path.to_path_buf()));
+    }
+    if looks_like_filesystem_path(value) {
+        return Err(Error::msg(format!("Path does not exist: {value}")));
+    }
+    if looks_like_remote_source(value) {
+        return Ok(AddSource::Github(parse_remote(value)?));
+    }
+    Ok(AddSource::LibraryName(value.to_string()))
+}
+
+/// Recover the source kind from lockfile structure, never from path existence.
+pub fn classify_locked(
+    project_root: &Path,
+    name: &str,
+    source: &str,
+    revision: Option<&str>,
+    source_path: Option<&str>,
+) -> Result<LockedSource, Error> {
+    if source == EMBEDDED_MANAGE_TINK {
+        if name != "manage-tink" {
+            return Err(Error::msg(format!(
+                "Embedded source does not provide skill: {name}"
+            )));
+        }
+        if revision.is_some() || source_path.is_some() {
+            return Err(Error::msg(format!(
+                "Embedded lock entry has remote fields: {name}"
+            )));
+        }
+        return Ok(LockedSource::EmbeddedManageTink);
+    }
+    if source.starts_with("https://") {
+        let remote = parse_remote(source)?;
+        if remote.url != source {
+            return Err(Error::msg(format!(
+                "Manifest source must be canonical GitHub HTTPS URL: {name}"
+            )));
+        }
+        let revision = revision
+            .ok_or_else(|| Error::msg(format!("Remote lock entry missing revision: {name}")))?;
+        if !(revision.len() == 40 || revision.len() == 64)
+            || !revision.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            return Err(Error::msg(format!(
+                "Invalid revision for project lockfile skill: {name}"
+            )));
+        }
+        let source_path = source_path
+            .ok_or_else(|| Error::msg(format!("Remote lock entry missing path: {name}")))?;
+        validate_remote_path(source_path, name, "lockfile")?;
+        return Ok(LockedSource::Github {
+            remote,
+            revision: revision.to_string(),
+            path: source_path.to_string(),
+        });
+    }
+    if revision.is_some() || source_path.is_some() {
+        return Err(Error::msg(format!(
+            "Local lock entry has remote fields: {name}"
+        )));
+    }
+    normalize_project_path(Path::new(source), name)?;
+    Ok(LockedSource::LocalPath {
+        declared: source.to_string(),
+        path: project_root.join(source),
+    })
+}
+
+pub fn validate_manifest_source(
+    name: &str,
+    source: &str,
+    source_path: Option<&str>,
+) -> Result<(), Error> {
+    if source == EMBEDDED_MANAGE_TINK {
+        if name != "manage-tink" {
+            return Err(Error::msg(format!(
+                "Embedded source does not provide skill: {name}"
+            )));
+        }
+        if source_path.is_some() {
+            return Err(Error::msg(format!(
+                "Embedded manifest skill has remote path: {name}"
+            )));
+        }
+        return Ok(());
+    }
+    if source.starts_with("https://") {
+        let remote = parse_remote(source)?;
+        if remote.url != source {
+            return Err(Error::msg(format!(
+                "Manifest source must be canonical GitHub HTTPS URL: {name}"
+            )));
+        }
+        if let Some(path) = source_path {
+            validate_remote_path(path, name, "manifest")?;
+        }
+        return Ok(());
+    }
+    if source_path.is_some() {
+        return Err(Error::msg(format!(
+            "Local manifest skill has remote path: {name}"
+        )));
+    }
+    normalize_project_path(Path::new(source), name).map(|_| ())
+}
+
+fn validate_remote_path(path: &str, name: &str, kind: &str) -> Result<(), Error> {
+    if path.starts_with('/') || path.contains("..") || path.contains('\\') {
+        return Err(Error::msg(format!(
+            "Invalid source path for project {kind} skill: {name}"
+        )));
+    }
+    Ok(())
+}
+
+pub fn normalize_project_path(path: &Path, name: &str) -> Result<String, Error> {
+    if path.as_os_str().is_empty() || path.to_string_lossy().contains('\\') {
+        return Err(Error::msg(format!(
+            "Project source must be a non-empty relative path: {name}"
+        )));
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(Error::msg(format!(
+                    "Project source must stay inside project: {name}"
+                )));
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err(Error::msg(format!(
+            "Project source must be a non-empty relative path: {name}"
+        )));
+    }
+    Ok(normalized.to_string_lossy().replace('\\', "/"))
+}
+
+fn looks_like_remote_source(value: &str) -> bool {
+    value.contains('/') || value.contains("://")
+}
+
+fn looks_like_filesystem_path(value: &str) -> bool {
+    let path = Path::new(value);
+    path.is_absolute()
+        || value.starts_with("./")
+        || value.starts_with("../")
+        || value.starts_with("~/")
+        || value.contains('\\')
 }
 
 fn github_part_ok(part: &str) -> bool {
@@ -135,5 +343,37 @@ mod tests {
     fn accepts_owner_repo() {
         let remote = parse_remote("example/skills").unwrap();
         assert_eq!(remote.url, "https://github.com/example/skills.git");
+    }
+
+    #[test]
+    fn classifies_add_input_variants() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            classify_add_input(temp.path().to_str().unwrap()).unwrap(),
+            AddSource::LocalPath(_)
+        ));
+        assert!(classify_add_input("./definitely-missing").is_err());
+        assert!(matches!(
+            classify_add_input("example/skills").unwrap(),
+            AddSource::Github(_)
+        ));
+        assert!(matches!(
+            classify_add_input("https://github.com/example/skills").unwrap(),
+            AddSource::Github(_)
+        ));
+        assert!(matches!(
+            classify_add_input("reviewer").unwrap(),
+            AddSource::LibraryName(name) if name == "reviewer"
+        ));
+        assert!(classify_add_input(EMBEDDED_MANAGE_TINK).is_err());
+    }
+
+    #[test]
+    fn locked_local_source_does_not_become_github_when_missing() {
+        let root = Path::new("/project");
+        assert!(matches!(
+            classify_locked(root, "local-skill", "owner/repo-shape", None, None).unwrap(),
+            LockedSource::LocalPath { path, .. } if path == root.join("owner/repo-shape")
+        ));
     }
 }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -541,6 +541,20 @@ fn r2_add_rejects_non_github_remote() {
 }
 
 #[test]
+fn r2_add_rejects_embedded_lock_source() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    ws.cmd(&project)
+        .args(["skill", "add", "tink:embedded/manage-tink"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Remote sources must be public GitHub HTTPS URLs or owner/repository",
+        ));
+}
+
+#[test]
 fn r3_add_dot_slash_missing_is_path_not_github() {
     let ws = Workspace::new();
     let project = ws.project("app");
@@ -826,6 +840,61 @@ fn m3_skill_sync_restores_missing_local_skill() {
         .args(["skill", "verify"])
         .assert()
         .success();
+}
+
+#[test]
+fn m4_skill_sync_restores_embedded_manage_tink() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--with-manage-tink"])
+        .assert()
+        .success();
+    ws.cmd(&project).args(["skill", "lock"]).assert().success();
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .success();
+    fs::remove_dir_all(Workspace::skill_path(&project, "manage-tink")).unwrap();
+    ws.cmd(&project)
+        .args(["skill", "sync"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Synced 1 manifest skill(s)"));
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn m5_skill_sync_keeps_missing_local_source_local() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    let source = project.join("owner").join("repo-shape");
+    write_skill(&source, "local-skill", "body");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+    ws.cmd(&project)
+        .args(["skill", "lock", "--source", "local-skill=owner/repo-shape"])
+        .assert()
+        .success();
+    fs::remove_dir_all(Workspace::skill_path(&project, "local-skill")).unwrap();
+    fs::remove_dir_all(project.join("owner")).unwrap();
+    ws.cmd(&project)
+        .args(["skill", "sync"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("Path does not exist")
+                .and(predicate::str::contains("github.com").not()),
+        );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- classify free-form add inputs and locked sources into distinct typed boundaries
- resolve lockfile sources once so missing local paths cannot become GitHub remotes during sync
- restore embedded manage-tink skills from their lock source without exposing the internal token through free-form add

## Root cause

Raw source strings were repeatedly reclassified using context-dependent heuristics. Verification consumed lockfile structure directly, while synchronization sent the same values back through free-form add classification, producing divergent behavior.

## User impact

Project sync now preserves locked source intent: local sources fail as missing local paths, GitHub sources remain pinned remotes, and embedded manage-tink installs can be restored. Existing free-form owner/repository behavior is unchanged.

## Validation

- cargo test --all-targets --all-features (36 unit, 71 acceptance)
- cargo check --all-targets --all-features
- cargo fmt --all
- git diff --check

## Scope

This does not address atomic swap/install policy work in #28-#30, broader validation deduplication in #31, or #26.

Closes #24
Closes #25
Closes #27