### PR TITLE
Add project-owned skillsets and GitHub inspection

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -32,6 +32,7 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill check` | Validate project skills; no network; no writes |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
 | `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` and drop that name from the by-project catalog (not library) |
+| `tink inspect <GITHUB_URL>` | Inspect skills and source-defined skillsets in a public GitHub URL without writing project or home state |
 | `tink update` | Replace this binary with the latest public GitHub Release (requires `curl` + `tar`) |
 | `tink destroy [--yes]` | Remove `.agents/`, `ZEN.md`, and `AGENTS.md`; drop this project's by-project catalog entry (not library) |
 
@@ -84,6 +85,35 @@ Ids are stable. Tests must name or comment the id they prove.
 | R3 | `skill add ./missing-skill` (path-like, absent) | Exit ≠ 0; "Path does not exist"; **no** GitHub network fetch |
 | R4 | `skill add /abs/missing` | Exit ≠ 0; "Path does not exist" |
 | R5 | `skill add owner/repo` when `SKILL.md` is at repo root | Receipt `path` is `"."` (non-empty); `skill check` passes; `skill refresh` updates from repo root |
+
+### Skillsets
+
+| Id | Action | Expect |
+|---|---|---|
+| K1 | `skillset add <name>-skillset` with `$TINK_HOME/catalog/by-skillset/<name>-skillset/meta.json` | Installs the pinned members under `.agents/skills/<name>-skillset/`, validates the project, then mirrors that exact tree to `$TINK_HOME/skills/<name>-skillset/`; matching re-add is a no-op; library drift is repaired from the valid project |
+| K2 | `skillset remove <name>-skillset` after K1 | Removes only the project skillset tree; preserves the shared catalog definition and home library copy; `skill remove` refuses the skillset root |
+| K3 | `skillset list [--library]` after K1 | Lists receipt-backed skillset names from the current project or home library without network or writes |
+| K4 | Any skillset command receives a name without `-skillset` | Exit ≠ 0; clear canonical-name error; no skillset tree written |
+| K5 | `skillset add` finds an ordinary or unowned library entry at the canonical name | Exit ≠ 0 before network/project publication; preserve the library entry |
+| K6 | `skillset remove` finds a missing or invalid receipt | Exit ≠ 0; preserve the complete project directory |
+| K7 | `skillset list` or `add` runs before project/catalog setup | List explains how to initialize; missing catalog leaves the project untouched |
+| K8 | Re-add a valid unchanged project skillset while its remote is unavailable | Succeeds offline as unchanged and synchronizes the library from the project |
+| K9 | `skill check` / `skill list` with grouped members only | Check reports standalone, skillset, and member counts; list says there are no standalone skills and points to `skillset list` |
+| K10 | `skillset refresh <name>-skillset` after the pinned catalog definition changes | Atomically replaces the clean project tree, then mirrors the validated result to the library; refuses local project modifications |
+| K11 | A declared member folder and its `SKILL.md` name differ | Exit ≠ 0 before project or library publication; explain the name mismatch |
+
+### GitHub inspection
+
+| Id | Action | Expect |
+|---|---|---|
+| G1 | `inspect` a repository URL | Reports source metadata, inferred source skillsets including empty peers, and all discovered skills in deterministic order |
+| G2 | `inspect` a group tree URL | Reports only the one inferred skillset and skills beneath that boundary |
+| G3 | `inspect` a skill tree URL | Reports one skill and zero skillsets |
+| G4 | `inspect` a repository with one non-`skills` structural wrapper | Infers grouped skillsets without relying on a literal `skills/` directory |
+| G5 | `inspect` duplicate names and invalid `SKILL.md` files | Succeeds with visible diagnostics and excludes invalid candidates from the skill count |
+| G6 | `inspect` an empty valid directory | Succeeds with zero skills and a structural diagnostic |
+| G7 | `inspect` unsupported URLs, missing or ambiguous slash-containing refs, and missing boundaries | Exits nonzero with actionable errors |
+| G8 | `inspect` with existing project and home state | Leaves both project and `$TINK_HOME` absent or byte-for-byte unchanged |
 
 ### Check
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 Skill manager that makes sense to you, and your agent.
 
-Live skills live only under a project’s `.agents/skills/<name>/`. There is no
-registry and no daemon. Agents that already look for project skills find them
-there.
+Live skills live only under a project’s `.agents/skills/<name>/`. Grouped
+skillsets use one canonical nested root at
+`.agents/skills/<name>-skillset/<member>/`. There
+is no registry and no daemon. Agents that already look for project skills find
+them there.
 
 ## Install
 
@@ -123,6 +125,12 @@ tink skill add ../my-skill
 tink skill add skill-name
 tink skill add owner/repository --skill skill-name
 tink skill add jon-devlapaz/tink-skills --skill skill-eval-loop
+tink skillset add common-skillset
+tink skillset list
+tink skillset list --library
+tink skillset refresh common-skillset
+tink skillset remove common-skillset
+tink inspect https://github.com/mattpocock/skills
 tink skill list
 tink skill check
 tink skill refresh
@@ -136,6 +144,31 @@ tink skill remove skill-name
 - tink does not overwrite a project skill that differs from what it would
   install.
 - tink never inits Git, stages, commits, or pushes.
+
+### Skillsets
+
+Skillset names are explicit and canonical: every name must end in `-skillset`;
+Tink never appends or removes that suffix. `skillset add NAME-skillset` reads
+the pinned definition at
+`$TINK_HOME/catalog/by-skillset/NAME-skillset/meta.json`. The definition contains an
+absolute HTTPS Git URL, a full commit SHA, a repository-relative `sourceRoot`,
+and explicit member names. Tink copies those member skill trees atomically
+under `.agents/skills/NAME-skillset/`, validates the project tree, then mirrors
+that exact tree to `$TINK_HOME/skills/NAME-skillset/`. The project is primary;
+the home library conforms to it and never overwrites it. Both copies carry
+`.tink-skillset.json` as derived receipt evidence. Repeated identical installs
+are offline no-ops. `skillset refresh NAME-skillset` updates a clean project to
+its pinned catalog definition; local project modifications are refused. Library
+drift is repaired only from a valid project tree.
+`skillset remove NAME-skillset` removes only the project tree; it preserves the
+shared catalog definition and home library copy.
+`skillset list` lists receipt-backed skillsets installed in the current project.
+`skillset list --library` lists receipt-backed skillsets in the home library.
+
+`tink inspect <GITHUB_URL>` performs a read-only inspection of a public GitHub
+repository, folder, or skill URL. It reports directories containing valid
+`SKILL.md` files and infers source skillsets from the URL boundary's directory
+structure. Inspection never writes the project, catalog, or home library.
 
 ## Power
 

--- a/docs/GITHUB-INSPECTION-SPEC.md
+++ b/docs/GITHUB-INSPECTION-SPEC.md
@@ -1,0 +1,300 @@
+# GitHub Source Inspection Specification
+
+## Status
+
+Implementation-ready specification for the first read-only `tink inspect`
+tracer bullet.
+
+## Purpose
+
+Given a supported GitHub repository, folder, or skill URL, report the skills
+and source-defined skillsets visible inside that URL boundary. Inspection must
+not modify the current project, Tink home, catalog, or library.
+
+This command discovers source structure. It does not install, register, or name
+new project content.
+
+## Domain language
+
+- **Inspection boundary**: the repository subtree selected by the input URL.
+- **Discovered skill**: a directory inside the boundary containing a regular,
+  valid `SKILL.md`.
+- **Skill collection root**: the directory whose immediate child directories
+  represent source-defined skillset groups.
+- **Source skillset**: an immediate child directory of the skill collection
+  root. Its proposed canonical Tink name is `<folder>-skillset` when the folder
+  is already a valid Tink name.
+- **Structural wrapper**: a directory between the inspection boundary and the
+  skill collection root that contains one skill-bearing child and no direct
+  discovered skills.
+- **Diagnostic**: an ambiguity or invalid source condition that prevents Tink
+  from presenting an item as an unqualified skill or skillset.
+
+Skills are marker-defined by `SKILL.md`. Skillsets are boundary-defined by the
+source directory structure.
+
+## Public interface
+
+```text
+tink inspect <GITHUB_URL>
+```
+
+The MVP accepts canonical public GitHub HTTPS URLs in these forms:
+
+```text
+https://github.com/<owner>/<repository>
+https://github.com/<owner>/<repository>.git
+https://github.com/<owner>/<repository>/tree/<ref>/<path>
+```
+
+For a repository URL, the inspection boundary is the repository root at the
+remote default branch. For a tree URL, the inspection boundary is `<path>` at
+`<ref>`.
+
+Refs containing `/` are out of scope for this tracer bullet because the GitHub
+URL does not unambiguously separate such a ref from the path without additional
+remote resolution. Tink must refuse them with an actionable error rather than
+guessing.
+
+The command has no flags in the MVP. Machine-readable output, local paths,
+GitLab, SSH URLs, private repositories, installation, and catalog writes are
+out of scope.
+
+## Source resolution
+
+1. Parse the URL into canonical clone URL, requested ref, and boundary path.
+2. Clone into a temporary directory without writing Tink or project state.
+3. Resolve the inspected checkout to a full immutable Git commit ID.
+4. Validate that the boundary exists as a regular directory inside the
+   checkout.
+5. Never follow symbolic links while discovering skills.
+6. Delete temporary checkout state when the command exits.
+
+The reported source must contain:
+
+```text
+Repository: https://github.com/<owner>/<repository>.git
+Revision:   <full commit ID>
+Boundary:   <repository-relative POSIX path or .>
+```
+
+## Skill discovery
+
+Walk the inspection boundary recursively in deterministic lexical path order.
+A candidate is a directory containing a regular `SKILL.md`.
+
+For every candidate:
+
+1. Reuse Tink's existing `SKILL.md` validation.
+2. Read its canonical name from frontmatter.
+3. Record its repository-relative POSIX directory path.
+4. Do not require the directory basename to equal the frontmatter name during
+   inspection; report a mismatch as a diagnostic.
+5. Report duplicate canonical names as diagnostics while retaining every
+   candidate path in the output.
+6. Report nested/overlapping skill roots as diagnostics rather than silently
+   discarding either candidate.
+
+Invalid `SKILL.md` candidates are diagnostics and are not counted as discovered
+skills. A valid source with zero discovered skills is a successful inspection.
+
+## Skillset inference
+
+Inference operates only inside the inspection boundary and never changes the
+discovered skill list.
+
+### Boundary is a skill
+
+If the boundary itself contains `SKILL.md`, report that one skill and no
+skillsets. Do not infer a one-member skillset.
+
+### Boundary directly contains skills
+
+If one or more immediate child directories of the boundary are discovered
+skills and no other immediate child contains deeper discovered skills, treat the
+boundary as one source skillset. Use the boundary folder name to propose
+`<folder>-skillset`. A repository-root boundary has no folder name; in that case
+report an unnamed boundary proposal rather than inventing a name.
+
+The exact directory basename `skills` is reserved as a structural collection
+root and is never itself a source skillset. If `skills/` directly contains
+discovered skills, report those skills and zero skillsets. If it contains
+grouped skills, infer meaningful child groups normally. This rule applies
+equally when `skills/` is reached through a repository URL or selected directly
+by a tree URL. A repository whose own name is `skills` is unaffected because
+its repository-root boundary is `.`.
+
+If direct skills coexist with one or more nested skill-bearing collections,
+report the skills but infer no skillsets. Emit a diagnostic explaining that the
+mixed root is ambiguous and that inspecting a narrower tree URL can select the
+intended collection. Do not collapse unrelated levels into one skillset.
+
+### Boundary contains grouped skills
+
+If the boundary has no direct skill children and at least two immediate child
+directories contain descendant discovered skills, treat the boundary as the
+skill collection root. Every regular, non-hidden immediate child directory is a
+source skillset, including empty peers. Its member count is the number of
+discovered skills beneath that child.
+
+This rule intentionally reports an empty structural peer such as
+`skills/deprecated/` alongside populated groups. Display zero-member groups as
+empty structural candidates so users can distinguish structural inference from
+a skill-backed group.
+
+### Single structural wrapper
+
+If the boundary has no direct skill children and exactly one immediate child
+directory that is non-hidden, regular, and contains descendant discovered
+skills, descend through that child and evaluate again. Stop at the first
+directory satisfying one of the rules above. Do not descend through symlinks.
+
+This allows a repository root containing one `skills/` wrapper to expose the
+groups beneath `skills/` without encoding the literal directory name `skills`.
+
+### Ambiguous structure
+
+If no valid skills are discovered, report zero skills and a diagnostic that no
+valid skills were found in the boundary. Otherwise, if no rule yields one
+collection root, report discovered skills and a diagnostic that skillsets could
+not be inferred. Do not manufacture groupings from every ancestor directory.
+
+### Canonical skillset names
+
+When a source skillset folder is a valid Tink name, append `-skillset` in the
+displayed proposal. If it already ends in `-skillset`, use it verbatim rather
+than doubling the suffix. The resulting canonical name must also pass Tink's
+name validation, including the length limit. Inspection does not create or
+accept that name on the user's behalf. If no valid canonical name can be formed,
+report a naming diagnostic and display no canonical proposal.
+
+## Human-readable output
+
+Output has four sections in this order:
+
+1. `Source`
+2. `Skillsets (<count>, <member-count> member skills)`; each inferred skillset
+   owns its nested member list and reports its source path once
+3. `Standalone skills (<count>)`; discovered skills outside every inferred
+   skillset retain their individual source paths
+4. `Diagnostics (<count>)`, omitted when empty
+
+Within each section, entries are sorted lexically by repository-relative path.
+Do not use color when stdout is not a terminal, consistent with existing Tink
+style behavior.
+
+For `https://github.com/mattpocock/skills` at commit
+`84fdeffd12f2ee307994d1eb6feb48173b6e0502`, the semantic output is:
+
+```text
+Source
+  Repository: https://github.com/mattpocock/skills.git
+  Revision:   84fdeffd12f2ee307994d1eb6feb48173b6e0502
+  Boundary:   .
+
+Skillsets (5, 35 member skills)
+  deprecated-skillset (0 skills)  skills/deprecated/
+    (empty structural candidate)
+
+  engineering-skillset (18 skills)  skills/engineering/
+    ask-matt
+    ...
+
+  productivity-skillset (7 skills)  skills/productivity/
+    grill-me
+    ...
+    writing-for-agents
+
+Standalone skills (0)
+```
+
+For a boundary at `skills/productivity`, report one
+`productivity-skillset` proposal and its seven skills. For a boundary at
+`skills/productivity/grill-me`, report zero skillsets and the single
+`grill-me` skill.
+
+Exact spacing is not contractual. Section names, counts, canonical names,
+membership, skill names, source paths, and deterministic ordering are
+contractual.
+
+When stdout is an interactive terminal, color reinforces—but never replaces—the
+text hierarchy:
+
+- skillset names use Tink's blue grouped-identity style;
+- skill names use Tink's magenta identity style;
+- repository metadata values and source paths use Tink's cyan accent style;
+- the `Diagnostics` heading uses Tink's yellow warning style while diagnostic
+  messages remain in the terminal's default foreground;
+- headings, counts, and empty structural annotations use the terminal's default
+  foreground.
+
+Apply padding before ANSI styling so escape sequences cannot disturb column
+alignment. Non-terminal output and `NO_COLOR` output remain plain and
+byte-stable.
+
+## Side-effect contract
+
+Inspection must not create or change:
+
+- `.agents/`
+- `.tink/` inside the project
+- `$TINK_HOME`
+- skillset catalog definitions
+- home-library trees
+- Git state in the current project
+
+Network access and temporary checkout files are the only expected effects.
+
+## Failure behavior
+
+Exit nonzero with an actionable message for:
+
+- unsupported or malformed URL;
+- non-GitHub host;
+- unavailable repository or ref;
+- ambiguous slash-containing tree ref;
+- missing or non-directory boundary;
+- inability to create or cleanly use temporary checkout state.
+
+Content diagnostics inside a successfully resolved boundary do not by
+themselves make inspection fail.
+
+## Implementation ownership
+
+- `src/lib.rs`: CLI declaration, dispatch, and presentation only.
+- New `src/inspect.rs`: GitHub URL parsing, source inspection orchestration,
+  discovery result model, skillset inference, and deterministic report data.
+- `src/git.rs`: only the smallest reusable checkout primitive required to
+  inspect a requested ref.
+- `src/skills.rs`: reuse existing skill validation; do not add GitHub policy.
+- `tests/acceptance.rs`: end-to-end command behavior and side-effect proof.
+
+Do not route inspection through `skill add` or `skillset add`; those commands
+own mutation and stronger installation policy.
+
+## Acceptance criteria
+
+Add stable acceptance rows and tests proving:
+
+1. Repository URL for `mattpocock/skills` shape reports five source skillsets,
+   including empty `deprecated`, and 35 skills in deterministic order.
+2. Group tree URL reports one skillset and only skills beneath that boundary.
+3. Skill tree URL reports one skill and zero skillsets.
+4. A repository with one structural wrapper whose name is not `skills` is
+   inferred identically, proving no literal `skills/` convention.
+5. Duplicate skill names and invalid `SKILL.md` files are visible diagnostics.
+6. Empty valid boundaries succeed with zero skills and appropriate structural
+   output.
+7. Unsupported URLs, missing refs, and missing boundaries fail clearly.
+8. Inspection leaves the project and `$TINK_HOME` absent or byte-for-byte
+   unchanged.
+
+All existing unit and acceptance tests, formatting, and `git diff --check`
+must remain green.
+
+## Out of scope and next decision
+
+This tracer bullet does not decide how discovered skills become catalog entries
+or installed skillsets. After inspecting real repository shapes, the next human
+decision is whether `tink skillset add` accepts every discovered member,
+requires explicit confirmation, or accepts an explicit subset.

