### PR TITLE
Show skillset members in list output

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -92,7 +92,7 @@ Ids are stable. Tests must name or comment the id they prove.
 |---|---|---|
 | K1 | `skillset add <name>-skillset` with `$TINK_HOME/catalog/by-skillset/<name>-skillset/meta.json` | Installs the pinned members under `.agents/skills/<name>-skillset/`, validates the project, then mirrors that exact tree to `$TINK_HOME/skills/<name>-skillset/`; matching re-add is a no-op; library drift is repaired from the valid project |
 | K2 | `skillset remove <name>-skillset` after K1 | Removes only the project skillset tree; preserves the shared catalog definition and home library copy; `skill remove` refuses the skillset root |
-| K3 | `skillset list [--library]` after K1 | Lists receipt-backed skillset names from the current project or home library without network or writes |
+| K3 | `skillset list [--library]` after K1 | Groups each receipt-backed project or library skillset with its member skill names without network or writes |
 | K4 | Any skillset command receives a name without `-skillset` | Exit ≠ 0; clear canonical-name error; no skillset tree written |
 | K5 | `skillset add` finds an ordinary or unowned library entry at the canonical name | Exit ≠ 0 before network/project publication; preserve the library entry |
 | K6 | `skillset remove` finds a missing or invalid receipt | Exit ≠ 0; preserve the complete project directory |

--- a/README.md
+++ b/README.md
@@ -162,8 +162,9 @@ its pinned catalog definition; local project modifications are refused. Library
 drift is repaired only from a valid project tree.
 `skillset remove NAME-skillset` removes only the project tree; it preserves the
 shared catalog definition and home library copy.
