### PR TITLE
Harden Tink inventory lifecycle boundaries

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -77,6 +77,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | A6 | `skill add` when library has same name but different tree (project missing) | Exit 0; installs project; repairs library; warns on stderr that the home copy was updated |
 | A7 | `skill add` skill named `by-project` | Exit ≠ 0; reserved name; no project/library write |
 | A8 | `skill add` same GitHub tip already in library | Exit 0; installs project from library (no clone); stdout notes library |
+| A9 | `skill add` when catalog metadata is malformed, repair the catalog, then rerun the same command | First run fails after preserving valid project/library copies; second run exits 0, catalogs the skill, and leaves those copies byte-identical |
 
 ### Remote add
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -62,6 +62,8 @@ Ids are stable. Tests must name or comment the id they prove.
 | I6 | `init` (default) | Installs `.agents/skills/manage-tink/`; catalogs `manage-tink`; copies tree into library at `skills/manage-tink/` |
 | I7 | `init --no-manage-tink` | Does **not** install `manage-tink` |
 | I8 | `init` with relative `TINK_HOME` (e.g. `../home`) from project cwd | Exit 0; home is the absolutized sibling path (not nested under the project); stdout shows an absolute home path |
+| I9 | Run non-interactive `init` twice with an unchanged project | Second run exits 0, reports `Ready` / `Already present`, and leaves project/home contract files byte-identical |
+| I10 | Run `init --with-tink-skills` against an incomplete optional bundle, repair the bundle, then rerun the same command | First run fails but preserves completed setup; second run exits 0 and converges to `manage-tink` plus both bundle skills |
 
 ### Local add
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -65,6 +65,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | I9 | Run non-interactive `init` twice with an unchanged project | Second run exits 0, reports `Ready` / `Already present`, and leaves project/home contract files byte-identical |
 | I10 | Run `init --with-tink-skills` against an incomplete optional bundle, repair the bundle, then rerun the same command | First run fails but preserves completed setup; second run exits 0 and converges to `manage-tink` plus both bundle skills |
 | I11 | Run `init` with `TINK_HOME` pointed at the non-empty project directory | Exit ≠ 0; refuses to claim the directory and leaves the project byte-identical |
+| I12 | Run `init` with a marker-only partial Tink home left by interrupted initialization | Exit 0; recreates the owned library/catalog directories and leaves a valid inventory |
 
 ### Local add
 
@@ -158,6 +159,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | H7 | `skill harvest` when library diverges | Exit 0; library unchanged; stderr skip warn |
 | H8 | `skill harvest` skips library sources and unsafe (symlink-inside) skill trees; still harvests cwd skills under `TINK_HOME` outside `skills/` | Library/unsafe omitted; non-library path under home deposited |
 | H9 | Shell completion for `tink skill add <prefix>` | Offers matching names from the current library without creating the home or library |
+| H10 | `skill list --library` when a valid library skill contains a nested symlink | Exit ≠ 0; mentions the symlink; does not advertise the unsafe skill or alter either side of the link |
 
 ### CLI surface
 
@@ -187,6 +189,8 @@ Ids are stable. Tests must name or comment the id they prove.
 | X3 | `skill remove` when `.agents` is a symlink | Exit ≠ 0; mentions symlink; tree unchanged |
 | X4 | Successful `skill remove <name>` | Does **not** delete `$TINK_HOME/skills/<name>/` |
 | X5 | `init` installs `manage-tink` | Embedded skill covers standalone skill lifecycle, manifests, library promotion/harvest, read-only GitHub inspection, canonical nested skillsets, project-first library authority, catalog effects, CLI update, and destroy; removals preserve library state |
+| X6 | `skill remove <name>` when that project's catalog metadata is malformed | Exit ≠ 0; project and library skill trees remain intact |
+| X7 | `skill remove <name>` when `$TINK_HOME/catalog` is a symlink | Exit ≠ 0; mentions the symlink; project skill and external catalog target remain byte-identical |
 
 ### Destroy
 
@@ -195,6 +199,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | D1 | `destroy --yes` after `init --with-zen` (extra skill allowed) | Removes `.agents/`, `ZEN.md`, `AGENTS.md`; leaves library + `layout.json` intact; drops this project's by-project catalog entry (`skill list --catalog` has no rows for it) |
 | D2 | `destroy` without `--yes` (non-TTY) | Exit ≠ 0; refuses without confirmation; project files unchanged |
 | D3 | `destroy --yes` when `.agents` is a symlink | Exit ≠ 0; mentions symlink |
+| D4 | `destroy --yes` when `$TINK_HOME/catalog` is a symlink | Exit ≠ 0; mentions the symlink; project scaffolding and external catalog target remain byte-identical |
 
 ### Update (CLI binary)
 
@@ -210,6 +215,7 @@ Ids are stable. Tests must name or comment the id they prove.
 |---|---|---|
 | S1 | Any successful command | Does not `git init`, stage, commit, or push |
 | S2 | Home root | Never treated as an agent discovery root |
+| S3 | `skill remove` or `destroy --yes` when neither `TINK_HOME` nor `HOME` can resolve an inventory | Exit 0; completes local cleanup without creating or mutating inventory state |
 
 ## Proof
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -140,6 +140,10 @@ Ids are stable. Tests must name or comment the id they prove.
 | L3 | `skill list --catalog` after init+add | Exit 0; header `project\\troot\\tskill` plus TSV rows for cataloged skills |
 | L4 | `skill list` when `ZEN.md` exists without `AGENTS.md` reference | Exit 0; lists skills; warns on stderr about ZEN/AGENTS; `skill check` still fails |
 | L5 | `skill list --stash` or `skill list --home` | Exit ≠ 0; stderr mentions the flag or unexpected argument (removed in 0.3.0; use `--library` / `--catalog`) |
+| L6 | `skill list --catalog` with valid and malformed project metadata | Exit 0; lists valid rows and omits malformed entries |
+| L7 | Insert a nested symlink into an installed standalone skill, then run `skill list` and `skill check` | Both exit ≠ 0 and mention the symlink; the installed tree is untouched |
+| L8 | `skill list --library` or `--catalog` with an existing non-empty unmarked `TINK_HOME` | Exit ≠ 0; refuses the unrelated directory and leaves it byte-identical |
+| L9 | `skill list --library` or `--catalog` when the corresponding direct home owner (`skills/` or `catalog/`) is a symlink | Exit ≠ 0; refuses the symlink without following or replacing it |
 
 ### Library
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -64,6 +64,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | I8 | `init` with relative `TINK_HOME` (e.g. `../home`) from project cwd | Exit 0; home is the absolutized sibling path (not nested under the project); stdout shows an absolute home path |
 | I9 | Run non-interactive `init` twice with an unchanged project | Second run exits 0, reports `Ready` / `Already present`, and leaves project/home contract files byte-identical |
 | I10 | Run `init --with-tink-skills` against an incomplete optional bundle, repair the bundle, then rerun the same command | First run fails but preserves completed setup; second run exits 0 and converges to `manage-tink` plus both bundle skills |
+| I11 | Run `init` with `TINK_HOME` pointed at the non-empty project directory | Exit ≠ 0; refuses to claim the directory and leaves the project byte-identical |
 
 ### Local add
 
@@ -78,6 +79,9 @@ Ids are stable. Tests must name or comment the id they prove.
 | A7 | `skill add` skill named `by-project` | Exit ≠ 0; reserved name; no project/library write |
 | A8 | `skill add` same GitHub tip already in library | Exit 0; installs project from library (no clone); stdout notes library |
 | A9 | `skill add` when catalog metadata is malformed, repair the catalog, then rerun the same command | First run fails after preserving valid project/library copies; second run exits 0, catalogs the skill, and leaves those copies byte-identical |
+| A10 | `skill add` from a direct symlink or a symlinked child under `skills/` | Exit ≠ 0; mentions symlink; creates no project, library, or catalog entry for that skill |
+| A11 | `skill add` when the matching project target is a symlink | Exit ≠ 0; leaves the symlink untouched; creates no library or catalog entry |
+| A12 | `skill add` with `TINK_HOME` pointed at an unrelated non-empty directory | Exit ≠ 0; refuses to claim the directory and leaves its existing files byte-identical |
 
 ### Remote add
 