--- a/src/check.rs
+++ b/src/check.rs
@@ -22,6 +22,12 @@ fn read_skill_entry(path: &Path) -> Result<Option<Skill>, Error> {
             "Unexpected entry in .agents/skills: {name}"
         )));
     }
+    if path.join(crate::skillsets::RECEIPT_FILE).exists()
+        || path.join(crate::skillsets::RECEIPT_FILE).is_symlink()
+    {
+        crate::skillsets::validate_installed(path)?;
+        return Ok(None);
+    }
     let skill = skills::read_skill(path, true)?;
     provenance::read(&skill)?;
     Ok(Some(skill))

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,6 @@
 //! Git checkout helpers for public GitHub sources.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -96,20 +97,64 @@ pub fn remote_head(remote: &RemoteSource) -> Result<String, Error> {
     Ok(revision)
 }
 
+/// List branch and tag names advertised by a remote.
+pub fn remote_ref_names(remote: &RemoteSource) -> Result<BTreeSet<String>, Error> {
+    let output = run_git(
+        &["ls-remote", "--quiet", "--heads", "--tags", &remote.url],
+        None,
+        true,
+        "git ls-remote",
+        Some("Git is required for remote skill sources"),
+    )?;
+    if !output.status.success() {
+        let detail = git_detail(&output.stderr, "git ls-remote failed");
+        return Err(Error::msg(format!(
+            "Could not resolve refs for {}: {detail}",
+            remote.url
+        )));
+    }
+
+    let mut names = BTreeSet::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Some(reference) = line.split_whitespace().nth(1) else {
+            continue;
+        };
+        let reference = reference.trim_end_matches("^{}");
+        if let Some(name) = reference
+            .strip_prefix("refs/heads/")
+            .or_else(|| reference.strip_prefix("refs/tags/"))
+        {
+            names.insert(name.to_string());
+        }
+    }
+    Ok(names)
+}
+
 /// Clone `remote` into a temporary directory; return `(temp_keep_alive, repo_path, revision)`.
 pub fn checkout(remote: &RemoteSource) -> Result<(TempDir, PathBuf, String), Error> {
+    checkout_ref(remote, None)
+}
+
+/// Clone `remote`, optionally checking out the requested branch or tag.
+pub fn checkout_ref(
+    remote: &RemoteSource,
+    requested_ref: Option<&str>,
+) -> Result<(TempDir, PathBuf, String), Error> {
     let temp = TempDir::new().map_err(|e| Error::msg(format!("temp dir: {e}")))?;
     let repository = temp.path().join("repository");
+    let repository_string = repository
+        .to_str()
+        .ok_or_else(|| Error::msg("non-utf8 path"))?
+        .to_string();
+    let mut args = vec!["clone", "--quiet", "--no-tags"];
+    if let Some(requested_ref) = requested_ref {
+        args.push("--branch");
+        args.push(requested_ref);
+    }
+    args.push(&remote.url);
+    args.push(&repository_string);
     let output = run_git(
-        &[
-            "clone",
-            "--quiet",
-            "--no-tags",
-            &remote.url,
-            repository
-                .to_str()
-                .ok_or_else(|| Error::msg("non-utf8 path"))?,
-        ],
+        &args,
         None,
         true,
         "git clone",
@@ -117,9 +162,12 @@ pub fn checkout(remote: &RemoteSource) -> Result<(TempDir, PathBuf, String), Err
     )?;
     if !output.status.success() {
         let detail = git_detail(&output.stderr, "git clone failed");
+        let subject = requested_ref
+            .map(|requested_ref| format!(" ref {requested_ref}"))
+            .unwrap_or_default();
         return Err(Error::msg(format!(
-            "Could not fetch {}: {detail}",
-            remote.url
+            "Could not fetch {}{}: {detail}",
+            remote.url, subject
         )));
     }
     let revision = git_stdout(&repository, &["rev-parse", "HEAD"])?;

--- a/src/home.rs
+++ b/src/home.rs
@@ -15,6 +15,7 @@ pub const TINK_HOME_NAME: &str = ".tink";
 pub const LAYOUT_FILENAME: &str = "layout.json";
 pub const LAYOUT_KIND: &str = "tink-skill-inventory";
 pub const BY_PROJECT: &str = "by-project";
+pub const BY_SKILLSET: &str = "by-skillset";
 
 /// Project agent directory (`.agents`) — the single owner of this layout decision.
 pub const PROJECT_AGENTS_DIR: &str = ".agents";
@@ -40,8 +41,10 @@ Tink home directory. This is **not** an agent skill discovery root. Agents load
 skills only from a project's `.agents/skills/`.
 
 Successful installs:
-- copy skill trees into the library under `skills/<name>/` (divergent entries are repaired)
+- copy skill and validated project skillset trees into the library under `skills/<name>/`
+- skillsets use canonical `<name>-skillset` roots; their project tree is primary
 - record skill **names** under `catalog/by-project/<project>/meta.json`
+- read pinned skillset definitions from `catalog/by-skillset/<name>/meta.json`
 
 `skill remove` and `destroy` update that name catalog; they do not delete
 library trees.
@@ -93,6 +96,11 @@ pub fn by_project_path(home: &Path) -> PathBuf {
     home.join("catalog").join(BY_PROJECT)
 }
 
+/// Path to the catalog of authored skillset definitions.
+pub fn by_skillset_path(home: &Path) -> PathBuf {
+    home.join("catalog").join(BY_SKILLSET)
+}
+
 /// Path to the skill-tree library root (`skills/`).
 pub fn skills_library_path(home: &Path) -> PathBuf {
     home.join("skills")
@@ -120,6 +128,7 @@ pub fn ensure_inventory_root(root: Option<&Path>) -> Result<(PathBuf, bool), Err
     mkdir_p(&skills_library_path(&root))?;
     migrate_catalog_if_needed(&root)?;
     mkdir_p(&by_project_path(&root))?;
+    mkdir_p(&by_skillset_path(&root))?;
     write_layout_marker(&root)?;
     Ok((root, created))
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,0 +1,511 @@
+//! Read-only inspection of GitHub source structure.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::Error;
+use crate::git;
+use crate::skills;
+use crate::sources::RemoteSource;
+
+#[derive(Debug)]
+struct ParsedUrl {
+    remote: RemoteSource,
+    requested_ref: Option<String>,
+    boundary: PathBuf,
+    boundary_display: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredSkill {
+    pub name: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct InferredSkillset {
+    pub name: Option<String>,
+    pub path: String,
+    pub members: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct InspectionReport {
+    pub repository: String,
+    pub revision: String,
+    pub boundary: String,
+    pub skillsets: Vec<InferredSkillset>,
+    pub skills: Vec<DiscoveredSkill>,
+    pub diagnostics: Vec<String>,
+}
+
+pub fn inspect(url: &str) -> Result<InspectionReport, Error> {
+    let parsed = parse_url(url)?;
+    reject_ambiguous_ref(&parsed)?;
+    let (_temp, checkout, revision) =
+        git::checkout_ref(&parsed.remote, parsed.requested_ref.as_deref())?;
+    let boundary = checkout.join(&parsed.boundary);
+    let metadata = fs::symlink_metadata(&boundary).map_err(|_| {
+        Error::msg(format!(
+            "Inspection boundary does not exist: {}",
+            parsed.boundary_display
+        ))
+    })?;
+    if !metadata.is_dir() {
+        return Err(Error::msg(format!(
+            "Inspection boundary is not a directory: {}",
+            parsed.boundary_display
+        )));
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut discovered = Vec::new();
+    discover_skills(&checkout, &boundary, &mut discovered, &mut diagnostics)?;
+    discovered.sort_by(|left, right| left.path.cmp(&right.path));
+    diagnostics.extend(duplicate_diagnostics(&discovered));
+    diagnostics.extend(overlap_diagnostics(&discovered));
+    let skillsets = infer_skillsets(
+        &checkout,
+        &parsed.boundary,
+        &boundary,
+        &discovered,
+        &mut diagnostics,
+    )?;
+    for skillset in &skillsets {
+        if skillset.name.is_none() && skillset.path != "." {
+            diagnostics.push(format!(
+                "no valid canonical skillset name for {}",
+                skillset.path
+            ));
+        }
+    }
+
+    Ok(InspectionReport {
+        repository: parsed.remote.url,
+        revision,
+        boundary: parsed.boundary_display,
+        skillsets,
+        skills: discovered,
+        diagnostics,
+    })
+}
+
+fn reject_ambiguous_ref(parsed: &ParsedUrl) -> Result<(), Error> {
+    let Some(requested_ref) = parsed.requested_ref.as_deref() else {
+        return Ok(());
+    };
+    if parsed.boundary.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    let remote_refs = git::remote_ref_names(&parsed.remote)?;
+    let mut candidate = requested_ref.to_string();
+    for segment in parsed.boundary.iter() {
+        let segment = segment
+            .to_str()
+            .ok_or_else(|| Error::msg("Inspection URL contains non-UTF-8 path data"))?;
+        candidate.push('/');
+        candidate.push_str(segment);
+        if remote_refs.contains(&candidate) {
+            return Err(Error::msg(format!(
+                "Inspection URL is ambiguous because Git ref `{candidate}` contains `/`; use a ref without `/`"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn parse_url(value: &str) -> Result<ParsedUrl, Error> {
+    let parsed = value
+        .parse::<url_lite::Url>()
+        .map_err(|_| Error::msg("Inspection URL must be a public GitHub HTTPS URL"))?;
+    if parsed.scheme != "https"
+        || parsed.host.as_deref() != Some("github.com")
+        || parsed.userinfo.is_some()
+        || !parsed.query.is_empty()
+        || parsed.fragment.is_some()
+    {
+        return Err(Error::msg(
+            "Inspection URL must be a public GitHub HTTPS URL",
+        ));
+    }
+    let parts: Vec<&str> = parsed
+        .path
+        .trim_matches('/')
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect();
+    if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return Err(Error::msg(
+            "Inspection URL must identify a GitHub repository",
+        ));
+    }
+    let owner = parts[0];
+    let repository = parts[1].trim_end_matches(".git");
+    if !valid_part(owner) || !valid_part(repository) {
+        return Err(Error::msg(
+            "Inspection URL has an invalid GitHub repository",
+        ));
+    }
+    let remote = RemoteSource {
+        display: value.to_string(),
+        url: format!("https://github.com/{owner}/{repository}.git"),
+    };
+    if parts.len() == 2 {
+        return Ok(ParsedUrl {
+            remote,
+            requested_ref: None,
+            boundary: PathBuf::new(),
+            boundary_display: ".".to_string(),
+        });
+    }
+    if parts[2] != "tree" || parts.len() < 4 {
+        return Err(Error::msg(
+            "Inspection URL must use the GitHub /tree/<ref>/<path> form",
+        ));
+    }
+    let requested_ref = parts[3];
+    if requested_ref.is_empty() {
+        return Err(Error::msg("Inspection URL is missing the Git ref"));
+    }
+    let boundary_parts = &parts[4..];
+    let boundary = if boundary_parts.is_empty() {
+        PathBuf::new()
+    } else {
+        let mut boundary = PathBuf::new();
+        for part in boundary_parts {
+            if *part == "." || *part == ".." || part.contains('\\') {
+                return Err(Error::msg(
+                    "Inspection boundary must stay inside the repository",
+                ));
+            }
+            boundary.push(part);
+        }
+        boundary
+    };
+    let boundary_display = if boundary.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        boundary.to_string_lossy().replace('\\', "/")
+    };
+    Ok(ParsedUrl {
+        remote,
+        requested_ref: Some(requested_ref.to_string()),
+        boundary,
+        boundary_display,
+    })
+}
+
+fn valid_part(part: &str) -> bool {
+    !part.is_empty()
+        && !part.starts_with('.')
+        && !part.ends_with('.')
+        && part
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "_.-".contains(character))
+}
+
+fn discover_skills(
+    checkout: &Path,
+    directory: &Path,
+    discovered: &mut Vec<DiscoveredSkill>,
+    diagnostics: &mut Vec<String>,
+) -> Result<(), Error> {
+    let skill_file = directory.join("SKILL.md");
+    match fs::symlink_metadata(&skill_file) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {}
+        Ok(metadata) if metadata.is_file() => match skills::read_skill(directory, false) {
+            Ok(skill) => discovered.push(DiscoveredSkill {
+                name: skill.name.clone(),
+                path: relative_posix(checkout, directory),
+            }),
+            Err(error) => {
+                let relative_directory = relative_posix(checkout, directory);
+                let relative_skill_file = format!("{relative_directory}/SKILL.md");
+                let detail = error
+                    .to_string()
+                    .replace(skill_file.to_string_lossy().as_ref(), &relative_skill_file);
+                diagnostics.push(format!(
+                    "invalid SKILL.md at {relative_directory}: {detail}"
+                ));
+            }
+        },
+        _ => {}
+    }
+
+    if let Some(name) = discovered
+        .last()
+        .filter(|skill| skill.path == relative_posix(checkout, directory))
+        .map(|skill| skill.name.as_str())
+    {
+        let directory_name = directory
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("");
+        if name != directory_name {
+            diagnostics.push(format!(
+                "skill name {name} does not match directory {directory_name} at {}",
+                relative_posix(checkout, directory)
+            ));
+        }
+    }
+
+    let mut children = Vec::new();
+    for entry in fs::read_dir(directory).map_err(|error| {
+        Error::msg(format!(
+            "Could not read inspection boundary {}: {error}",
+            directory.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            Error::msg(format!(
+                "Could not inspect source {}: {error}",
+                directory.display()
+            ))
+        })?;
+        let path = entry.path();
+        if path.file_name().and_then(|name| name.to_str()) == Some(".git") {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(&path).map_err(|error| {
+            Error::msg(format!(
+                "Could not inspect source {}: {error}",
+                path.display()
+            ))
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            continue;
+        }
+        children.push(path);
+    }
+    children.sort();
+    for child in children {
+        discover_skills(checkout, &child, discovered, diagnostics)?;
+    }
+    Ok(())
+}
+
+fn relative_posix(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn duplicate_diagnostics(skills: &[DiscoveredSkill]) -> Vec<String> {
+    let mut by_name: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for skill in skills {
+        by_name.entry(&skill.name).or_default().push(&skill.path);
+    }
+    by_name
+        .into_iter()
+        .filter(|(_, paths)| paths.len() > 1)
+        .map(|(name, paths)| format!("duplicate skill name: {name} ({})", paths.join(", ")))
+        .collect()
+}
+
+fn overlap_diagnostics(skills: &[DiscoveredSkill]) -> Vec<String> {
+    let mut diagnostics = Vec::new();
+    for (index, ancestor) in skills.iter().enumerate() {
+        for descendant in skills.iter().skip(index + 1) {
+            if descendant.path.starts_with(&(ancestor.path.clone() + "/")) {
+                diagnostics.push(format!(
+                    "overlapping skill roots: {} and {}",
+                    ancestor.path, descendant.path
+                ));
+            }
+        }
+    }
+    diagnostics
+}
+
+fn infer_skillsets(
+    checkout: &Path,
+    boundary_path: &Path,
+    boundary: &Path,
+    skills: &[DiscoveredSkill],
+    diagnostics: &mut Vec<String>,
+) -> Result<Vec<InferredSkillset>, Error> {
+    let boundary_prefix = relative_posix(checkout, &checkout.join(boundary_path));
+    if skills.iter().any(|skill| skill.path == boundary_prefix) {
+        return Ok(Vec::new());
+    }
+    if skills.is_empty() {
+        diagnostics.push("no valid skills found in this boundary".to_string());
+        return Ok(Vec::new());
+    }
+    let direct: Vec<&DiscoveredSkill> = skills
+        .iter()
+        .filter(|skill| {
+            Path::new(&skill.path)
+                .parent()
+                .map(|parent| parent == Path::new(&boundary_prefix))
+                == Some(true)
+        })
+        .collect();
+    if !direct.is_empty() {
+        if boundary.file_name().and_then(|name| name.to_str()) == Some("skills") {
+            return Ok(Vec::new());
+        }
+        let has_nested_collection = regular_children(boundary)?.iter().any(|child| {
+            let child_path = relative_posix(checkout, child);
+            skills
+                .iter()
+                .any(|skill| skill.path.starts_with(&(child_path.clone() + "/")))
+        });
+        if has_nested_collection {
+            diagnostics.push(
+                "mixed skill layout: direct skills and nested skill collections coexist; inspect a narrower GitHub tree URL to select a skillset"
+                    .to_string(),
+            );
+            return Ok(Vec::new());
+        }
+        return Ok(vec![make_skillset(checkout, boundary, skills)]);
+    }
+    let mut children = regular_children(boundary)?;
+    children.sort();
+    let descendants: BTreeSet<PathBuf> = children
+        .iter()
+        .filter(|child| {
+            let child_path = relative_posix(checkout, child);
+            skills.iter().any(|skill| {
+                skill.path == child_path || skill.path.starts_with(&(child_path.clone() + "/"))
+            })
+        })
+        .cloned()
+        .collect();
+    if descendants.len() >= 2 {
+        return Ok(children
+            .iter()
+            .map(|child| {
+                let child_relative = relative_posix(checkout, child);
+                make_skillset(checkout, child, &skills_for_prefix(skills, &child_relative))
+            })
+            .collect());
+    }
+    if descendants.len() == 1 {
+        let child = descendants
+            .iter()
+            .next()
+            .expect("descendants length checked");
+        return infer_skillsets(checkout, child, child, skills, diagnostics);
+    }
+    diagnostics.push("skillsets could not be inferred from this boundary".to_string());
+    Ok(Vec::new())
+}
+
+fn skills_for_prefix(skills: &[DiscoveredSkill], prefix: &str) -> Vec<DiscoveredSkill> {
+    skills
+        .iter()
+        .filter(|skill| skill.path == prefix || skill.path.starts_with(&(prefix.to_string() + "/")))
+        .cloned()
+        .collect()
+}
+
+fn make_skillset(
+    checkout: &Path,
+    directory: &Path,
+    members: &[DiscoveredSkill],
+) -> InferredSkillset {
+    if directory == checkout {
+        return InferredSkillset {
+            name: None,
+            path: ".".to_string(),
+            members: members.len(),
+        };
+    }
+    let path = relative_posix(checkout, directory);
+    let folder = directory
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_string();
+    let name = if skills::valid_skill_name(&folder) {
+        let candidate = if folder.ends_with("-skillset") {
+            folder.clone()
+        } else {
+            format!("{folder}-skillset")
+        };
+        skills::valid_skill_name(&candidate).then_some(candidate)
+    } else {
+        None
+    };
+    InferredSkillset {
+        name,
+        path,
+        members: members.len(),
+    }
+}
+
+fn regular_children(directory: &Path) -> Result<Vec<PathBuf>, Error> {
+    let mut children = Vec::new();
+    for entry in fs::read_dir(directory)
+        .map_err(|error| Error::msg(format!("Could not inspect source: {error}")))?
+    {
+        let entry =
+            entry.map_err(|error| Error::msg(format!("Could not inspect source: {error}")))?;
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("");
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| Error::msg(format!("Could not inspect source: {error}")))?;
+        if !name.starts_with('.') && metadata.is_dir() && !metadata.file_type().is_symlink() {
+            children.push(path);
+        }
+    }
+    Ok(children)
+}
+
+mod url_lite {
+    #[derive(Debug)]
+    pub struct Url {
+        pub scheme: String,
+        pub host: Option<String>,
+        pub userinfo: Option<String>,
+        pub path: String,
+        pub query: String,
+        pub fragment: Option<String>,
+    }
+
+    pub fn parse(input: &str) -> Result<Url, ()> {
+        let (scheme, rest) = input.split_once("://").ok_or(())?;
+        let (authority, path_and_more) = match rest.find('/') {
+            Some(index) => (&rest[..index], &rest[index..]),
+            None => (rest, "/"),
+        };
+        let (userinfo, host) = if let Some((user, host)) = authority.split_once('@') {
+            (Some(user.to_string()), host)
+        } else {
+            (None, authority)
+        };
+        if host.is_empty() {
+            return Err(());
+        }
+        let (path_query, fragment) = match path_and_more.split_once('#') {
+            Some((path, fragment)) => (path, Some(fragment.to_string())),
+            None => (path_and_more, None),
+        };
+        let (path, query) = match path_query.split_once('?') {
+            Some((path, query)) => (path.to_string(), query.to_string()),
+            None => (path_query.to_string(), String::new()),
+        };
+        Ok(Url {
+            scheme: scheme.to_string(),
+            host: Some(host.to_string()),
+            userinfo,
+            path,
+            query,
+            fragment,
+        })
+    }
+
+    impl std::str::FromStr for Url {
+        type Err = ();
+        fn from_str(value: &str) -> Result<Self, Self::Err> {
+            parse(value)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod git;
 mod harvest;
 mod home;
 mod init;
+mod inspect;
 mod library;
 mod manage_tink;
 mod manifest;
@@ -19,6 +20,7 @@ mod provenance;
 mod refresh;
 mod remove;
 mod skills;
+mod skillsets;
 mod sources;
 mod style;
 mod templates;
@@ -29,6 +31,7 @@ use clap_complete::{
     CompletionCandidate,
     engine::{ArgValueCompleter, PathCompleter, ValueCompleter},
 };
+use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -77,6 +80,13 @@ pub enum Command {
         #[command(subcommand)]
         command: SkillCommand,
     },
+    /// Install grouped member skills as one nested project tree
+    Skillset {
+        #[command(subcommand)]
+        command: SkillsetCommand,
+    },
+    /// Inspect skills and source-defined skillsets in a public GitHub URL
+    Inspect { url: String },
     /// Remove `.agents/`, `ZEN.md`, `AGENTS.md`, and this project's catalog entry (not library)
     Destroy {
         /// Skip the confirmation prompt
@@ -133,6 +143,22 @@ pub enum SkillCommand {
     Harvest,
 }
 
+#[derive(Debug, Subcommand)]
+pub enum SkillsetCommand {
+    /// List receipt-backed skillsets installed in the current project
+    List {
+        /// List receipt-backed skillsets in the home library
+        #[arg(long)]
+        library: bool,
+    },
+    /// Install the pinned skillset named in `$TINK_HOME/catalog/by-skillset/`
+    Add { name: String },
+    /// Update one clean installed skillset to its pinned catalog definition
+    Refresh { name: String },
+    /// Remove one installed skillset without deleting its shared catalog definition
+    Remove { name: String },
+}
+
 fn add_source_candidates(current: &OsStr) -> Vec<CompletionCandidate> {
     let mut candidates = PathCompleter::any().complete(current);
     let Some(prefix) = current.to_str() else {
@@ -186,6 +212,8 @@ fn dispatch(cli: Cli, cwd: PathBuf) -> Result<(), Error> {
             flag_tri(with_manage_tink, no_manage_tink),
         ),
         Command::Skill { command } => dispatch_skill(&cwd, command),
+        Command::Skillset { command } => dispatch_skillset(&cwd, command),
+        Command::Inspect { url } => dispatch_inspect(&url),
         Command::Destroy { yes } => {
             let style = CliStyle::auto_stdout();
             let report = destroy::destroy_project(&cwd, yes)?;
@@ -210,6 +238,101 @@ fn dispatch(cli: Cli, cwd: PathBuf) -> Result<(), Error> {
     }
 }
 
+fn dispatch_inspect(url: &str) -> Result<(), Error> {
+    let style = CliStyle::auto_stdout();
+    let report = inspect::inspect(url)?;
+    println!("Source");
+    println!("  Repository: {}", style.accent(&report.repository));
+    println!("  Revision:   {}", style.accent(&report.revision));
+    println!("  Boundary:   {}", style.accent(&report.boundary));
+    println!();
+    let member_count: usize = report
+        .skillsets
+        .iter()
+        .map(|skillset| skillset.members)
+        .sum();
+    println!(
+        "Skillsets ({}, {} member skills)",
+        report.skillsets.len(),
+        member_count
+    );
+    let mut grouped_paths = BTreeSet::new();
+    for (index, skillset) in report.skillsets.iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        let name = skillset.name.as_deref().unwrap_or("(unnamed proposal)");
+        let padded_name = format!("{name:<28}");
+        let displayed_name = if skillset.name.is_some() {
+            style.skillset(padded_name)
+        } else {
+            padded_name
+        };
+        let source_path = if skillset.path == "." {
+            "./".to_string()
+        } else {
+            format!("{}/", skillset.path)
+        };
+        let noun = if skillset.members == 1 {
+            "skill"
+        } else {
+            "skills"
+        };
+        println!(
+            "  {} ({} {})  {}",
+            displayed_name,
+            skillset.members,
+            noun,
+            style.accent(source_path)
+        );
+        if skillset.members == 0 {
+            println!("    (empty structural candidate)");
+            continue;
+        }
+        let prefix = if skillset.path == "." {
+            None
+        } else {
+            Some(format!("{}/", skillset.path))
+        };
+        for skill in &report.skills {
+            if prefix
+                .as_ref()
+                .map(|prefix| skill.path.starts_with(prefix))
+                .unwrap_or(true)
+            {
+                println!("    {}", style.skill(&skill.name));
+                grouped_paths.insert(skill.path.as_str());
+            }
+        }
+    }
+    println!();
+    let standalone: Vec<_> = report
+        .skills
+        .iter()
+        .filter(|skill| !grouped_paths.contains(skill.path.as_str()))
+        .collect();
+    println!("Standalone skills ({})", standalone.len());
+    for skill in standalone {
+        let padded_name = format!("{:<28}", skill.name);
+        println!(
+            "  {} {}",
+            style.skill(padded_name),
+            style.accent(&skill.path)
+        );
+    }
+    if !report.diagnostics.is_empty() {
+        println!();
+        println!(
+            "{}",
+            style.warn(format!("Diagnostics ({})", report.diagnostics.len()))
+        );
+        for diagnostic in &report.diagnostics {
+            println!("  {diagnostic}");
+        }
+    }
+    Ok(())
+}
+
 fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
     match command {
         SkillCommand::Add { source, skill } => dispatch_skill_add(cwd, &source, skill.as_deref()),
@@ -229,6 +352,69 @@ fn dispatch_skill(cwd: &Path, command: SkillCommand) -> Result<(), Error> {
         SkillCommand::Refresh { name } => dispatch_skill_refresh(cwd, name.as_deref()),
         SkillCommand::Remove { name } => dispatch_skill_remove(cwd, &name),
         SkillCommand::Harvest => dispatch_skill_harvest(cwd),
+    }
+}
+
+fn dispatch_skillset(cwd: &Path, command: SkillsetCommand) -> Result<(), Error> {
+    match command {
+        SkillsetCommand::List { library } => {
+            let style = CliStyle::auto_stdout();
+            let names = if library {
+                skillsets::list_library(None)?
+            } else {
+                skillsets::list_installed(cwd)?
+            };
+            if names.is_empty() {
+                let message = if library {
+                    "(no library skillsets)"
+                } else {
+                    "(no skillsets)"
+                };
+                println!("{}", style.muted(message));
+            } else {
+                for name in names {
+                    println!("{}", style.skillset(name));
+                }
+            }
+            Ok(())
+        }
+        SkillsetCommand::Add { name } => {
+            let style = CliStyle::auto_stdout();
+            let (path, created, library_write) = skillsets::add_skillset(cwd, &name)?;
+            if library_write == skillsets::LibraryWrite::Repaired {
+                let err = CliStyle::auto_stderr();
+                eprintln!("{}", err.warn(format!("Updated home copy of {name}")));
+            }
+            if created {
+                println!(
+                    "{} {}",
+                    style.success("Installed"),
+                    style.accent(path.display())
+                );
+            } else {
+                println!("{} {}", style.muted("Unchanged"), style.skillset(name));
+            }
+            Ok(())
+        }
+        SkillsetCommand::Refresh { name } => {
+            let style = CliStyle::auto_stdout();
+            if skillsets::refresh_skillset(cwd, &name)? {
+                println!("{} {}", style.success("Refreshed"), style.skillset(name));
+            } else {
+                println!("{} {}", style.muted("Unchanged"), style.skillset(name));
+            }
+            Ok(())
+        }
+        SkillsetCommand::Remove { name } => {
+            let style = CliStyle::auto_stdout();
+            let path = skillsets::remove_skillset(cwd, &name)?;
+            println!(
+                "{} {}",
+                style.success("Removed"),
+                style.accent(path.display())
+            );
+            Ok(())
+        }
     }
 }
 
@@ -342,11 +528,22 @@ fn dispatch_skill_verify(cwd: &Path) -> Result<(), Error> {
 fn dispatch_skill_check(cwd: &Path) -> Result<(), Error> {
     let style = CliStyle::auto_stdout();
     let skills = check::check_project(cwd)?;
-    println!(
-        "{} {} skill(s)",
-        style.success("OK"),
-        style.accent(skills.len())
-    );
+    let (skillsets, members) = skillsets::project_counts(cwd)?;
+    if skillsets == 0 {
+        println!(
+            "{} {} skill(s)",
+            style.success("OK"),
+            style.accent(skills.len())
+        );
+    } else {
+        println!(
+            "{} {} skill(s), {} skillset(s), {} member skill(s)",
+            style.success("OK"),
+            style.accent(skills.len()),
+            style.accent(skillsets),
+            style.accent(members)
+        );
+    }
     Ok(())
 }
 
@@ -358,7 +555,15 @@ fn dispatch_skill_list(cwd: &Path) -> Result<(), Error> {
         eprintln!("{}", err.warn(zen_err.to_string()));
     }
     if skills.is_empty() {
-        println!("{}", out.muted("(no skills)"));
+        let (skillsets, _) = skillsets::project_counts(cwd)?;
+        if skillsets > 0 {
+            println!(
+                "{}",
+                out.muted("(no standalone skills; use `tink skillset list`)")
+            );
+        } else {
+            println!("{}", out.muted("(no skills)"));
+        }
     } else {
         for skill in &skills {
             println!("{}", out.skill(&skill.name));

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -42,6 +42,13 @@ pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Err
             target.display()
         )));
     }
+    if target.join(crate::skillsets::RECEIPT_FILE).exists()
+        || target.join(crate::skillsets::RECEIPT_FILE).is_symlink()
+    {
+        return Err(Error::msg(format!(
+            "Skillset root detected; use `tink skillset remove {name}`"
+        )));
+    }
 
     catalog::withdraw_skill(project_root, name)?;
     fs::remove_dir_all(&target).map_err(|e| map_io(&target, e))?;

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use sha2::{Digest, Sha256};
+
 use crate::error::Error;
 use crate::paths::{map_io, refuse_symlink};
 use crate::provenance::{self, Provenance};
@@ -296,6 +298,32 @@ pub fn copy_skill_tree(
         tree.retain(|key, _| !key.starts_with(&prefix));
     }
     materialize_tree(&tree, destination)
+}
+
+/// Compute the canonical digest used by opaque managed skillset trees.
+pub fn tree_digest(root: &Path, root_ignore: &[&str]) -> Result<String, Error> {
+    let mut tree = require_safe_tree(root)?;
+    for name in root_ignore {
+        tree.remove(*name);
+        let prefix = format!("{name}/");
+        tree.retain(|key, _| !key.starts_with(&prefix));
+    }
+
+    let mut hasher = Sha256::new();
+    for (relative, kind) in tree {
+        let path = relative.as_bytes();
+        hasher.update((path.len() as u64).to_be_bytes());
+        hasher.update(path);
+        match kind {
+            EntryKind::Dir => hasher.update([b'd']),
+            EntryKind::File(bytes) => {
+                hasher.update([b'f']);
+                hasher.update((bytes.len() as u64).to_be_bytes());
+                hasher.update(bytes);
+            }
+        }
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 /// Result of comparing a candidate skill tree to an install target.

--- a/src/skillsets.rs
+++ b/src/skillsets.rs
@@ -1,0 +1,627 @@
+//! Pinned nested skillset installation.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+use crate::git;
+use crate::home;
+use crate::init;
+use crate::paths::{map_io, refuse_symlink};
+use crate::skills;
+use crate::sources;
+
+pub const RECEIPT_FILE: &str = ".tink-skillset.json";
+const NAME_SUFFIX: &str = "-skillset";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LibraryWrite {
+    Created,
+    Unchanged,
+    Repaired,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct SkillsetMeta {
+    source: String,
+    revision: String,
+    #[serde(rename = "sourceRoot")]
+    source_root: String,
+    members: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct SkillsetReceipt {
+    source: String,
+    revision: String,
+    #[serde(rename = "sourceRoot")]
+    source_root: String,
+    members: Vec<String>,
+    digest: String,
+}
+
+#[derive(Debug)]
+struct InstalledSkillset {
+    name: String,
+    receipt: SkillsetReceipt,
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path, label: &str) -> Result<T, Error> {
+    refuse_symlink(path)?;
+    if !path.is_file() {
+        return Err(Error::msg(format!("Missing {label}: {}", path.display())));
+    }
+    let text = fs::read_to_string(path).map_err(|e| map_io(path, e))?;
+    serde_json::from_str(&text).map_err(|e| Error::msg(format!("Invalid {label}: {e}")))
+}
+
+fn validate_revision(revision: &str) -> Result<(), Error> {
+    if !(revision.len() == 40 || revision.len() == 64)
+        || !revision.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err(Error::msg("Skillset revision must be a full Git object ID"));
+    }
+    Ok(())
+}
+
+fn validate_digest(digest: &str) -> Result<(), Error> {
+    if digest.len() != 64 || !digest.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Error::msg("Skillset digest must be a SHA-256 hex string"));
+    }
+    Ok(())
+}
+
+fn normalized_source_root(source_root: &str) -> Result<PathBuf, Error> {
+    if source_root.is_empty() || source_root.starts_with('/') || source_root.contains('\\') {
+        return Err(Error::msg(
+            "Skillset sourceRoot must be a non-empty relative POSIX path",
+        ));
+    }
+    let mut path = PathBuf::new();
+    for segment in source_root.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err(Error::msg(
+                "Skillset sourceRoot must be normalized and repository-relative",
+            ));
+        }
+        path.push(segment);
+    }
+    Ok(path)
+}
+
+fn validate_members(members: &[String]) -> Result<(), Error> {
+    if members.is_empty() {
+        return Err(Error::msg("Skillset members must not be empty"));
+    }
+    let mut seen = BTreeSet::new();
+    for member in members {
+        if !skills::valid_skill_name(member) {
+            return Err(Error::msg(format!(
+                "Invalid skillset member name: {member}"
+            )));
+        }
+        if !seen.insert(member) {
+            return Err(Error::msg(format!("Duplicate skillset member: {member}")));
+        }
+    }
+    Ok(())
+}
+
+fn validate_skillset_name(name: &str) -> Result<(), Error> {
+    if !skills::valid_skill_name(name) {
+        return Err(Error::msg(format!("Invalid skillset name: {name}")));
+    }
+    if !name.ends_with(NAME_SUFFIX) {
+        return Err(Error::msg(format!(
+            "Skillset name must end in {NAME_SUFFIX}: {name}"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_source(source: &str) -> Result<sources::RemoteSource, Error> {
+    let rest = source
+        .strip_prefix("https://")
+        .ok_or_else(|| Error::msg("Skillset source must be an absolute HTTPS Git URL"))?;
+    let (authority, path) = rest
+        .split_once('/')
+        .ok_or_else(|| Error::msg("Skillset source must be an absolute HTTPS Git URL"))?;
+    if authority.is_empty()
+        || authority.contains('@')
+        || authority.chars().any(char::is_whitespace)
+        || path.is_empty()
+        || path.contains('?')
+        || path.contains('#')
+        || path.contains("//")
+    {
+        return Err(Error::msg(
+            "Skillset source must be an absolute HTTPS Git URL",
+        ));
+    }
+    Ok(sources::RemoteSource {
+        display: source.to_string(),
+        url: source.to_string(),
+    })
+}
+
+fn validate_meta(meta: &SkillsetMeta) -> Result<sources::RemoteSource, Error> {
+    let remote = parse_source(&meta.source)?;
+    validate_revision(&meta.revision)?;
+    normalized_source_root(&meta.source_root)?;
+    validate_members(&meta.members)?;
+    Ok(remote)
+}
+
+fn receipt_for(meta: &SkillsetMeta, digest: String) -> SkillsetReceipt {
+    SkillsetReceipt {
+        source: meta.source.clone(),
+        revision: meta.revision.clone(),
+        source_root: meta.source_root.clone(),
+        members: meta.members.clone(),
+        digest,
+    }
+}
+
+fn receipt_meta(receipt: &SkillsetReceipt) -> SkillsetMeta {
+    SkillsetMeta {
+        source: receipt.source.clone(),
+        revision: receipt.revision.clone(),
+        source_root: receipt.source_root.clone(),
+        members: receipt.members.clone(),
+    }
+}
+
+fn read_owned_receipt(path: &Path, label: &str) -> Result<SkillsetReceipt, Error> {
+    let receipt: SkillsetReceipt = read_json(&path.join(RECEIPT_FILE), label)?;
+    validate_meta(&receipt_meta(&receipt))?;
+    validate_digest(&receipt.digest)?;
+    Ok(receipt)
+}
+
+fn validate_installed_tree(path: &Path, receipt: &SkillsetReceipt) -> Result<(), Error> {
+    for member in &receipt.members {
+        let member_path = path.join(member);
+        refuse_symlink(&member_path)?;
+        if !member_path.is_dir() {
+            return Err(Error::msg(format!("Missing skillset member: {member}")));
+        }
+        skills::read_skill(&member_path, true)?;
+    }
+    let digest = skills::tree_digest(path, &[RECEIPT_FILE])?;
+    if digest != receipt.digest {
+        return Err(Error::msg(format!(
+            "Skillset tree digest mismatch: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn read_catalog(name: &str) -> Result<SkillsetMeta, Error> {
+    validate_skillset_name(name)?;
+    let home = home::resolve_home()?;
+    let catalog = home::by_skillset_path(&home).join(name);
+    refuse_symlink(&catalog)?;
+    let meta: SkillsetMeta = read_json(&catalog.join("meta.json"), "skillset catalog meta")?;
+    validate_meta(&meta)?;
+    Ok(meta)
+}
+
+fn source_member_root(
+    checkout: &Path,
+    meta: &SkillsetMeta,
+    member: &str,
+) -> Result<PathBuf, Error> {
+    let source_root = checkout.join(normalized_source_root(&meta.source_root)?);
+    refuse_symlink(&source_root)?;
+    if !source_root.is_dir() {
+        return Err(Error::msg(format!(
+            "Skillset sourceRoot is not a directory: {}",
+            source_root.display()
+        )));
+    }
+    let member_root = source_root.join(member);
+    refuse_symlink(&member_root)?;
+    if !member_root.is_dir() {
+        return Err(Error::msg(format!("Skillset member not found: {member}")));
+    }
+    skills::read_skill(&member_root, true)?;
+    Ok(member_root)
+}
+
+fn install_from_checkout(
+    checkout: &Path,
+    meta: &SkillsetMeta,
+    destination_root: &Path,
+    name: &str,
+) -> Result<(PathBuf, bool), Error> {
+    let target = destination_root.join(name);
+    if target.exists() || target.is_symlink() {
+        refuse_symlink(&target)?;
+        return Err(Error::msg(format!(
+            "Refusing to overwrite existing skillset: {}",
+            target.display()
+        )));
+    }
+
+    let (_staging, staged) = stage_from_checkout(checkout, meta, destination_root, name)?;
+    fs::rename(&staged, &target).map_err(|e| map_io(&target, e))?;
+    Ok((target, true))
+}
+
+fn stage_from_checkout(
+    checkout: &Path,
+    meta: &SkillsetMeta,
+    destination_root: &Path,
+    name: &str,
+) -> Result<(tempfile::TempDir, PathBuf), Error> {
+    let staging = tempfile::Builder::new()
+        .prefix(".tink-skillset-stage-")
+        .tempdir_in(destination_root)
+        .map_err(|e| Error::msg(format!("skillset staging dir: {e}")))?;
+    let staged = staging.path().join(name);
+    fs::create_dir_all(&staged).map_err(|e| map_io(&staged, e))?;
+    for member in &meta.members {
+        let source = source_member_root(checkout, meta, member)?;
+        skills::copy_skill_tree(&source, &staged.join(member), &[".git"])?;
+    }
+    let digest = skills::tree_digest(&staged, &[RECEIPT_FILE])?;
+    let receipt = receipt_for(meta, digest);
+    let receipt_path = staged.join(RECEIPT_FILE);
+    let receipt_text = serde_json::to_string_pretty(&receipt)
+        .map_err(|e| Error::msg(format!("serialize skillset receipt: {e}")))?;
+    fs::write(&receipt_path, format!("{receipt_text}\n")).map_err(|e| map_io(&receipt_path, e))?;
+    read_installed(&staged)?;
+    Ok((staging, staged))
+}
+
+fn replace_from_checkout(
+    checkout: &Path,
+    meta: &SkillsetMeta,
+    destination_root: &Path,
+    name: &str,
+) -> Result<PathBuf, Error> {
+    let target = destination_root.join(name);
+    let (staging, staged) = stage_from_checkout(checkout, meta, destination_root, name)?;
+
+    let backup = staging.path().join("old");
+    fs::rename(&target, &backup).map_err(|e| map_io(&target, e))?;
+    if let Err(error) = fs::rename(&staged, &target) {
+        let _ = fs::rename(&backup, &target);
+        return Err(map_io(&target, error));
+    }
+    Ok(target)
+}
+
+pub fn add_skillset(
+    project_root: &Path,
+    name: &str,
+) -> Result<(PathBuf, bool, LibraryWrite), Error> {
+    validate_skillset_name(name)?;
+    let meta = read_catalog(name)?;
+    preflight_library_target(name)?;
+    let target = home::project_skills_path(project_root).join(name);
+    if target.exists() || target.is_symlink() {
+        refuse_symlink(&target)?;
+        if !target.is_dir() {
+            return Err(Error::msg(format!(
+                "Refusing to overwrite non-directory skillset: {}",
+                target.display()
+            )));
+        }
+        let receipt = read_owned_receipt(&target, "installed skillset receipt")?;
+        if validate_installed_tree(&target, &receipt).is_err() {
+            return Err(Error::msg(format!(
+                "Refusing to add {name}: local modifications are present; remove it first to discard them"
+            )));
+        }
+        if receipt_meta(&receipt) != meta {
+            return Err(Error::msg(format!(
+                "Skillset catalog changed for {name}; run `tink skillset refresh {name}`"
+            )));
+        }
+        let library_write = sync_library_from_project(&target)?;
+        return Ok((target, false, library_write));
+    }
+
+    init::ensure_project_layout(project_root)?;
+    let remote = validate_meta(&meta)?;
+    let (_clone, repository, tip) = git::checkout(&remote)?;
+    let (_old_checkout, checkout) = if tip == meta.revision {
+        (None, repository)
+    } else {
+        let (temp, checkout) = git::checkout_revision(&repository, &meta.revision)?;
+        (Some(temp), checkout)
+    };
+    let (installed, created) = install_from_checkout(
+        &checkout,
+        &meta,
+        &home::project_skills_path(project_root),
+        name,
+    )?;
+    let library_write = sync_library_from_project(&installed)?;
+    Ok((installed, created, library_write))
+}
+
+pub fn refresh_skillset(project_root: &Path, name: &str) -> Result<bool, Error> {
+    validate_skillset_name(name)?;
+    let meta = read_catalog(name)?;
+    let skills_root = home::project_skills_path(project_root);
+    let target = skills_root.join(name);
+    refuse_symlink(&target)?;
+    if !target.is_dir() {
+        return Err(Error::msg(format!("Skillset not found: {name}")));
+    }
+    let receipt = read_owned_receipt(&target, "installed skillset receipt")?;
+    if validate_installed_tree(&target, &receipt).is_err() {
+        return Err(Error::msg(format!(
+            "Refusing to refresh {name}: local modifications are present"
+        )));
+    }
+    preflight_library_target(name)?;
+    if receipt_meta(&receipt) == meta {
+        sync_library_from_project(&target)?;
+        return Ok(false);
+    }
+
+    let remote = validate_meta(&meta)?;
+    let (_clone, repository, tip) = git::checkout(&remote)?;
+    let (_old_checkout, checkout) = if tip == meta.revision {
+        (None, repository)
+    } else {
+        let (temp, checkout) = git::checkout_revision(&repository, &meta.revision)?;
+        (Some(temp), checkout)
+    };
+    let installed = replace_from_checkout(&checkout, &meta, &skills_root, name)?;
+    sync_library_from_project(&installed)?;
+    Ok(true)
+}
+
+pub fn remove_skillset(project_root: &Path, name: &str) -> Result<PathBuf, Error> {
+    validate_skillset_name(name)?;
+    let agents = home::project_agents_path(project_root);
+    let skills_root = home::project_skills_path(project_root);
+    refuse_symlink(&agents)?;
+    refuse_symlink(&skills_root)?;
+    let target = skills_root.join(name);
+    refuse_symlink(&target)?;
+    if !target.is_dir() {
+        return Err(Error::msg(format!("Skillset not found: {name}")));
+    }
+    read_owned_receipt(&target, "installed skillset receipt")?;
+    fs::remove_dir_all(&target).map_err(|e| map_io(&target, e))?;
+    Ok(target)
+}
+
+fn read_installed(path: &Path) -> Result<InstalledSkillset, Error> {
+    refuse_symlink(path)?;
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("");
+    validate_skillset_name(name)?;
+    let receipt = read_owned_receipt(path, "installed skillset receipt")?;
+    validate_installed_tree(path, &receipt)?;
+    Ok(InstalledSkillset {
+        name: name.to_string(),
+        receipt,
+    })
+}
+
+/// Validate an installed skillset without consulting the network or catalog.
+pub fn validate_installed(path: &Path) -> Result<(), Error> {
+    read_installed(path).map(|_| ())
+}
+
+/// List receipt-backed skillsets installed in a project.
+pub fn list_installed(project_root: &Path) -> Result<Vec<String>, Error> {
+    let agents = home::project_agents_path(project_root);
+    let skills_root = home::project_skills_path(project_root);
+    refuse_symlink(&agents)?;
+    refuse_symlink(&skills_root)?;
+    if !skills_root.is_dir() {
+        return Err(Error::msg(
+            "Not a Tink project (missing .agents/skills); run `tink init` first",
+        ));
+    }
+
+    let mut entries: Vec<_> = fs::read_dir(&skills_root)
+        .map_err(|e| map_io(&skills_root, e))?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .collect();
+    entries.sort();
+
+    let mut names = Vec::new();
+    for path in entries {
+        let name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("");
+        if name == "README.md" || name.starts_with('.') {
+            continue;
+        }
+        if path.is_symlink() || !path.is_dir() {
+            return Err(Error::msg(format!(
+                "Unexpected entry in .agents/skills: {name}"
+            )));
+        }
+        if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
+            names.push(read_installed(&path)?.name);
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// Count validated project skillsets and their declared member skills.
+pub fn project_counts(project_root: &Path) -> Result<(usize, usize), Error> {
+    let skills_root = home::project_skills_path(project_root);
+    let mut skillset_count = 0;
+    let mut member_count = 0;
+    for entry in fs::read_dir(&skills_root).map_err(|e| map_io(&skills_root, e))? {
+        let path = entry.map_err(|e| map_io(&skills_root, e))?.path();
+        if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
+            let installed = read_installed(&path)?;
+            skillset_count += 1;
+            member_count += installed.receipt.members.len();
+        }
+    }
+    Ok((skillset_count, member_count))
+}
+
+fn validate_library_receipt(path: &Path) -> Result<(), Error> {
+    read_owned_receipt(path, "library skillset receipt").map(|_| ())
+}
+
+fn library_root() -> Result<PathBuf, Error> {
+    let (home, _) = home::ensure_inventory_root(None)?;
+    Ok(home::skills_library_path(&home))
+}
+
+fn preflight_library_target(name: &str) -> Result<(), Error> {
+    let target = library_root()?.join(name);
+    if !target.exists() && !target.is_symlink() {
+        return Ok(());
+    }
+    refuse_symlink(&target)?;
+    if !target.is_dir() {
+        return Err(Error::msg(format!(
+            "Library name collision for skillset: {}",
+            target.display()
+        )));
+    }
+    validate_library_receipt(&target).map_err(|_| {
+        Error::msg(format!(
+            "Library name collision for skillset: {}; existing entry is not an owned skillset",
+            target.display()
+        ))
+    })
+}
+
+fn copy_project_tree(
+    project: &Path,
+    library: &Path,
+    name: &str,
+    replace: bool,
+) -> Result<(), Error> {
+    let staging = tempfile::Builder::new()
+        .prefix(".tink-skillset-library-")
+        .tempdir_in(library)
+        .map_err(|e| Error::msg(format!("skillset library staging: {e}")))?;
+    let staged = staging.path().join(name);
+    skills::copy_skill_tree(project, &staged, &[])?;
+    read_installed(&staged)?;
+    let target = library.join(name);
+    if !replace {
+        fs::rename(&staged, &target).map_err(|e| map_io(&target, e))?;
+        return Ok(());
+    }
+
+    let backup = staging.path().join("old");
+    fs::rename(&target, &backup).map_err(|e| map_io(&target, e))?;
+    if let Err(error) = fs::rename(&staged, &target) {
+        let _ = fs::rename(&backup, &target);
+        return Err(map_io(&target, error));
+    }
+    let _ = fs::remove_dir_all(&backup);
+    Ok(())
+}
+
+fn sync_library_from_project(project: &Path) -> Result<LibraryWrite, Error> {
+    let name = read_installed(project)?.name;
+    let library = library_root()?;
+    let target = library.join(&name);
+    if !target.exists() && !target.is_symlink() {
+        copy_project_tree(project, &library, &name, false)?;
+        return Ok(LibraryWrite::Created);
+    }
+    preflight_library_target(&name)?;
+    if skills::skill_contents_equal(project, &target)? {
+        return Ok(LibraryWrite::Unchanged);
+    }
+    copy_project_tree(project, &library, &name, true)?;
+    Ok(LibraryWrite::Repaired)
+}
+
+/// List receipt-backed skillsets in the home library without creating it.
+pub fn list_library(home_root: Option<&Path>) -> Result<Vec<String>, Error> {
+    let home = match home_root {
+        Some(path) => path.to_path_buf(),
+        None => home::resolve_home()?,
+    };
+    if !home.exists() {
+        return Ok(Vec::new());
+    }
+    refuse_symlink(&home)?;
+    let library = home::skills_library_path(&home);
+    if !library.exists() {
+        return Ok(Vec::new());
+    }
+    refuse_symlink(&library)?;
+    if !library.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing to read non-directory library: {}",
+            library.display()
+        )));
+    }
+
+    let mut entries: Vec<_> = fs::read_dir(&library)
+        .map_err(|e| map_io(&library, e))?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .collect();
+    entries.sort();
+    let mut names = Vec::new();
+    for path in entries {
+        if path.is_symlink() || !path.is_dir() {
+            continue;
+        }
+        if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
+            names.push(read_installed(&path)?.name);
+        }
+    }
+    Ok(names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_root_rejects_escape_and_empty_segments() {
+        for value in [
+            "",
+            ".",
+            "skills/../other",
+            "/skills",
+            "skills//common",
+            "skills\\common",
+        ] {
+            assert!(normalized_source_root(value).is_err(), "{value}");
+        }
+        assert_eq!(
+            normalized_source_root("skills/common").unwrap(),
+            PathBuf::from("skills/common")
+        );
+    }
+
+    #[test]
+    fn validates_explicit_unique_member_names() {
+        assert!(validate_members(&["alpha".into(), "beta-two".into()]).is_ok());
+        assert!(validate_members(&["alpha".into(), "alpha".into()]).is_err());
+        assert!(validate_members(&["Alpha".into()]).is_err());
+    }
+
+    #[test]
+    fn accepts_absolute_https_sources_and_rejects_local_or_credentialed_ones() {
+        assert!(parse_source("https://git.example.test/team/skills.git").is_ok());
+        assert!(parse_source("owner/skills").is_err());
+        assert!(parse_source("https://user@git.example.test/skills.git").is_err());
+    }
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -108,6 +108,14 @@ impl CliStyle {
         )
     }
 
+    /// Skillset names — blue so grouped identities read apart from member skills.
+    pub fn skillset(self, text: impl std::fmt::Display) -> String {
+        self.paint(
+            Style::new().fg_color(Some(BLUE)).effects(Effects::BOLD),
+            text,
+        )
+    }
+
     /// Per-character rainbow (init ZEN tease). Plain text when styling is off.
     pub fn rainbow(self, text: impl std::fmt::Display) -> String {
         let text = text.to_string();
@@ -161,6 +169,10 @@ mod tests {
         assert_eq!(style.error("nope"), "nope");
         assert_eq!(style.accent("tui-design"), "tui-design");
         assert_eq!(style.skill("manage-tink"), "manage-tink");
+        assert_eq!(
+            style.skillset("engineering-skillset"),
+            "engineering-skillset"
+        );
         assert_eq!(style.rainbow("ZEN.md"), "ZEN.md");
         assert_eq!(
             style.link("https://github.com/jon-devlapaz/tink-skills", "tink-skills"),
@@ -179,6 +191,11 @@ mod tests {
         let skill = style.skill("manage-tink");
         assert!(skill.contains("manage-tink"), "{skill}");
         assert!(skill.contains('\u{1b}'), "{skill}");
+        let skillset = style.skillset("engineering-skillset");
+        assert!(skillset.contains("engineering-skillset"), "{skillset}");
+        assert!(skillset.contains('\u{1b}'), "{skillset}");
+        assert!(skill.contains("\u{1b}[35m"), "{skill}");
+        assert!(skillset.contains("\u{1b}[34m"), "{skillset}");
         let rainbow = style.rainbow("ZEN.md");
         assert!(rainbow.contains('Z') && rainbow.contains('N'), "{rainbow}");
         assert!(rainbow.contains('\u{1b}'), "{rainbow}");

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -55,6 +55,18 @@ impl Workspace {
         self.inventory.join("skills").join(skill)
     }
 
+    fn library_skillset(&self, skillset: &str) -> PathBuf {
+        self.inventory.join("skills").join(skillset)
+    }
+
+    fn skillset_meta(&self, name: &str) -> PathBuf {
+        self.inventory
+            .join("catalog")
+            .join("by-skillset")
+            .join(name)
+            .join("meta.json")
+    }
+
     fn assert_cataloged(&self, project_name: &str, skill: &str) {
         let raw = fs::read_to_string(self.catalog_meta(project_name))
             .unwrap_or_else(|_| panic!("missing catalog for {project_name}"));
@@ -85,6 +97,27 @@ fn write_skill(path: &Path, name: &str, body: &str) {
         "---\nname: {name}\ndescription: Valid skill fixture named {name}.\n---\n\n# {name}\n\n{body}\n"
     );
     fs::write(path.join("SKILL.md"), text).expect("SKILL.md");
+}
+
+fn write_skillset_meta(
+    path: &Path,
+    source: &str,
+    revision: &str,
+    source_root: &str,
+    members: &[&str],
+) {
+    fs::create_dir_all(path.parent().expect("skillset catalog parent")).expect("catalog dir");
+    let meta = serde_json::json!({
+        "source": source,
+        "revision": revision,
+        "sourceRoot": source_root,
+        "members": members,
+    });
+    fs::write(
+        path,
+        format!("{}\n", serde_json::to_string_pretty(&meta).unwrap()),
+    )
+    .expect("skillset meta");
 }
 
 fn git(cwd: &Path, args: &[&str]) {
@@ -491,6 +524,402 @@ fn a8_add_uses_library_when_remote_tip_matches() {
         receipt.contains("\"path\": \".\"") || receipt.contains("\"path\":\".\""),
         "{receipt}"
     );
+}
+
+// --- K*: skillsets ---
+
+#[test]
+fn k1_skillset_add_installs_explicit_members_and_checks_digest() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let repository = ws.root.join("skillset-repo");
+    init_repo(&repository);
+    write_skill(
+        &repository.join("bundles/common/alpha"),
+        "alpha",
+        "first member",
+    );
+    write_skill(
+        &repository.join("bundles/common/beta"),
+        "beta",
+        "second member",
+    );
+    let revision = commit_all(&repository, "skillset");
+    let source = "https://github.com/example/skillsets.git";
+    write_skillset_meta(
+        &ws.skillset_meta("common-skillset"),
+        source,
+        &revision,
+        "bundles/common",
+        &["alpha", "beta"],
+    );
+
+    let redirect = github_redirect(&repository, source);
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(redirect.clone())
+        .assert()
+        .success();
+
+    let installed = Workspace::skill_path(&project, "common-skillset");
+    let library = ws.library_skillset("common-skillset");
+    assert!(installed.join("alpha/SKILL.md").is_file());
+    assert!(installed.join("beta/SKILL.md").is_file());
+    assert!(installed.join(".tink-skillset.json").is_file());
+    assert!(library.join("alpha/SKILL.md").is_file());
+    assert!(library.join("beta/SKILL.md").is_file());
+    assert!(library.join(".tink-skillset.json").is_file());
+
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(redirect.clone())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Unchanged"));
+    ws.cmd(&project).args(["skill", "check"]).assert().success();
+    ws.cmd(&project)
+        .args(["skillset", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("common-skillset"));
+    ws.cmd(&project)
+        .args(["skillset", "list", "--library"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("common-skillset"));
+
+    fs::write(
+        library.join("alpha/SKILL.md"),
+        "---\nname: alpha\ndescription: library drift\n---\n",
+    )
+    .unwrap();
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(redirect.clone())
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read(installed.join("alpha/SKILL.md")).unwrap(),
+        fs::read(library.join("alpha/SKILL.md")).unwrap(),
+        "library must conform to the validated project tree"
+    );
+
+    fs::write(
+        installed.join("alpha/SKILL.md"),
+        "---\nname: alpha\ndescription: changed\n---\n",
+    )
+    .unwrap();
+    let library_before_failed_add = fs::read(library.join("alpha/SKILL.md")).unwrap();
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(redirect)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("local modifications are present"));
+    assert_eq!(
+        fs::read(library.join("alpha/SKILL.md")).unwrap(),
+        library_before_failed_add,
+        "project drift must block library mutation"
+    );
+    ws.cmd(&project)
+        .args(["skill", "check"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("digest mismatch"));
+
+    ws.cmd(&project)
+        .args(["skill", "remove", "common-skillset"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("skillset remove"));
+    ws.cmd(&project)
+        .args(["skillset", "remove", "common-skillset"])
+        .assert()
+        .success();
+    assert!(!installed.exists());
+    assert!(library.is_dir());
+    assert!(ws.skillset_meta("common-skillset").is_file());
+}
+
+#[test]
+fn k4_skillset_commands_require_canonical_suffix() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["skillset", "add", "common"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must end in -skillset"));
+    assert!(!Workspace::skill_path(&project, "common").exists());
+}
+
+#[test]
+fn k5_skillset_add_refuses_unowned_library_collision() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let name = "common-skillset";
+    write_skill(
+        &ws.library_skill(name),
+        name,
+        "ordinary library skill with colliding name",
+    );
+    write_skillset_meta(
+        &ws.skillset_meta(name),
+        "https://github.com/example/skillsets.git",
+        &"a".repeat(40),
+        "bundles/common",
+        &["alpha"],
+    );
+
+    ws.cmd(&project)
+        .args(["skillset", "add", name])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Library name collision"));
+    assert!(!Workspace::skill_path(&project, name).exists());
+}
+
+#[test]
+fn k6_skillset_remove_requires_a_valid_owned_receipt() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let target = Workspace::skill_path(&project, "victim-skillset");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join(".tink-skillset.json"), "not a receipt\n").unwrap();
+    fs::write(target.join("keep.txt"), "valuable user data\n").unwrap();
+
+    ws.cmd(&project)
+        .args(["skillset", "remove", "victim-skillset"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Invalid installed skillset receipt",
+        ));
+    assert_eq!(
+        fs::read_to_string(target.join("keep.txt")).unwrap(),
+        "valuable user data\n"
+    );
+
+    let missing_receipt = Workspace::skill_path(&project, "unowned-skillset");
+    fs::create_dir_all(&missing_receipt).unwrap();
+    fs::write(missing_receipt.join("keep.txt"), "also valuable\n").unwrap();
+    ws.cmd(&project)
+        .args(["skillset", "remove", "unowned-skillset"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Missing installed skillset receipt",
+        ));
+    assert!(missing_receipt.join("keep.txt").is_file());
+}
+
+#[test]
+fn k7_skillset_setup_failures_are_actionable_and_non_mutating() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+
+    ws.cmd(&project)
+        .args(["skillset", "list"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("Not a Tink project")
+                .and(predicate::str::contains("tink init")),
+        );
+    ws.cmd(&project)
+        .args(["skillset", "add", "missing-skillset"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Missing skillset catalog meta"));
+    assert!(!project.join(".agents").exists());
+}
+
+#[test]
+fn k8_skillset_readd_is_offline_when_project_is_unchanged() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let repository = ws.root.join("skillset-repo");
+    init_repo(&repository);
+    write_skill(&repository.join("bundles/common/alpha"), "alpha", "member");
+    let revision = commit_all(&repository, "skillset");
+    let source = "https://github.com/example/skillsets.git";
+    write_skillset_meta(
+        &ws.skillset_meta("common-skillset"),
+        source,
+        &revision,
+        "bundles/common",
+        &["alpha"],
+    );
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(github_redirect(&repository, source))
+        .assert()
+        .success();
+    fs::remove_dir_all(ws.library_skillset("common-skillset")).unwrap();
+
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .env("GIT_CONFIG_COUNT", "1")
+        .env(
+            "GIT_CONFIG_KEY_0",
+            "url.file:///definitely-missing-tink-repo/.insteadOf",
+        )
+        .env("GIT_CONFIG_VALUE_0", source)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Unchanged common-skillset"));
+    assert!(
+        ws.library_skillset("common-skillset")
+            .join("alpha/SKILL.md")
+            .is_file()
+    );
+}
+
+#[test]
+fn k9_skill_status_reports_grouped_members_honestly() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let repository = ws.root.join("skillset-repo");
+    init_repo(&repository);
+    write_skill(&repository.join("bundles/common/alpha"), "alpha", "first");
+    write_skill(&repository.join("bundles/common/beta"), "beta", "second");
+    let revision = commit_all(&repository, "skillset");
+    let source = "https://github.com/example/skillsets.git";
+    write_skillset_meta(
+        &ws.skillset_meta("common-skillset"),
+        source,
+        &revision,
+        "bundles/common",
+        &["alpha", "beta"],
+    );
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(github_redirect(&repository, source))
+        .assert()
+        .success();
+
+    ws.cmd(&project)
+        .args(["skill", "check"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "OK 0 skill(s), 1 skillset(s), 2 member skill(s)",
+        ));
+    ws.cmd(&project)
+        .args(["skill", "list"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("no standalone skills")
+                .and(predicate::str::contains("tink skillset list")),
+        );
+}
+
+#[test]
+fn k10_skillset_refresh_updates_clean_tree_and_refuses_local_edits() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let repository = ws.root.join("skillset-repo");
+    init_repo(&repository);
+    let source = "https://github.com/example/skillsets.git";
+    let member = repository.join("bundles/common/alpha");
+    write_skill(&member, "alpha", "version one");
+    let first_revision = commit_all(&repository, "first");
+    write_skillset_meta(
+        &ws.skillset_meta("common-skillset"),
+        source,
+        &first_revision,
+        "bundles/common",
+        &["alpha"],
+    );
+    let redirect = github_redirect(&repository, source);
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(redirect.clone())
+        .assert()
+        .success();
+
+    write_skill(&member, "alpha", "version two");
+    let second_revision = commit_all(&repository, "second");
+    write_skillset_meta(
+        &ws.skillset_meta("common-skillset"),
+        source,
+        &second_revision,
+        "bundles/common",
+        &["alpha"],
+    );
+    ws.cmd(&project)
+        .args(["skillset", "refresh", "common-skillset"])
+        .envs(redirect.clone())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Refreshed common-skillset"));
+    let installed = Workspace::skill_path(&project, "common-skillset");
+    assert!(
+        fs::read_to_string(installed.join("alpha/SKILL.md"))
+            .unwrap()
+            .contains("version two")
+    );
+    assert_eq!(
+        fs::read(installed.join("alpha/SKILL.md")).unwrap(),
+        fs::read(
+            ws.library_skillset("common-skillset")
+                .join("alpha/SKILL.md")
+        )
+        .unwrap()
+    );
+
+    fs::write(
+        installed.join("alpha/SKILL.md"),
+        "---\nname: alpha\ndescription: local edit\n---\n",
+    )
+    .unwrap();
+    ws.cmd(&project)
+        .args(["skillset", "refresh", "common-skillset"])
+        .envs(redirect)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("local modifications are present"));
+}
+
+#[test]
+fn k11_skillset_rejects_member_directory_name_mismatch() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let repository = ws.root.join("skillset-repo");
+    init_repo(&repository);
+    write_skill(
+        &repository.join("bundles/common/alpha"),
+        "different-name",
+        "mismatched member",
+    );
+    let revision = commit_all(&repository, "mismatched member");
+    let source = "https://github.com/example/skillsets.git";
+    write_skillset_meta(
+        &ws.skillset_meta("common-skillset"),
+        source,
+        &revision,
+        "bundles/common",
+        &["alpha"],
+    );
+
+    ws.cmd(&project)
+        .args(["skillset", "add", "common-skillset"])
+        .envs(github_redirect(&repository, source))
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("different-name")
+                .and(predicate::str::contains("must match directory"))
+                .and(predicate::str::contains("alpha")),
+        );
+    assert!(!Workspace::skill_path(&project, "common-skillset").exists());
+    assert!(!ws.library_skillset("common-skillset").exists());
 }
 
 // --- R*: remote add ---
@@ -2199,4 +2628,379 @@ fn u3_update_replaces_binary_when_newer_release_exists() {
     assert!(installed.is_file());
     let after = fs::metadata(&installed).unwrap().modified().unwrap();
     assert!(after >= before);
+}
+
+// --- G*: GitHub source inspection ---
+
+fn inspect_fixture() -> (Workspace, PathBuf, Vec<(String, String)>) {
+    let ws = Workspace::new();
+    let repo = ws.root.join("skills-repo");
+    init_repo(&repo);
+    for (group, names) in [
+        ("deprecated", Vec::<&str>::new()),
+        ("engineering", vec!["alpha", "beta"]),
+        ("in-progress", vec!["gamma"]),
+        ("misc", vec!["delta"]),
+        ("productivity", vec!["epsilon"]),
+    ] {
+        fs::create_dir_all(repo.join("skills").join(group)).unwrap();
+        if group == "deprecated" {
+            fs::write(
+                repo.join("skills").join(group).join("README.md"),
+                "empty peer\n",
+            )
+            .unwrap();
+        }
+        for name in names {
+            write_skill(&repo.join("skills").join(group).join(name), name, "fixture");
+        }
+    }
+    fs::write(repo.join("README.md"), "repository documentation\n").unwrap();
+    fs::create_dir_all(repo.join("docs")).unwrap();
+    fs::write(repo.join("docs").join("overview.md"), "unrelated sibling\n").unwrap();
+    commit_all(&repo, "fixture");
+    let public = "https://github.com/example/skills.git";
+    let redirect = github_redirect(&repo, public);
+    (ws, repo, redirect)
+}
+
+#[test]
+fn g1_inspect_repository_reports_groups_empty_peers_and_sorted_skills() {
+    let (ws, _repo, redirect) = inspect_fixture();
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args(["inspect", "https://github.com/example/skills"]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Skillsets (5, 5 member skills)")
+            .and(predicate::str::contains("deprecated-skillset"))
+            .and(predicate::str::contains("empty structural candidate"))
+            .and(predicate::str::contains("engineering-skillset"))
+            .and(predicate::str::contains("skills/engineering/"))
+            .and(predicate::str::contains("    alpha"))
+            .and(predicate::str::contains("skills/productivity/"))
+            .and(predicate::str::contains("    epsilon"))
+            .and(predicate::str::contains("Standalone skills (0)")),
+    );
+    assert!(!project.join(".agents").exists());
+    assert!(!ws.inventory.exists());
+}
+
+#[test]
+fn g2_inspect_group_tree_limits_boundary() {
+    let (ws, _repo, redirect) = inspect_fixture();
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args([
+        "inspect",
+        "https://github.com/example/skills/tree/master/skills/productivity",
+    ]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Skillsets (1, 1 member skills)")
+            .and(predicate::str::contains("productivity-skillset"))
+            .and(predicate::str::contains("skills/productivity/"))
+            .and(predicate::str::contains("    epsilon"))
+            .and(predicate::str::contains("Standalone skills (0)"))
+            .and(predicate::str::contains("engineering/alpha").not()),
+    );
+}
+
+#[test]
+fn g3_inspect_skill_tree_reports_one_skill_and_no_skillset() {
+    let (ws, _repo, redirect) = inspect_fixture();
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args([
+        "inspect",
+        "https://github.com/example/skills/tree/master/skills/productivity/epsilon",
+    ]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Skillsets (0, 0 member skills)")
+            .and(predicate::str::contains("Standalone skills (1)"))
+            .and(predicate::str::contains("epsilon")),
+    );
+}
+
+#[test]
+fn g4_inspect_infers_wrapper_without_skills_convention() {
+    let ws = Workspace::new();
+    let repo = ws.root.join("wrapped-repo");
+    init_repo(&repo);
+    write_skill(
+        &repo.join("bundles").join("one").join("first"),
+        "first",
+        "fixture",
+    );
+    write_skill(
+        &repo.join("bundles").join("two").join("second"),
+        "second",
+        "fixture",
+    );
+    commit_all(&repo, "wrapped fixture");
+    let public = "https://github.com/example/wrapped.git";
+    let redirect = github_redirect(&repo, public);
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args(["inspect", public]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Skillsets (2, 2 member skills)")
+            .and(predicate::str::contains("one-skillset"))
+            .and(predicate::str::contains("two-skillset")),
+    );
+}
+
+#[test]
+fn g4b_inspect_flat_repository_does_not_expose_checkout_directory_name() {
+    let ws = Workspace::new();
+    let repo = ws.root.join("flat-repo");
+    init_repo(&repo);
+    write_skill(&repo.join("alpha"), "alpha", "fixture");
+    write_skill(&repo.join("beta"), "beta", "fixture");
+    commit_all(&repo, "flat fixture");
+    let public = "https://github.com/example/flat.git";
+    let redirect = github_redirect(&repo, public);
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args(["inspect", public]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Skillsets (1, 2 member skills)")
+            .and(predicate::str::contains("(unnamed proposal)"))
+            .and(predicate::str::contains("repository-skillset").not())
+            .and(predicate::str::contains("invalid skillset folder name").not()),
+    );
+}
+
+#[test]
+fn g4c_inspect_mixed_root_refuses_to_collapse_unrelated_levels() {
+    let ws = Workspace::new();
+    let repo = ws.root.join("mixed-repo");
+    init_repo(&repo);
+    write_skill(&repo.join("template"), "template", "fixture");
+    write_skill(&repo.join("skills/alpha"), "alpha", "fixture");
+    write_skill(&repo.join("skills/beta"), "beta", "fixture");
+    commit_all(&repo, "mixed fixture");
+    let public = "https://github.com/example/mixed.git";
+    let redirect = github_redirect(&repo, public);
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args(["inspect", public]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Skillsets (0, 0 member skills)")
+            .and(predicate::str::contains("Standalone skills (3)"))
+            .and(predicate::str::contains("mixed skill layout"))
+            .and(predicate::str::contains("narrower GitHub tree URL")),
+    );
+}
+
+#[test]
+fn g4d_inspect_reserves_skills_as_a_collection_root() {
+    let ws = Workspace::new();
+    let repo = ws.root.join("collection-repo");
+    init_repo(&repo);
+    write_skill(&repo.join("skills/alpha"), "alpha", "fixture");
+    write_skill(&repo.join("skills/beta"), "beta", "fixture");
+    commit_all(&repo, "collection fixture");
+    let public = "https://github.com/example/collection.git";
+    let redirect = github_redirect(&repo, public);
+    let project = ws.project("app");
+
+    for url in [
+        public,
+        "https://github.com/example/collection/tree/master/skills",
+    ] {
+        let mut cmd = ws.cmd(&project);
+        cmd.args(["inspect", url]);
+        for (key, value) in &redirect {
+            cmd.env(key, value);
+        }
+        cmd.assert().success().stdout(
+            predicate::str::contains("Skillsets (0, 0 member skills)")
+                .and(predicate::str::contains("Standalone skills (2)"))
+                .and(predicate::str::contains("skills-skillset").not()),
+        );
+    }
+}
+
+#[test]
+fn g4e_inspect_does_not_propose_an_overlong_canonical_skillset_name() {
+    let ws = Workspace::new();
+    let repo = ws.root.join("long-name-repo");
+    init_repo(&repo);
+    let group = "a".repeat(64);
+    write_skill(
+        &repo.join("skills").join(&group).join("alpha"),
+        "alpha",
+        "fixture",
+    );
+    write_skill(&repo.join("skills/short/beta"), "beta", "fixture");
+    commit_all(&repo, "long group name");
+    let public = "https://github.com/example/long-name.git";
+    let redirect = github_redirect(&repo, public);
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args(["inspect", public]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("(unnamed proposal)")
+            .and(predicate::str::contains("no valid canonical skillset name"))
+            .and(predicate::str::contains(format!("{group}-skillset")).not()),
+    );
+}
+
+#[test]
+fn g5_inspect_reports_duplicate_names_and_invalid_candidates() {
+    let ws = Workspace::new();
+    let repo = ws.root.join("diagnostic-repo");
+    init_repo(&repo);
+    write_skill(
+        &repo.join("skills").join("one").join("same"),
+        "same",
+        "fixture",
+    );
+    write_skill(
+        &repo.join("skills").join("two").join("same"),
+        "same",
+        "fixture",
+    );
+    fs::create_dir_all(repo.join("skills").join("bad")).unwrap();
+    fs::write(
+        repo.join("skills").join("bad").join("SKILL.md"),
+        "not frontmatter\n",
+    )
+    .unwrap();
+    commit_all(&repo, "diagnostics");
+    let public = "https://github.com/example/diagnostics.git";
+    let redirect = github_redirect(&repo, public);
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args(["inspect", public]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Diagnostics (2)")
+            .and(predicate::str::contains("duplicate skill name: same"))
+            .and(predicate::str::contains("invalid SKILL.md"))
+            .and(predicate::str::contains(repo.to_string_lossy().as_ref()).not()),
+    );
+}
+
+#[test]
+fn g6_inspect_empty_boundary_succeeds() {
+    let ws = Workspace::new();
+    let repo = ws.root.join("empty-repo");
+    init_repo(&repo);
+    fs::create_dir_all(repo.join("empty")).unwrap();
+    fs::write(repo.join("empty").join("README.md"), "empty\n").unwrap();
+    commit_all(&repo, "empty");
+    let public = "https://github.com/example/empty.git";
+    let redirect = github_redirect(&repo, public);
+    let project = ws.project("app");
+    let mut cmd = ws.cmd(&project);
+    cmd.args([
+        "inspect",
+        "https://github.com/example/empty/tree/master/empty",
+    ]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success().stdout(
+        predicate::str::contains("Skillsets (0, 0 member skills)")
+            .and(predicate::str::contains("Standalone skills (0)"))
+            .and(predicate::str::contains("Diagnostics (1)"))
+            .and(predicate::str::contains("no valid skills found"))
+            .and(predicate::str::contains("could not be inferred").not()),
+    );
+}
+
+#[test]
+fn g7_inspect_rejects_bad_urls_refs_and_boundaries() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["inspect", "https://gitlab.com/example/skills"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("GitHub"));
+
+    let repo = ws.root.join("failure-repo");
+    init_repo(&repo);
+    fs::write(repo.join("README.md"), "failure\n").unwrap();
+    commit_all(&repo, "failure");
+    let public = "https://github.com/example/failure.git";
+    let redirect = github_redirect(&repo, public);
+    for url in [
+        "https://github.com/example/failure/tree/missing",
+        "https://github.com/example/failure/tree/master/missing",
+    ] {
+        let mut cmd = ws.cmd(&project);
+        cmd.args(["inspect", url]);
+        for (key, value) in &redirect {
+            cmd.env(key, value);
+        }
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("ref").or(predicate::str::contains("boundary")));
+    }
+
+    git(&repo, &["checkout", "-b", "feature/grouped"]);
+    fs::create_dir_all(repo.join("skills")).unwrap();
+    write_skill(&repo.join("skills/alpha"), "alpha", "slash ref");
+    commit_all(&repo, "slash ref");
+    let mut cmd = ws.cmd(&project);
+    cmd.args([
+        "inspect",
+        "https://github.com/example/failure/tree/feature/grouped/skills",
+    ]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().failure().stderr(
+        predicate::str::contains("ambiguous")
+            .and(predicate::str::contains("feature/grouped"))
+            .and(predicate::str::contains("contains `/`")),
+    );
+}
+
+#[test]
+fn g8_inspect_preserves_project_and_home_bytes() {
+    let (ws, _repo, redirect) = inspect_fixture();
+    let project = ws.project("app");
+    fs::create_dir_all(project.join(".tink")).unwrap();
+    fs::write(project.join(".tink").join("marker"), "project").unwrap();
+    fs::create_dir_all(&ws.inventory).unwrap();
+    fs::write(ws.inventory.join("marker"), "home").unwrap();
+    let project_before = fs::read(project.join(".tink").join("marker")).unwrap();
+    let home_before = fs::read(ws.inventory.join("marker")).unwrap();
+    let mut cmd = ws.cmd(&project);
+    cmd.args(["inspect", "https://github.com/example/skills"]);
+    for (key, value) in &redirect {
+        cmd.env(key, value);
+    }
+    cmd.assert().success();
+    assert_eq!(
+        fs::read(project.join(".tink").join("marker")).unwrap(),
+        project_before
+    );
+    assert_eq!(fs::read(ws.inventory.join("marker")).unwrap(), home_before);
+    assert!(!project.join(".agents").exists());
 }


### PR DESCRIPTION
## Summary

- add project-owned nested skillsets with canonical `-skillset` names
- add receipt-backed project and home-library lifecycle commands
- add read-only GitHub inspection with structural skillset inference
- integrate grouped member validation, status output, and terminal color differentiation

## Why

Tink treats skills as project-owned state. This adds a reproducible grouped-skill workflow while keeping the project authoritative over the home library, and gives users a safe way to understand arbitrary GitHub skill repository layouts before creating catalog definitions.

## Review fixes

- reject ambiguous GitHub tree URLs when a slash-containing ref could be misread as a path
- suppress canonical proposals that become invalid after appending `-skillset`
- require each member directory to match its `SKILL.md` name
- state the project-tree and library refresh guarantees precisely

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check --all-targets --all-features`
- 39 unit tests and 92 acceptance tests
- Clippy pass with only documented pre-existing baseline lints allowed
- `cargo build --release --locked`
- live inspection of `mattpocock/skills` and `addyosmani/agent-skills`