-`skillset list` lists receipt-backed skillsets installed in the current project.
-`skillset list --library` lists receipt-backed skillsets in the home library.
+`skillset list` groups each receipt-backed project skillset with its member
+skills. `skillset list --library` shows the same grouped view for the home
+library.
 
 `tink inspect <GITHUB_URL>` performs a read-only inspection of a public GitHub
 repository, folder, or skill URL. It reports directories containing valid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,9 +145,9 @@ pub enum SkillCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum SkillsetCommand {
-    /// List receipt-backed skillsets installed in the current project
+    /// List receipt-backed project skillsets and their members
     List {
-        /// List receipt-backed skillsets in the home library
+        /// List receipt-backed library skillsets and their members
         #[arg(long)]
         library: bool,
     },
@@ -359,12 +359,12 @@ fn dispatch_skillset(cwd: &Path, command: SkillsetCommand) -> Result<(), Error> 
     match command {
         SkillsetCommand::List { library } => {
             let style = CliStyle::auto_stdout();
-            let names = if library {
+            let skillsets = if library {
                 skillsets::list_library(None)?
             } else {
                 skillsets::list_installed(cwd)?
             };
-            if names.is_empty() {
+            if skillsets.is_empty() {
                 let message = if library {
                     "(no library skillsets)"
                 } else {
@@ -372,8 +372,23 @@ fn dispatch_skillset(cwd: &Path, command: SkillsetCommand) -> Result<(), Error> 
                 };
                 println!("{}", style.muted(message));
             } else {
-                for name in names {
-                    println!("{}", style.skillset(name));
+                for (index, skillset) in skillsets.iter().enumerate() {
+                    if index > 0 {
+                        println!();
+                    }
+                    let noun = if skillset.members.len() == 1 {
+                        "skill"
+                    } else {
+                        "skills"
+                    };
+                    println!(
+                        "{} {}",
+                        style.skillset(&skillset.name),
+                        style.muted(format!("({} {noun})", skillset.members.len()))
+                    );
+                    for member in &skillset.members {
+                        println!("  {}", style.skill(member));
+                    }
                 }
             }
             Ok(())

--- a/src/skillsets.rs
+++ b/src/skillsets.rs
@@ -51,6 +51,12 @@ struct InstalledSkillset {
     receipt: SkillsetReceipt,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListedSkillset {
+    pub name: String,
+    pub members: Vec<String>,
+}
+
 fn read_json<T: for<'de> Deserialize<'de>>(path: &Path, label: &str) -> Result<T, Error> {
     refuse_symlink(path)?;
     if !path.is_file() {
@@ -419,7 +425,7 @@ pub fn validate_installed(path: &Path) -> Result<(), Error> {
 }
 
 /// List receipt-backed skillsets installed in a project.
-pub fn list_installed(project_root: &Path) -> Result<Vec<String>, Error> {
+pub fn list_installed(project_root: &Path) -> Result<Vec<ListedSkillset>, Error> {
     let agents = home::project_agents_path(project_root);
     let skills_root = home::project_skills_path(project_root);
     refuse_symlink(&agents)?;
@@ -437,7 +443,7 @@ pub fn list_installed(project_root: &Path) -> Result<Vec<String>, Error> {
         .collect();
     entries.sort();
 
-    let mut names = Vec::new();
+    let mut skillsets = Vec::new();
     for path in entries {
         let name = path
             .file_name()
@@ -452,11 +458,15 @@ pub fn list_installed(project_root: &Path) -> Result<Vec<String>, Error> {
             )));
         }
         if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
-            names.push(read_installed(&path)?.name);
+            let installed = read_installed(&path)?;
+            skillsets.push(ListedSkillset {
+                name: installed.name,
+                members: installed.receipt.members,
+            });
         }
     }
-    names.sort();
-    Ok(names)
+    skillsets.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(skillsets)
 }
 
 /// Count validated project skillsets and their declared member skills.
@@ -550,7 +560,7 @@ fn sync_library_from_project(project: &Path) -> Result<LibraryWrite, Error> {
 }
 
 /// List receipt-backed skillsets in the home library without creating it.
-pub fn list_library(home_root: Option<&Path>) -> Result<Vec<String>, Error> {
+pub fn list_library(home_root: Option<&Path>) -> Result<Vec<ListedSkillset>, Error> {
     let home = match home_root {
         Some(path) => path.to_path_buf(),
         None => home::resolve_home()?,
@@ -577,16 +587,20 @@ pub fn list_library(home_root: Option<&Path>) -> Result<Vec<String>, Error> {
         .map(|entry| entry.path())
         .collect();
     entries.sort();
-    let mut names = Vec::new();
+    let mut skillsets = Vec::new();
     for path in entries {
         if path.is_symlink() || !path.is_dir() {
             continue;
         }
         if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
-            names.push(read_installed(&path)?.name);
+            let installed = read_installed(&path)?;
+            skillsets.push(ListedSkillset {
+                name: installed.name,
+                members: installed.receipt.members,
+            });
         }
     }
-    Ok(names)
+    Ok(skillsets)
 }
 
 #[cfg(test)]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -586,12 +586,16 @@ fn k1_skillset_add_installs_explicit_members_and_checks_digest() {
         .args(["skillset", "list"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("common-skillset"));
+        .stdout(predicate::str::contains(
+            "common-skillset (2 skills)\n  alpha\n  beta\n",
+        ));
     ws.cmd(&project)
         .args(["skillset", "list", "--library"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("common-skillset"));
+        .stdout(predicate::str::contains(
+            "common-skillset (2 skills)\n  alpha\n  beta\n",
+        ));
 
     fs::write(
         library.join("alpha/SKILL.md"),


### PR DESCRIPTION
## What changed

- make project and library skillset listings return validated member names
- render each skillset as a grouped heading with its member skills
- preserve receipt member order and existing skillset/skill color roles
- update help, README, acceptance contract, and acceptance coverage

## Why

A name-only skillset list forced users and downstream workflows to inspect managed filesystem internals to discover which capabilities were active. The public CLI should own that inventory.

## Validation

- 39 unit tests
- 92 acceptance tests
- cargo check --all-targets --all-features
- cargo fmt --all -- --check
- git diff --check