--- a/src/add.rs
+++ b/src/add.rs
@@ -172,6 +172,7 @@ pub(crate) fn add_locked_skill(
     match source {
         LockedSource::LocalPath { path, .. } => {
             init::ensure_project_layout(project_root)?;
+            crate::paths::refuse_symlink(&path)?;
             if !path.exists() {
                 return Err(Error::msg(format!(
                     "Path does not exist: {}",
@@ -253,6 +254,7 @@ fn add_skill_inner(
     let destination_root = crate::home::project_skills_path(project_root);
     match sources::classify_add_input(source_value)? {
         AddSource::LocalPath(local_source) => {
+            crate::paths::refuse_symlink(&local_source)?;
             let source_root = local_source
                 .canonicalize()
                 .map_err(|e| crate::paths::map_io(&local_source, e))?;

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -491,6 +491,7 @@ mod tests {
     fn skill_shaped_by_project_dir_is_not_legacy_catalog() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("inv");
+        ensure_inventory_root(Some(&root)).unwrap();
         let skill_shaped = root.join("skills").join(BY_PROJECT);
         fs::create_dir_all(&skill_shaped).unwrap();
         fs::write(

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -155,20 +155,49 @@ fn remove_catalog_dir(catalog: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-/// Soft-resolve home for withdraw/forget: missing home is success, not create.
-fn existing_home(home: Option<&Path>) -> Result<Option<PathBuf>, Error> {
+/// Find an existing project catalog only after validating the owned home and
+/// every directory boundary that a destructive operation would traverse.
+fn existing_project_catalog(
+    home: Option<&Path>,
+    project_root: &Path,
+) -> Result<Option<PathBuf>, Error> {
     let home = match home {
         Some(path) => path.to_path_buf(),
+        // Cleanup remains a soft success when the implicit home cannot be
+        // resolved (for example, HOME is unset). An explicit home is strict.
         None => match resolve_home() {
             Ok(path) => path,
             Err(_) => return Ok(None),
         },
     };
-    if !home.exists() {
+    let Some(home) = existing_inventory_root(Some(&home))? else {
+        return Ok(None);
+    };
+    let by_project = by_project_path(&home);
+    if !by_project.exists() && !by_project.is_symlink() {
         return Ok(None);
     }
-    refuse_symlink(&home)?;
-    Ok(Some(home))
+    refuse_symlink(&by_project)?;
+    if !by_project.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing non-directory catalog: {}",
+            by_project.display()
+        )));
+    }
+
+    let catalog = project_catalog_dir(&home, project_root)?;
+    if !catalog.exists() && !catalog.is_symlink() {
+        return Ok(None);
+    }
+    refuse_symlink(&catalog)?;
+    if !catalog.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing to remove non-directory catalog: {}",
+            catalog.display()
+        )));
+    }
+    require_file(&catalog.join("meta.json"))?;
+    Ok(Some(catalog))
 }
 
 /// Record that `skill_name` is installed in `project_root`.
@@ -228,10 +257,9 @@ pub(crate) fn withdraw_skill_at(
         Ok(path) => path,
         Err(_) => return Ok(()),
     };
-    let Some(home) = existing_home(home)? else {
+    let Some(catalog) = existing_project_catalog(home, &project_root)? else {
         return Ok(());
     };
-    let catalog = project_catalog_dir(&home, &project_root)?;
     let meta_path = catalog.join("meta.json");
     if !meta_path.is_file() {
         return Ok(());
@@ -268,10 +296,9 @@ pub(crate) fn forget_project_at(home: Option<&Path>, project_root: &Path) -> Res
         Ok(path) => path,
         Err(_) => return Ok(()),
     };
-    let Some(home) = existing_home(home)? else {
+    let Some(catalog) = existing_project_catalog(home, &project_root)? else {
         return Ok(());
     };
-    let catalog = project_catalog_dir(&home, &project_root)?;
     let meta_path = catalog.join("meta.json");
     if meta_path.is_file() {
         refuse_symlink(&meta_path)?;
@@ -674,5 +701,83 @@ mod tests {
             vec!["keep"]
         );
         forget_project_at(Some(&home), &temp.path().join("other-missing")).unwrap();
+    }
+
+    #[test]
+    fn destructive_operations_refuse_unowned_home_without_mutation() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        let catalog = by_project_path(&home).join("app");
+        fs::create_dir_all(&catalog).unwrap();
+        let meta = catalog.join("meta.json");
+        fs::write(&meta, "unowned catalog\n").unwrap();
+        let before = fs::read(&meta).unwrap();
+
+        for operation in [
+            withdraw_skill_at(Some(&home), &app, "alpha"),
+            forget_project_at(Some(&home), &app),
+        ] {
+            let err = operation.unwrap_err();
+            assert!(err.to_string().contains("Not a Tink home"), "{err}");
+        }
+
+        assert_eq!(fs::read(&meta).unwrap(), before);
+        assert!(catalog.is_dir());
+    }
+
+    #[test]
+    fn destructive_operations_refuse_catalog_symlinks_without_following() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        ensure_inventory_root(Some(&home)).unwrap();
+
+        let outside = temp.path().join("outside");
+        let outside_catalog = outside.join("app");
+        fs::create_dir_all(&outside_catalog).unwrap();
+        let meta = outside_catalog.join("meta.json");
+        fs::write(&meta, "external catalog\n").unwrap();
+        fs::remove_dir_all(by_project_path(&home)).unwrap();
+        std::os::unix::fs::symlink(&outside, by_project_path(&home)).unwrap();
+
+        for operation in [
+            withdraw_skill_at(Some(&home), &app, "alpha"),
+            forget_project_at(Some(&home), &app),
+        ] {
+            let err = operation.unwrap_err();
+            assert!(err.to_string().contains("symlink"), "{err}");
+        }
+
+        assert!(outside_catalog.is_dir());
+        assert_eq!(fs::read_to_string(&meta).unwrap(), "external catalog\n");
+    }
+
+    #[test]
+    fn destructive_operations_refuse_project_catalog_symlink_without_following() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let app = temp.path().join("app");
+        fs::create_dir_all(&app).unwrap();
+        ensure_inventory_root(Some(&home)).unwrap();
+
+        let outside_catalog = temp.path().join("outside-app");
+        fs::create_dir_all(&outside_catalog).unwrap();
+        let meta = outside_catalog.join("meta.json");
+        fs::write(&meta, "external catalog\n").unwrap();
+        std::os::unix::fs::symlink(&outside_catalog, by_project_path(&home).join("app")).unwrap();
+
+        for operation in [
+            withdraw_skill_at(Some(&home), &app, "alpha"),
+            forget_project_at(Some(&home), &app),
+        ] {
+            let err = operation.unwrap_err();
+            assert!(err.to_string().contains("symlink"), "{err}");
+        }
+
+        assert!(outside_catalog.is_dir());
+        assert_eq!(fs::read_to_string(&meta).unwrap(), "external catalog\n");
     }
 }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -11,7 +11,8 @@ use serde_json::{Value, json};
 
 use crate::error::Error;
 use crate::home::{
-    BY_PROJECT, by_project_path, ensure_inventory_root, looks_like_legacy_catalog, resolve_home,
+    BY_PROJECT, by_project_path, ensure_inventory_root, existing_inventory_root,
+    looks_like_legacy_catalog, resolve_home,
 };
 use crate::paths::{map_io, mkdir_p, refuse_symlink, require_directory, require_file};
 
@@ -292,14 +293,9 @@ pub struct CatalogEntry {
 
 /// Read `$TINK_HOME` / `~/.tink` by-project catalogs (read-only; creates nothing).
 pub fn list_catalog(home: Option<&Path>) -> Result<Vec<CatalogEntry>, Error> {
-    let home = match home {
-        Some(path) => path.to_path_buf(),
-        None => resolve_home()?,
-    };
-    if !home.exists() {
+    let Some(home) = existing_inventory_root(home)? else {
         return Ok(Vec::new());
-    }
-    refuse_symlink(&home)?;
+    };
     let new = by_project_path(&home);
     let legacy = home.join("skills").join(BY_PROJECT);
     let legacy_catalog = looks_like_legacy_catalog(&legacy);
@@ -384,8 +380,24 @@ mod tests {
         let home = temp.path().join("home");
         fs::create_dir_all(home.join("skills").join(BY_PROJECT).join("app")).unwrap();
         fs::create_dir_all(by_project_path(&home).join("app")).unwrap();
+        fs::write(
+            home.join(crate::home::LAYOUT_FILENAME),
+            format!("{{\"kind\":\"{}\"}}", crate::home::LAYOUT_KIND),
+        )
+        .unwrap();
         let err = list_catalog(Some(&home)).unwrap_err();
         assert!(err.to_string().contains("Catalog split"), "{err}");
+    }
+
+    #[test]
+    fn list_catalog_requires_owned_home_before_reading_catalog() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        fs::create_dir_all(by_project_path(&home)).unwrap();
+
+        let err = list_catalog(Some(&home)).unwrap_err();
+
+        assert!(err.to_string().contains("Not a Tink home"), "{err}");
     }
 
     #[test]

--- a/src/check.rs
+++ b/src/check.rs
@@ -29,6 +29,7 @@ fn read_skill_entry(path: &Path) -> Result<Option<Skill>, Error> {
         return Ok(None);
     }
     let skill = skills::read_skill(path, true)?;
+    skills::validate_skill_tree(path)?;
     provenance::read(&skill)?;
     Ok(Some(skill))
 }
@@ -93,4 +94,60 @@ pub fn check_project(root: &Path) -> Result<Vec<Skill>, Error> {
     let skills = load_project_skills(root)?;
     check_zen_coupling(root)?;
     Ok(skills)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_skill(root: &Path) {
+        fs::create_dir_all(root).unwrap();
+        fs::write(
+            root.join("SKILL.md"),
+            "---\nname: demo-skill\ndescription: A valid test skill.\n---\n",
+        )
+        .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_project_skills_refuses_nested_symlink() {
+        let temp = TempDir::new().unwrap();
+        let skill = temp.path().join(".agents/skills/demo-skill");
+        write_skill(&skill);
+        std::os::unix::fs::symlink("/tmp", skill.join("nested-link")).unwrap();
+
+        let err = load_project_skills(temp.path()).unwrap_err();
+
+        assert!(err.to_string().contains("symlink"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_project_skills_refuses_nested_special_file() {
+        let temp = TempDir::new().unwrap();
+        let skill = temp.path().join(".agents/skills/demo-skill");
+        write_skill(&skill);
+        let _socket = std::os::unix::net::UnixListener::bind(skill.join("socket")).unwrap();
+
+        let err = load_project_skills(temp.path()).unwrap_err();
+
+        assert!(err.to_string().contains("special file"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_project_skills_ignores_git_contents() {
+        let temp = TempDir::new().unwrap();
+        let skill = temp.path().join(".agents/skills/demo-skill");
+        write_skill(&skill);
+        fs::create_dir_all(skill.join(".git")).unwrap();
+        std::os::unix::fs::symlink("/tmp", skill.join(".git/ignored-link")).unwrap();
+
+        let skills = load_project_skills(temp.path()).unwrap();
+
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "demo-skill");
+    }
 }

--- a/src/home.rs
+++ b/src/home.rs
@@ -124,6 +124,7 @@ pub fn ensure_inventory_root(root: Option<&Path>) -> Result<(PathBuf, bool), Err
             root.display()
         )));
     }
+    preflight_inventory_root(&root)?;
     mkdir_p(&root)?;
     mkdir_p(&skills_library_path(&root))?;
     migrate_catalog_if_needed(&root)?;
@@ -131,6 +132,33 @@ pub fn ensure_inventory_root(root: Option<&Path>) -> Result<(PathBuf, bool), Err
     mkdir_p(&by_skillset_path(&root))?;
     write_layout_marker(&root)?;
     Ok((root, created))
+}
+
+/// Refuse to claim an unrelated existing directory as Tink home.
+///
+/// A valid layout marker establishes ownership. An existing empty directory is
+/// also safe to initialize; every other non-empty unmarked directory is left
+/// byte-for-byte untouched.
+fn preflight_inventory_root(root: &Path) -> Result<(), Error> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let layout = root.join(LAYOUT_FILENAME);
+    require_file(&layout)?;
+    if layout.is_file() {
+        return validate_layout_marker(root, &layout);
+    }
+    let is_empty = fs::read_dir(root)
+        .map_err(|e| map_io(root, e))?
+        .next()
+        .is_none();
+    if is_empty {
+        return Ok(());
+    }
+    Err(Error::msg(format!(
+        "Refusing to initialize non-empty directory as Tink home: {}",
+        root.display()
+    )))
 }
 
 /// True when `skills/by-project` looks like the old name catalog (not a skill tree).
@@ -178,13 +206,7 @@ fn write_layout_marker(root: &Path) -> Result<(), Error> {
     let layout_path = root.join(LAYOUT_FILENAME);
     require_file(&layout_path)?;
     if layout_path.is_file() {
-        let existing = fs::read_to_string(&layout_path).map_err(|e| map_io(&layout_path, e))?;
-        if !existing.contains(LAYOUT_KIND) {
-            return Err(Error::msg(format!(
-                "Not a Tink home inventory: {}",
-                root.display()
-            )));
-        }
+        validate_layout_marker(root, &layout_path)?;
     } else {
         let body = format!("{{\n  \"kind\": \"{LAYOUT_KIND}\"\n}}\n");
         fs::write(&layout_path, body).map_err(|e| map_io(&layout_path, e))?;
@@ -200,6 +222,19 @@ fn write_layout_marker(root: &Path) -> Result<(), Error> {
     };
     if refresh_readme {
         fs::write(&readme, HOME_README).map_err(|e| map_io(&readme, e))?;
+    }
+    Ok(())
+}
+
+fn validate_layout_marker(root: &Path, layout: &Path) -> Result<(), Error> {
+    let raw = fs::read_to_string(layout).map_err(|e| map_io(layout, e))?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|_| Error::msg(format!("Not a Tink home inventory: {}", root.display())))?;
+    if value.get("kind").and_then(serde_json::Value::as_str) != Some(LAYOUT_KIND) {
+        return Err(Error::msg(format!(
+            "Not a Tink home inventory: {}",
+            root.display()
+        )));
     }
     Ok(())
 }
@@ -231,6 +266,11 @@ mod tests {
         let legacy = root.join("skills").join(BY_PROJECT).join("app");
         fs::create_dir_all(&legacy).unwrap();
         fs::write(
+            root.join(LAYOUT_FILENAME),
+            format!("{{\n  \"kind\": \"{LAYOUT_KIND}\"\n}}\n"),
+        )
+        .unwrap();
+        fs::write(
             legacy.join("meta.json"),
             "{\"name\":\"app\",\"root\":\"/tmp/app\",\"skills\":[\"x\"]}\n",
         )
@@ -251,6 +291,11 @@ mod tests {
         let root = temp.path().join("inv");
         fs::create_dir_all(root.join("skills").join(BY_PROJECT).join("old")).unwrap();
         fs::create_dir_all(by_project_path(&root).join("new")).unwrap();
+        fs::write(
+            root.join(LAYOUT_FILENAME),
+            format!("{{\n  \"kind\": \"{LAYOUT_KIND}\"\n}}\n"),
+        )
+        .unwrap();
         let err = ensure_inventory_root(Some(&root)).unwrap_err();
         assert!(err.to_string().contains("Catalog split"), "{err}");
     }
@@ -261,6 +306,11 @@ mod tests {
         let root = temp.path().join("inv");
         fs::create_dir_all(root.join("skills")).unwrap();
         fs::write(root.join("skills").join(BY_PROJECT), "not a dir\n").unwrap();
+        fs::write(
+            root.join(LAYOUT_FILENAME),
+            format!("{{\n  \"kind\": \"{LAYOUT_KIND}\"\n}}\n"),
+        )
+        .unwrap();
         let err = ensure_inventory_root(Some(&root)).unwrap_err();
         assert!(
             err.to_string().contains("non-directory legacy catalog"),
@@ -287,6 +337,56 @@ mod tests {
         let readme = fs::read_to_string(root.join("README.md")).unwrap();
         assert!(readme.contains("catalog/by-project"));
         assert!(!readme.contains("skills/by-project/<project>"));
+    }
+
+    #[test]
+    fn ensure_initializes_existing_empty_root() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("inv");
+        fs::create_dir(&root).unwrap();
+
+        let (_, created) = ensure_inventory_root(Some(&root)).unwrap();
+
+        assert!(!created);
+        assert!(root.join(LAYOUT_FILENAME).is_file());
+        assert!(skills_library_path(&root).is_dir());
+        assert!(by_project_path(&root).is_dir());
+    }
+
+    #[test]
+    fn ensure_refuses_nonempty_unmarked_root_without_writes() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("project");
+        fs::create_dir(&root).unwrap();
+        let readme = root.join("README.md");
+        fs::write(&readme, "# Important project\n").unwrap();
+        let before = fs::read(&readme).unwrap();
+
+        let err = ensure_inventory_root(Some(&root)).unwrap_err();
+
+        assert!(err.to_string().contains("non-empty"), "{err}");
+        assert_eq!(fs::read(&readme).unwrap(), before);
+        assert!(!root.join(LAYOUT_FILENAME).exists());
+        assert!(!root.join("skills").exists());
+        assert!(!root.join("catalog").exists());
+    }
+
+    #[test]
+    fn ensure_refuses_malformed_marker_without_writes() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("inv");
+        fs::create_dir(&root).unwrap();
+        let layout = root.join(LAYOUT_FILENAME);
+        fs::write(&layout, "{not-json}\n").unwrap();
+        let before = fs::read(&layout).unwrap();
+
+        let err = ensure_inventory_root(Some(&root)).unwrap_err();
+
+        assert!(err.to_string().contains("Not a Tink home"), "{err}");
+        assert_eq!(fs::read(&layout).unwrap(), before);
+        assert!(!root.join("skills").exists());
+        assert!(!root.join("catalog").exists());
+        assert!(!root.join("README.md").exists());
     }
 
     #[test]

--- a/src/home.rs
+++ b/src/home.rs
@@ -151,6 +151,7 @@ pub fn ensure_inventory_root(root: Option<&Path>) -> Result<(PathBuf, bool), Err
     preflight_inventory_root(&root)?;
     mkdir_p(&root)?;
     validate_direct_owners(&root)?;
+    publish_layout_marker(&root)?;
     mkdir_p(&skills_library_path(&root))?;
     migrate_catalog_if_needed(&root)?;
     mkdir_p(&by_project_path(&root))?;
@@ -244,14 +245,7 @@ fn migrate_catalog_if_needed(home: &Path) -> Result<(), Error> {
 }
 
 fn write_layout_marker(root: &Path) -> Result<(), Error> {
-    let layout_path = root.join(LAYOUT_FILENAME);
-    require_file(&layout_path)?;
-    if layout_path.is_file() {
-        validate_layout_marker(root, &layout_path)?;
-    } else {
-        let body = format!("{{\n  \"kind\": \"{LAYOUT_KIND}\"\n}}\n");
-        fs::write(&layout_path, body).map_err(|e| map_io(&layout_path, e))?;
-    }
+    publish_layout_marker(root)?;
 
     let readme = root.join("README.md");
     require_file(&readme)?;
@@ -263,6 +257,19 @@ fn write_layout_marker(root: &Path) -> Result<(), Error> {
     };
     if refresh_readme {
         fs::write(&readme, HOME_README).map_err(|e| map_io(&readme, e))?;
+    }
+    Ok(())
+}
+
+/// Publish the ownership marker before creating owned child directories.
+fn publish_layout_marker(root: &Path) -> Result<(), Error> {
+    let layout_path = root.join(LAYOUT_FILENAME);
+    require_file(&layout_path)?;
+    if layout_path.is_file() {
+        validate_layout_marker(root, &layout_path)?;
+    } else {
+        let body = format!("{{\n  \"kind\": \"{LAYOUT_KIND}\"\n}}\n");
+        fs::write(&layout_path, body).map_err(|e| map_io(&layout_path, e))?;
     }
     Ok(())
 }
@@ -402,6 +409,25 @@ mod tests {
     }
 
     #[test]
+    fn ensure_resumes_after_marker_only_interruption() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("inv");
+        fs::create_dir(&root).unwrap();
+
+        publish_layout_marker(&root).unwrap();
+        assert!(root.join(LAYOUT_FILENAME).is_file());
+        assert!(!root.join("README.md").exists());
+        assert!(!root.join("skills").exists());
+        assert!(!root.join("catalog").exists());
+
+        ensure_inventory_root(Some(&root)).unwrap();
+
+        assert!(root.join("README.md").is_file());
+        assert!(skills_library_path(&root).is_dir());
+        assert!(by_project_path(&root).is_dir());
+    }
+
+    #[test]
     fn ensure_refuses_nonempty_unmarked_root_without_writes() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("project");
@@ -505,12 +531,16 @@ mod tests {
                 format!("{{\"kind\":\"{LAYOUT_KIND}\"}}"),
             )
             .unwrap();
+            let readme = root.join("README.md");
+            fs::write(&readme, "existing home text\n").unwrap();
+            let before = fs::read(&readme).unwrap();
             std::os::unix::fs::symlink(&target, root.join(owner)).unwrap();
 
             let err = ensure_inventory_root(Some(&root)).unwrap_err();
 
             assert!(err.to_string().contains("symlink"), "{err}");
             assert!(fs::read_dir(&target).unwrap().next().is_none());
+            assert_eq!(fs::read(&readme).unwrap(), before);
         }
     }
 

--- a/src/home.rs
+++ b/src/home.rs
@@ -91,6 +91,30 @@ pub fn resolve_home() -> Result<PathBuf, Error> {
     absolutize(PathBuf::from(home).join(TINK_HOME_NAME))
 }
 
+/// Resolve an existing, owned inventory root without creating anything.
+///
+/// Missing homes are treated as absent. Existing homes must have the Tink
+/// layout marker and safe direct owner directories before callers inspect them.
+pub fn existing_inventory_root(root: Option<&Path>) -> Result<Option<PathBuf>, Error> {
+    let root = match root {
+        Some(path) => absolutize(path.to_path_buf())?,
+        None => resolve_home()?,
+    };
+    refuse_symlink(&root)?;
+    if !root.exists() {
+        return Ok(None);
+    }
+    if !root.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing to read non-directory inventory root: {}",
+            root.display()
+        )));
+    }
+    validate_layout_marker(&root, &root.join(LAYOUT_FILENAME))?;
+    validate_direct_owners(&root)?;
+    Ok(Some(root))
+}
+
 /// Path to `catalog/by-project` under a home root.
 pub fn by_project_path(home: &Path) -> PathBuf {
     home.join("catalog").join(BY_PROJECT)
@@ -126,6 +150,7 @@ pub fn ensure_inventory_root(root: Option<&Path>) -> Result<(PathBuf, bool), Err
     }
     preflight_inventory_root(&root)?;
     mkdir_p(&root)?;
+    validate_direct_owners(&root)?;
     mkdir_p(&skills_library_path(&root))?;
     migrate_catalog_if_needed(&root)?;
     mkdir_p(&by_project_path(&root))?;
@@ -161,13 +186,29 @@ fn preflight_inventory_root(root: &Path) -> Result<(), Error> {
     )))
 }
 
+/// Refuse direct Tink-owned paths that would make creation or inspection
+/// traverse a symlink or replace a non-directory.
+fn validate_direct_owners(root: &Path) -> Result<(), Error> {
+    for name in ["catalog", "skills"] {
+        let owner = root.join(name);
+        refuse_symlink(&owner)?;
+        if owner.exists() && !owner.is_dir() {
+            return Err(Error::msg(format!(
+                "Refusing non-directory Tink home owner: {}",
+                owner.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// True when `skills/by-project` looks like the old name catalog (not a skill tree).
 pub(crate) fn looks_like_legacy_catalog(path: &Path) -> bool {
     path.is_dir() && !path.join("SKILL.md").is_file()
 }
 
-/// Older homes kept the name catalog at `skills/by-project/`; move it out so
-/// `skills/<name>/` can hold library trees.
+/// Older marked homes kept the name catalog at `skills/by-project/`; move it
+/// out so `skills/<name>/` can hold library trees.
 fn migrate_catalog_if_needed(home: &Path) -> Result<(), Error> {
     let old = home.join("skills").join(BY_PROJECT);
     let new = by_project_path(home);
@@ -227,6 +268,13 @@ fn write_layout_marker(root: &Path) -> Result<(), Error> {
 }
 
 fn validate_layout_marker(root: &Path, layout: &Path) -> Result<(), Error> {
+    refuse_symlink(layout)?;
+    if !layout.is_file() {
+        return Err(Error::msg(format!(
+            "Not a Tink home inventory: {}",
+            root.display()
+        )));
+    }
     let raw = fs::read_to_string(layout).map_err(|e| map_io(layout, e))?;
     let value: serde_json::Value = serde_json::from_str(&raw)
         .map_err(|_| Error::msg(format!("Not a Tink home inventory: {}", root.display())))?;
@@ -387,6 +435,83 @@ mod tests {
         assert!(!root.join("skills").exists());
         assert!(!root.join("catalog").exists());
         assert!(!root.join("README.md").exists());
+    }
+
+    #[test]
+    fn existing_home_requires_marker_but_keeps_missing_home_empty() {
+        let temp = TempDir::new().unwrap();
+        let missing = temp.path().join("missing");
+        assert!(existing_inventory_root(Some(&missing)).unwrap().is_none());
+
+        let unmarked = temp.path().join("unmarked");
+        fs::create_dir(&unmarked).unwrap();
+        let err = existing_inventory_root(Some(&unmarked)).unwrap_err();
+        assert!(err.to_string().contains("Not a Tink home"), "{err}");
+
+        fs::write(
+            unmarked.join(LAYOUT_FILENAME),
+            format!("{{\"kind\":\"{LAYOUT_KIND}\"}}"),
+        )
+        .unwrap();
+        assert_eq!(
+            existing_inventory_root(Some(&unmarked)).unwrap(),
+            Some(unmarked)
+        );
+    }
+
+    #[test]
+    fn existing_home_keeps_marked_legacy_layout_compatible() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("legacy");
+        fs::create_dir_all(root.join("skills").join(BY_PROJECT)).unwrap();
+        fs::write(
+            root.join(LAYOUT_FILENAME),
+            format!("{{\"kind\":\"{LAYOUT_KIND}\"}}"),
+        )
+        .unwrap();
+
+        assert_eq!(existing_inventory_root(Some(&root)).unwrap(), Some(root));
+    }
+
+    #[test]
+    fn existing_home_refuses_non_directory_direct_owners() {
+        let temp = TempDir::new().unwrap();
+        for owner in ["catalog", "skills"] {
+            let root = temp.path().join(format!("{owner}-home"));
+            fs::create_dir(&root).unwrap();
+            fs::write(
+                root.join(LAYOUT_FILENAME),
+                format!("{{\"kind\":\"{LAYOUT_KIND}\"}}"),
+            )
+            .unwrap();
+            fs::write(root.join(owner), "not a directory\n").unwrap();
+
+            let err = existing_inventory_root(Some(&root)).unwrap_err();
+
+            assert!(err.to_string().contains("non-directory"), "{err}");
+        }
+    }
+
+    #[test]
+    fn ensure_refuses_direct_owner_symlinks_before_traversal() {
+        let temp = TempDir::new().unwrap();
+        for owner in ["catalog", "skills"] {
+            let root = temp.path().join(owner);
+            let target = temp.path().join(format!("{owner}-target"));
+            fs::create_dir_all(&root).unwrap();
+            fs::create_dir(&target).unwrap();
+            fs::write(
+                root.join(LAYOUT_FILENAME),
+                format!("{{\"kind\":\"{LAYOUT_KIND}\"}}"),
+            )
+            .unwrap();
+            std::os::unix::fs::symlink(&target, root.join(owner)).unwrap();
+
+            let err = ensure_inventory_root(Some(&root)).unwrap_err();
+
+            assert!(err.to_string().contains("symlink"), "{err}");
+            assert!(fs::read_dir(&target).unwrap().next().is_none());
+        }
     }
 
     #[test]

--- a/src/init.rs
+++ b/src/init.rs
@@ -183,6 +183,7 @@ pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitRep
         require_file(&project_root.join(templates::ZEN_FILENAME))?;
         require_file(&project_root.join("AGENTS.md"))?;
     }
+    let (home, home_created) = home::ensure_inventory_root(None)?;
 
     let skills_created = !skills.is_dir();
     mkdir_p(&agents)?;
@@ -218,7 +219,6 @@ pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitRep
         }
     }
 
-    let (home, home_created) = home::ensure_inventory_root(None)?;
     Ok(InitReport {
         skills_path: skills,
         skills_created,
@@ -239,12 +239,12 @@ pub fn ensure_project_layout(project_root: &Path) -> Result<(), Error> {
     require_directory(&agents)?;
     require_directory(&skills)?;
     require_file(&readme)?;
+    let _ = home::ensure_inventory_root(None)?;
 
     mkdir_p(&agents)?;
     mkdir_p(&skills)?;
     if !readme.exists() {
         std::fs::write(&readme, SKILLS_README).map_err(|e| map_io(&readme, e))?;
     }
-    let _ = home::ensure_inventory_root(None)?;
     Ok(())
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -79,6 +79,7 @@ fn iter_library_skills(library: &Path) -> Result<Vec<Skill>, Error> {
             continue;
         }
         if let Ok(skill) = skills::read_skill(&path, true) {
+            skills::validate_skill_tree(&path)?;
             skills.push(skill);
         }
     }
@@ -377,6 +378,31 @@ mod tests {
         fs::create_dir_all(unmarked.join("skills")).unwrap();
         let err = list_names(Some(&unmarked)).unwrap_err();
         assert!(err.to_string().contains("Not a Tink home"), "{err}");
+    }
+
+    #[test]
+    fn list_names_skips_malformed_root_manifest() {
+        let home = TempHome::new();
+        ensure_inventory_root(Some(&home.home)).unwrap();
+        let malformed = home.library_skill("broken-skill");
+        fs::create_dir_all(&malformed).unwrap();
+        fs::write(malformed.join("SKILL.md"), "not frontmatter\n").unwrap();
+
+        assert!(list_names(Some(&home.home)).unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_names_refuses_valid_manifest_with_unsafe_nested_tree() {
+        let home = TempHome::new();
+        ensure_inventory_root(Some(&home.home)).unwrap();
+        let unsafe_skill = home.library_skill("demo-skill");
+        write_skill(&unsafe_skill, "demo-skill", "valid manifest, unsafe tree");
+        std::os::unix::fs::symlink("/tmp", unsafe_skill.join("nested-link")).unwrap();
+
+        let err = list_names(Some(&home.home)).unwrap_err();
+
+        assert!(err.to_string().contains("symlink"), "{err}");
     }
 
     #[test]

--- a/src/library.rs
+++ b/src/library.rs
@@ -7,7 +7,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::Error;
-use crate::home::{BY_PROJECT, ensure_inventory_root, skills_library_path};
+use crate::home::{
+    BY_PROJECT, ensure_inventory_root, existing_inventory_root, skills_library_path,
+};
 use crate::paths::{map_io, mkdir_p, refuse_symlink};
 use crate::provenance::{self, Provenance};
 use crate::skills::{self, PreflightOutcome, Skill};
@@ -155,14 +157,9 @@ pub fn matching(skill: &Skill, provenance: Option<&Provenance>) -> Result<Option
 ///
 /// Creates nothing; empty when home or library root is missing.
 pub fn list_names(home: Option<&Path>) -> Result<Vec<String>, Error> {
-    let home = match home {
-        Some(path) => path.to_path_buf(),
-        None => crate::home::resolve_home()?,
-    };
-    if !home.exists() {
+    let Some(home) = existing_inventory_root(home)? else {
         return Ok(Vec::new());
-    }
-    refuse_symlink(&home)?;
+    };
     let library = skills_library_path(&home);
     Ok(iter_library_skills(&library)?
         .into_iter()
@@ -368,6 +365,18 @@ mod tests {
         assert_eq!(write, CreateOnlyWrite::Created);
         assert_eq!(path, home.library_skill("demo-skill"));
         assert!(skill_md(&path).contains("fresh body"));
+    }
+
+    #[test]
+    fn list_names_requires_owned_home_but_missing_home_is_empty() {
+        let temp = TempDir::new().unwrap();
+        let missing = temp.path().join("missing");
+        assert!(list_names(Some(&missing)).unwrap().is_empty());
+
+        let unmarked = temp.path().join("unmarked");
+        fs::create_dir_all(unmarked.join("skills")).unwrap();
+        let err = list_names(Some(&unmarked)).unwrap_err();
+        assert!(err.to_string().contains("Not a Tink home"), "{err}");
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -235,9 +235,44 @@ fn require_safe_tree(root: &Path) -> Result<BTreeMap<String, EntryKind>, Error> 
     }
 }
 
+fn validate_tree_structure(root: &Path) -> Result<Option<(PathBuf, &'static str)>, Error> {
+    refuse_symlink(root)?;
+    fn walk(root: &Path, dir: &Path) -> Result<Option<(PathBuf, &'static str)>, Error> {
+        for entry in fs::read_dir(dir).map_err(|e| map_io(dir, e))? {
+            let entry = entry.map_err(|e| map_io(dir, e))?;
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| Error::msg(format!("path escape: {}", path.display())))?;
+            if relative == Path::new(".git") || relative.starts_with(".git") {
+                continue;
+            }
+            if path.is_symlink() {
+                return Ok(Some((path, "symlink")));
+            }
+            let ft = entry.file_type().map_err(|e| map_io(&path, e))?;
+            if ft.is_dir() {
+                if let Some(bad) = walk(root, &path)? {
+                    return Ok(Some(bad));
+                }
+            } else if !ft.is_file() {
+                return Ok(Some((path, "special file")));
+            }
+        }
+        Ok(None)
+    }
+    walk(root, root)
+}
+
 /// Reject symlinks and special files anywhere in a skill tree, except `.git`.
 pub fn validate_skill_tree(root: &Path) -> Result<(), Error> {
-    require_safe_tree(root).map(|_| ())
+    match validate_tree_structure(root)? {
+        None => Ok(()),
+        Some((path, what)) => Err(Error::msg(format!(
+            "Refusing to copy {what}: {}",
+            path.display()
+        ))),
+    }
 }
 
 fn tree_contents(root: &Path) -> Result<Option<BTreeMap<String, EntryKind>>, Error> {
@@ -513,4 +548,28 @@ pub fn replace_verified(
     }
     let _ = fs::remove_dir_all(&backup);
     Ok(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_skill_tree_reads_only_metadata_for_regular_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let tree = temp.path().join("skill");
+        fs::create_dir_all(&tree).unwrap();
+        let unreadable = tree.join("private.txt");
+        fs::write(&unreadable, "contents must not be read\n").unwrap();
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = validate_skill_tree(&tree);
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o600)).unwrap();
+
+        assert!(result.is_ok(), "{result:?}");
+    }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -80,6 +80,7 @@ fn frontmatter_value(lines: &[&str], key: &str) -> Option<String> {
 }
 
 pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Error> {
+    refuse_symlink(path)?;
     let skill_file = path.join("SKILL.md");
     refuse_symlink(&skill_file)?;
     if !skill_file.is_file() {
@@ -182,6 +183,7 @@ enum Collected {
 }
 
 fn collect_tree(root: &Path) -> Result<Collected, Error> {
+    refuse_symlink(root)?;
     let mut contents = BTreeMap::new();
     fn walk(
         root: &Path,
@@ -420,6 +422,7 @@ pub fn preflight_install(
 ) -> Result<PreflightOutcome, Error> {
     let expected = expected_install_tree(skill, provenance)?;
     let target = destination_root.join(&skill.name);
+    refuse_symlink(&target)?;
     if !target.exists() && !target.is_symlink() {
         return Ok(PreflightOutcome::Ready);
     }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -235,6 +235,11 @@ fn require_safe_tree(root: &Path) -> Result<BTreeMap<String, EntryKind>, Error> 
     }
 }
 
+/// Reject symlinks and special files anywhere in a skill tree, except `.git`.
+pub fn validate_skill_tree(root: &Path) -> Result<(), Error> {
+    require_safe_tree(root).map(|_| ())
+}
+
 fn tree_contents(root: &Path) -> Result<Option<BTreeMap<String, EntryKind>>, Error> {
     match collect_tree(root)? {
         Collected::Tree(tree) => Ok(Some(tree)),

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -626,6 +626,67 @@ fn a8_add_uses_library_when_remote_tip_matches() {
     );
 }
 
+#[test]
+fn a9_add_catalog_failure_is_resumable() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills"])
+        .assert()
+        .success();
+
+    let source = ws.root.join("demo-skill");
+    write_skill(&source, "demo-skill", "Do the work.");
+    let args = ["skill", "add", source.to_str().unwrap()];
+    let catalog = ws.catalog_meta("app");
+    let catalog_before = fs::read(&catalog).unwrap();
+    let malformed_catalog = b"{not-json}\n";
+    fs::write(&catalog, malformed_catalog).unwrap();
+
+    ws.cmd(&project)
+        .args(args)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid catalog meta"));
+
+    let installed_root = Workspace::skill_path(&project, "demo-skill");
+    let library_root = ws.library_skill("demo-skill");
+    let installed = installed_root.join("SKILL.md");
+    let library = library_root.join("SKILL.md");
+    assert!(installed.is_file());
+    assert!(library.is_file());
+    assert_eq!(fs::read(&catalog).unwrap(), malformed_catalog);
+    ws.cmd(&project).args(["skill", "check"]).assert().success();
+    let source_before = fs::read(source.join("SKILL.md")).unwrap();
+    let installed_before = fs::read(&installed).unwrap();
+    let library_before = fs::read(&library).unwrap();
+    assert_eq!(installed_before, source_before);
+    assert_eq!(library_before, source_before);
+    assert_eq!(fs::read_dir(&installed_root).unwrap().count(), 1);
+    assert_eq!(fs::read_dir(&library_root).unwrap().count(), 1);
+
+    fs::write(&catalog, catalog_before).unwrap();
+    ws.cmd(&project)
+        .args(args)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Unchanged demo-skill"));
+
+    ws.assert_cataloged("app", "manage-tink");
+    ws.assert_cataloged("app", "demo-skill");
+    let meta: serde_json::Value =
+        serde_json::from_slice(&fs::read(&catalog).unwrap()).expect("valid catalog meta");
+    let skills = meta["skills"].as_array().expect("catalog skills");
+    assert_eq!(skills.len(), 2);
+    assert!(skills.contains(&serde_json::json!("demo-skill")));
+    assert!(skills.contains(&serde_json::json!("manage-tink")));
+    assert_eq!(fs::read(installed).unwrap(), installed_before);
+    assert_eq!(fs::read(library).unwrap(), library_before);
+    assert_eq!(fs::read_dir(installed_root).unwrap().count(), 1);
+    assert_eq!(fs::read_dir(library_root).unwrap().count(), 1);
+    ws.cmd(&project).args(["skill", "check"]).assert().success();
+}
+
 // --- K*: skillsets ---
 
 #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -425,6 +425,28 @@ fn i11_init_refuses_unrelated_existing_tink_home_without_writes() {
     assert!(!project.join(".agents").exists());
 }
 
+#[test]
+fn i12_init_resumes_marker_only_partial_inventory() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    fs::create_dir_all(&ws.inventory).unwrap();
+    fs::write(
+        ws.inventory.join("layout.json"),
+        "{\n  \"kind\": \"tink-skill-inventory\"\n}\n",
+    )
+    .unwrap();
+
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    assert!(ws.inventory.join("skills").is_dir());
+    assert!(ws.inventory.join("catalog").join("by-project").is_dir());
+    assert!(ws.inventory.join("catalog").join("by-skillset").is_dir());
+    assert!(project.join(".agents").join("skills").is_dir());
+}
+
 // --- A*: local add ---
 
 #[test]
@@ -1876,6 +1898,34 @@ fn h1_skill_list_library_includes_archived_names() {
 }
 
 #[test]
+fn h10_skill_list_library_refuses_nested_symlink() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.initialize_inventory();
+    let skill = ws.library_skill("unsafe-skill");
+    write_skill(
+        &skill,
+        "unsafe-skill",
+        "valid manifest with unsafe nested content",
+    );
+    let outside = ws.root.join("outside-library.txt");
+    fs::write(&outside, "outside stays unchanged\n").unwrap();
+    let link = skill.join("escape");
+    std::os::unix::fs::symlink(&outside, &link).unwrap();
+    let before = fs::read(&outside).unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "list", "--library"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("unsafe-skill").not())
+        .stderr(predicate::str::contains("symlink"));
+
+    assert!(link.is_symlink());
+    assert_eq!(fs::read(&outside).unwrap(), before);
+}
+
+#[test]
 fn h2_skill_add_library_installs_into_project() {
     let ws = Workspace::new();
     let donor = ws.project("donor");
@@ -2658,6 +2708,35 @@ fn d3_destroy_refuses_agents_symlink() {
     assert!(project.join(".agents").is_symlink());
 }
 
+#[test]
+fn d4_destroy_refuses_symlinked_catalog_without_external_or_project_writes() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+    let catalog = ws.inventory.join("catalog");
+    let external = ws.root.join("external-catalog-destroy");
+    fs::rename(&catalog, &external).unwrap();
+    std::os::unix::fs::symlink(&external, &catalog).unwrap();
+    let external_meta = external.join("by-project").join("app").join("meta.json");
+    let catalog_before = fs::read(&external_meta).unwrap();
+    let project_before =
+        fs::read(Workspace::skill_path(&project, "manage-tink").join("SKILL.md")).unwrap();
+
+    ws.cmd(&project)
+        .args(["destroy", "--yes"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("symlink"));
+
+    assert!(catalog.is_symlink());
+    assert_eq!(fs::read(&external_meta).unwrap(), catalog_before);
+    assert_eq!(
+        fs::read(Workspace::skill_path(&project, "manage-tink").join("SKILL.md")).unwrap(),
+        project_before
+    );
+    assert!(project.join(".agents").is_dir());
+}
+
 // --- X*: skill remove ---
 
 #[test]
@@ -2892,6 +2971,45 @@ fn x6_remove_fails_when_catalog_meta_is_malformed() {
     assert!(ws.library_skill("demo-skill").join("SKILL.md").is_file());
 }
 
+#[test]
+fn x7_remove_refuses_symlinked_catalog_without_external_or_project_writes() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    let source = ws.root.join("demo-skill");
+    write_skill(&source, "demo-skill", "body");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let catalog = ws.inventory.join("catalog");
+    let external = ws.root.join("external-catalog-remove");
+    fs::rename(&catalog, &external).unwrap();
+    std::os::unix::fs::symlink(&external, &catalog).unwrap();
+    let external_meta = external.join("by-project").join("app").join("meta.json");
+    let catalog_before = fs::read(&external_meta).unwrap();
+    let project_skill = Workspace::skill_path(&project, "demo-skill");
+    let project_before = fs::read(project_skill.join("SKILL.md")).unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "remove", "demo-skill"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("symlink"));
+
+    assert!(catalog.is_symlink());
+    assert_eq!(fs::read(&external_meta).unwrap(), catalog_before);
+    assert_eq!(
+        fs::read(project_skill.join("SKILL.md")).unwrap(),
+        project_before
+    );
+    assert!(ws.library_skill("demo-skill").join("SKILL.md").is_file());
+}
+
 // --- S*: safety ---
 
 #[test]
@@ -2901,6 +3019,48 @@ fn s1_init_does_not_create_git_repo() {
     assert!(!project.join(".git").exists());
     ws.cmd(&project).arg("init").assert().success();
     assert!(!project.join(".git").exists());
+}
+
+#[test]
+fn s3_remove_and_destroy_complete_when_implicit_home_cannot_resolve() {
+    let ws = Workspace::new();
+    let remove_project = ws.project("remove-app");
+    ws.cmd(&remove_project).arg("init").assert().success();
+    let remove_catalog_before = fs::read(ws.catalog_meta("remove-app")).unwrap();
+
+    Command::cargo_bin("tink")
+        .unwrap()
+        .current_dir(&remove_project)
+        .env_remove("TINK_HOME")
+        .env_remove("HOME")
+        .args(["skill", "remove", "manage-tink"])
+        .assert()
+        .success();
+    assert!(!Workspace::skill_path(&remove_project, "manage-tink").exists());
+    assert_eq!(
+        fs::read(ws.catalog_meta("remove-app")).unwrap(),
+        remove_catalog_before
+    );
+    assert!(!remove_project.join(".tink").exists());
+
+    let destroy_project = ws.project("destroy-app");
+    ws.cmd(&destroy_project).arg("init").assert().success();
+    let destroy_catalog_before = fs::read(ws.catalog_meta("destroy-app")).unwrap();
+
+    Command::cargo_bin("tink")
+        .unwrap()
+        .current_dir(&destroy_project)
+        .env_remove("TINK_HOME")
+        .env_remove("HOME")
+        .args(["destroy", "--yes"])
+        .assert()
+        .success();
+    assert!(!destroy_project.join(".agents").exists());
+    assert_eq!(
+        fs::read(ws.catalog_meta("destroy-app")).unwrap(),
+        destroy_catalog_before
+    );
+    assert!(!destroy_project.join(".tink").exists());
 }
 
 // --- U*: tink update ---

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -1694,6 +1694,7 @@ fn l3_skill_list_catalog_prints_tsv() {
 fn l6_skill_list_catalog_skips_malformed_meta_entries() {
     let ws = Workspace::new();
     let project = ws.project("app");
+    ws.initialize_inventory();
 
     let by_project = ws.inventory.join("catalog").join("by-project");
     let good = by_project.join("good-project");
@@ -1771,6 +1772,84 @@ fn l4_skill_list_warns_on_zen_without_agents_still_lists() {
         .stderr(predicate::str::contains(
             "ZEN.md is not referenced by a regular AGENTS.md",
         ));
+}
+
+#[test]
+fn l7_skill_list_and_check_reject_nested_symlink_drift() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    let source = ws.root.join("demo-skill");
+    write_skill(&source, "demo-skill", "safe before local drift");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let outside = ws.root.join("outside.txt");
+    fs::write(&outside, "outside\n").unwrap();
+    let link = Workspace::skill_path(&project, "demo-skill").join("escape");
+    std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+    for command in [["skill", "list"], ["skill", "check"]] {
+        ws.cmd(&project)
+            .args(command)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("symlink"));
+    }
+    assert!(link.is_symlink());
+    assert_eq!(fs::read_to_string(&outside).unwrap(), "outside\n");
+}
+
+#[test]
+fn l8_skill_list_refuses_unmarked_existing_home_without_writes() {
+    let root = TempDir::new().unwrap();
+    let project = root.path().join("project");
+    let home = root.path().join("unrelated-home");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&home).unwrap();
+    let readme = home.join("README.md");
+    fs::write(&readme, "# Important unrelated directory\n").unwrap();
+    let before = fs::read(&readme).unwrap();
+
+    for mode in ["--library", "--catalog"] {
+        Command::cargo_bin("tink")
+            .unwrap()
+            .current_dir(&project)
+            .env("TINK_HOME", &home)
+            .args(["skill", "list", mode])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Tink home"));
+    }
+
+    assert_eq!(fs::read(&readme).unwrap(), before);
+    assert_eq!(fs::read_dir(&home).unwrap().count(), 1);
+}
+
+#[test]
+fn l9_skill_list_refuses_symlinked_home_owner_directories() {
+    for (owner, mode) in [("skills", "--library"), ("catalog", "--catalog")] {
+        let ws = Workspace::new();
+        let project = ws.project("app");
+        ws.initialize_inventory();
+        let owned = ws.inventory.join(owner);
+        let outside = ws.root.join(format!("outside-{owner}"));
+        fs::rename(&owned, &outside).unwrap();
+        std::os::unix::fs::symlink(&outside, &owned).unwrap();
+
+        ws.cmd(&project)
+            .args(["skill", "list", mode])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("symlink"));
+        assert!(owned.is_symlink());
+        assert!(outside.is_dir());
+    }
 }
 
 // --- H*: library ---
@@ -2106,6 +2185,7 @@ fn h9_completion_offers_current_library_matches_without_creating_home() {
         .success()
         .stdout(predicate::str::contains("--skill"));
 
+    ws.initialize_inventory();
     write_skill(
         ws.library_skill("demo-skill").as_path(),
         "demo-skill",

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -39,6 +39,15 @@ impl Workspace {
         cmd
     }
 
+    fn initialize_inventory(&self) {
+        let bootstrap = self.root.join("inventory-bootstrap");
+        fs::create_dir_all(&bootstrap).expect("inventory bootstrap project");
+        self.cmd(&bootstrap)
+            .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+            .assert()
+            .success();
+    }
+
     fn skill_path(project: &Path, name: &str) -> PathBuf {
         project.join(".agents").join("skills").join(name)
     }
@@ -393,6 +402,29 @@ fn i10_init_bundle_failure_is_resumable() {
     );
 }
 
+#[test]
+fn i11_init_refuses_unrelated_existing_tink_home_without_writes() {
+    let root = TempDir::new().unwrap();
+    let project = root.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let readme = project.join("README.md");
+    fs::write(&readme, "# Important project\n\nKeep this content.\n").unwrap();
+    let before = fs::read(&readme).unwrap();
+
+    Command::cargo_bin("tink")
+        .unwrap()
+        .current_dir(&project)
+        .env("TINK_HOME", ".")
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Tink home").and(predicate::str::contains("non-empty")));
+
+    assert_eq!(fs::read(&readme).unwrap(), before);
+    assert_eq!(fs::read_dir(&project).unwrap().count(), 1);
+    assert!(!project.join(".agents").exists());
+}
+
 // --- A*: local add ---
 
 #[test]
@@ -687,6 +719,102 @@ fn a9_add_catalog_failure_is_resumable() {
     ws.cmd(&project).args(["skill", "check"]).assert().success();
 }
 
+#[test]
+fn a10_add_refuses_symlinked_skill_roots() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let outside = ws.root.join("outside");
+    write_skill(&outside, "linked-skill", "Outside the declared tree.");
+    let bundle = ws.root.join("bundle");
+    fs::create_dir_all(bundle.join("skills")).unwrap();
+    std::os::unix::fs::symlink(&outside, bundle.join("skills").join("linked-skill")).unwrap();
+
+    ws.cmd(&project)
+        .args([
+            "skill",
+            "add",
+            bundle.to_str().unwrap(),
+            "--skill",
+            "linked-skill",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("symlink"));
+    assert!(!Workspace::skill_path(&project, "linked-skill").exists());
+    assert!(!ws.library_skill("linked-skill").exists());
+
+    let direct = ws.root.join("direct-skill");
+    write_skill(&direct, "direct-skill", "Direct source target.");
+    let direct_link = ws.root.join("direct-link");
+    std::os::unix::fs::symlink(&direct, &direct_link).unwrap();
+    ws.cmd(&project)
+        .args(["skill", "add", direct_link.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("symlink"));
+    assert!(!Workspace::skill_path(&project, "direct-skill").exists());
+    assert!(!ws.library_skill("direct-skill").exists());
+    assert!(!ws.catalog_meta("app").exists());
+}
+
+#[test]
+fn a11_add_refuses_matching_project_target_symlink() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let source = ws.root.join("source");
+    let external = ws.root.join("external");
+    write_skill(&source, "demo-skill", "Same bytes.");
+    write_skill(&external, "demo-skill", "Same bytes.");
+    let target = Workspace::skill_path(&project, "demo-skill");
+    std::os::unix::fs::symlink(&external, &target).unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("symlink"));
+    assert!(target.is_symlink());
+    assert!(!ws.library_skill("demo-skill").exists());
+    assert!(!ws.catalog_meta("app").exists());
+}
+
+#[test]
+fn a12_add_refuses_unrelated_existing_tink_home() {
+    let root = TempDir::new().unwrap();
+    let project = root.path().join("project");
+    let source = root.path().join("source");
+    fs::create_dir_all(&project).unwrap();
+    write_skill(&source, "demo-skill", "Safe source.");
+    let readme = project.join("README.md");
+    fs::write(&readme, "# Important project\n\nKeep this content.\n").unwrap();
+    let before = fs::read(&readme).unwrap();
+
+    Command::cargo_bin("tink")
+        .unwrap()
+        .current_dir(&project)
+        .env("TINK_HOME", ".")
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Tink home").and(predicate::str::contains("non-empty")));
+
+    assert_eq!(fs::read(&readme).unwrap(), before);
+    assert!(!project.join(".agents").exists());
+    assert!(!project.join("layout.json").exists());
+    assert!(!project.join("catalog").exists());
+    assert!(!project.join("skills").exists());
+}
+
 // --- K*: skillsets ---
 
 #[test]
@@ -827,6 +955,7 @@ fn k4_skillset_commands_require_canonical_suffix() {
 fn k5_skillset_add_refuses_unowned_library_collision() {
     let ws = Workspace::new();
     let project = ws.project("app");
+    ws.initialize_inventory();
     let name = "common-skillset";
     write_skill(
         &ws.library_skill(name),
@@ -908,6 +1037,7 @@ fn k7_skillset_setup_failures_are_actionable_and_non_mutating() {
 fn k8_skillset_readd_is_offline_when_project_is_unchanged() {
     let ws = Workspace::new();
     let project = ws.project("app");
+    ws.initialize_inventory();
     let repository = ws.root.join("skillset-repo");
     init_repo(&repository);
     write_skill(&repository.join("bundles/common/alpha"), "alpha", "member");
@@ -949,6 +1079,7 @@ fn k8_skillset_readd_is_offline_when_project_is_unchanged() {
 fn k9_skill_status_reports_grouped_members_honestly() {
     let ws = Workspace::new();
     let project = ws.project("app");
+    ws.initialize_inventory();
     let repository = ws.root.join("skillset-repo");
     init_repo(&repository);
     write_skill(&repository.join("bundles/common/alpha"), "alpha", "first");
@@ -989,6 +1120,7 @@ fn k9_skill_status_reports_grouped_members_honestly() {
 fn k10_skillset_refresh_updates_clean_tree_and_refuses_local_edits() {
     let ws = Workspace::new();
     let project = ws.project("app");
+    ws.initialize_inventory();
     let repository = ws.root.join("skillset-repo");
     init_repo(&repository);
     let source = "https://github.com/example/skillsets.git";
@@ -1056,6 +1188,7 @@ fn k10_skillset_refresh_updates_clean_tree_and_refuses_local_edits() {
 fn k11_skillset_rejects_member_directory_name_mismatch() {
     let ws = Workspace::new();
     let project = ws.project("app");
+    ws.initialize_inventory();
     let repository = ws.root.join("skillset-repo");
     init_repo(&repository);
     write_skill(
@@ -1828,6 +1961,7 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
     let ws = Workspace::new();
     let home = ws.root.join("home");
     let project = ws.project("app");
+    ws.initialize_inventory();
     write_skill(
         &home.join(".agents").join("skills").join("demo-skill"),
         "demo-skill",
@@ -1860,6 +1994,7 @@ fn h7_skill_harvest_divergent_skips_without_repair() {
 fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
     let ws = Workspace::new();
     let home = ws.root.join("home");
+    ws.initialize_inventory();
     // Project lives under TINK_HOME but outside skills/ — must still harvest.
     let project = ws.inventory.join("workspace");
     fs::create_dir_all(&project).unwrap();

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -293,6 +293,106 @@ fn i8_relative_tink_home_resolves_absolute_not_nested() {
     );
 }
 
+#[test]
+fn i9_init_rerun_is_idempotent() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let args = ["init", "--no-zen", "--no-tink-skills"];
+
+    ws.cmd(&project).args(args).assert().success();
+
+    let contract_files = [
+        project.join(".agents").join("skills").join("README.md"),
+        Workspace::skill_path(&project, "manage-tink").join("SKILL.md"),
+        ws.catalog_meta("app"),
+        ws.library_skill("manage-tink").join("SKILL.md"),
+        ws.inventory.join("layout.json"),
+    ];
+    let before: Vec<Vec<u8>> = contract_files
+        .iter()
+        .map(|path| fs::read(path).unwrap_or_else(|_| panic!("missing {}", path.display())))
+        .collect();
+
+    ws.cmd(&project).args(args).assert().success().stdout(
+        predicate::str::contains("Ready")
+            .and(predicate::str::contains("Already present manage-tink")),
+    );
+
+    let after: Vec<Vec<u8>> = contract_files
+        .iter()
+        .map(|path| fs::read(path).unwrap_or_else(|_| panic!("missing {}", path.display())))
+        .collect();
+    assert_eq!(after, before, "re-running init changed contract files");
+}
+
+#[test]
+fn i10_init_bundle_failure_is_resumable() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let remote = ws.root.join("tink-skills");
+    init_repo(&remote);
+    write_skill(
+        &remote.join("skills").join("skill-scout"),
+        "skill-scout",
+        "Scout for skills.",
+    );
+    commit_all(&remote, "add skill-scout");
+
+    let redirect = github_redirect(&remote, "https://github.com/jon-devlapaz/tink-skills.git");
+    let args = ["init", "--no-zen", "--with-tink-skills"];
+
+    let mut first = ws.cmd(&project);
+    first.args(args);
+    for (key, value) in &redirect {
+        first.env(key, value);
+    }
+    first
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("skill-eval-loop"));
+
+    ws.assert_cataloged("app", "manage-tink");
+    ws.assert_cataloged("app", "skill-scout");
+    assert!(!Workspace::skill_path(&project, "skill-eval-loop").exists());
+    assert!(!ws.library_skill("skill-eval-loop").exists());
+    ws.cmd(&project).args(["skill", "check"]).assert().success();
+    let manage_before =
+        fs::read(Workspace::skill_path(&project, "manage-tink").join("SKILL.md")).unwrap();
+    let scout_before =
+        fs::read(Workspace::skill_path(&project, "skill-scout").join("SKILL.md")).unwrap();
+
+    write_skill(
+        &remote.join("skills").join("skill-eval-loop"),
+        "skill-eval-loop",
+        "Evaluate skills.",
+    );
+    commit_all(&remote, "add skill-eval-loop");
+
+    let mut second = ws.cmd(&project);
+    second.args(args);
+    for (key, value) in &redirect {
+        second.env(key, value);
+    }
+    second
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Added skill-eval-loop"));
+
+    ws.assert_cataloged("app", "manage-tink");
+    ws.assert_cataloged("app", "skill-scout");
+    ws.assert_cataloged("app", "skill-eval-loop");
+    assert_eq!(
+        fs::read(Workspace::skill_path(&project, "manage-tink").join("SKILL.md")).unwrap(),
+        manage_before,
+        "resuming init changed manage-tink"
+    );
+    assert_eq!(
+        fs::read(Workspace::skill_path(&project, "skill-scout").join("SKILL.md")).unwrap(),
+        scout_before,
+        "resuming init changed skill-scout"
+    );
+}
+
 // --- A*: local add ---
 
 #[test]


### PR DESCRIPTION
## Summary

- make repeated and partially failed `tink init` runs converge safely
- make `skill add` resume after catalog failures without overwriting divergent project state
- require marked, owned Tink inventory roots before reading or mutating library and catalog data
- reject symlinks and special files throughout installed and library skill trees
- publish the inventory ownership marker before creating child owners so interrupted initialization can resume
- make `skill remove` and `destroy` refuse unsafe catalog boundaries without touching project or external state

## Root cause

Inventory ownership and tree-safety checks were inconsistent across init, add, list, check, remove, and destroy. Some read and destructive paths validated only the home root, while other paths read full file contents merely to validate structure. Initialization also created child directories before publishing its ownership marker, leaving an unrecoverable partial state after interruption.

## Impact

The lifecycle now fails closed at unsafe filesystem boundaries, preserves external and project state on refusal, and resumes from expected partial states. Missing or unresolvable implicit homes still allow local remove/destroy cleanup without creating inventory state.

## Verification

- `cargo test --all-targets --all-features` — 58 unit tests and 107 acceptance tests passed
- `cargo check --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent review of the full slice plus cross-review of the fixes

## Out of scope

Projects with the same final directory basename still share the legacy basename-keyed catalog slot. That persisted-identity change is intentionally deferred to a separate slice.