### PR TITLE
Support nested remote skill selection

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -24,7 +24,7 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | Command | Meaning |
 |---|---|
 | `tink init` | Create `.agents/skills/`; install `manage-tink` by default; optional ZEN + tink-skills; ensure `~/.tink` |
-| `tink skill add <source> [--skill <name>]` | Install one local path, public GitHub skill, or library skill by name |
+| `tink skill add <source> [--skill <name-or-path>]` | Install one local path, public GitHub skill, or library skill by name; remote selectors may be unique names or repository-relative paths |
 | `tink skill list` | List project skills under `.agents/skills/` (read-only) |
 | `tink skill list --catalog` | List offline by-project catalog (`project`, `root`, `skill` TSV) |
 | `tink skill list --library` | List skill names in the library (`skills/<name>/` with `SKILL.md`) |
@@ -83,6 +83,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | A10 | `skill add` from a direct symlink or a symlinked child under `skills/` | Exit ≠ 0; mentions symlink; creates no project, library, or catalog entry for that skill |
 | A11 | `skill add` when the matching project target is a symlink | Exit ≠ 0; leaves the symlink untouched; creates no library or catalog entry |
 | A12 | `skill add` with `TINK_HOME` pointed at an unrelated non-empty directory | Exit ≠ 0; refuses to claim the directory and leaves its existing files byte-identical |
+| A13 | `skill add owner/repo` when one non-root remote skill at the same tip is already in the library | Exit 0 without cloning; installs from library and reports that source |
 
 ### Remote add
 
@@ -93,6 +94,12 @@ Ids are stable. Tests must name or comment the id they prove.
 | R3 | `skill add ./missing-skill` (path-like, absent) | Exit ≠ 0; "Path does not exist"; **no** GitHub network fetch |
 | R4 | `skill add /abs/missing` | Exit ≠ 0; "Path does not exist" |
 | R5 | `skill add owner/repo` when `SKILL.md` is at repo root | Receipt `path` is `"."` (non-empty); `skill check` passes; `skill refresh` updates from repo root |
+| R6 | `skill add owner/repo --skill <unique-name>` when the skill is nested below a nonstandard wrapper | Installs the unique recursive match; receipt records its exact repository-relative path; catalog, library, and `skill check` are valid |
+| R7 | `skill add owner/repo --skill <duplicate-name>` with multiple recursive matches | Exit ≠ 0 before project/library/catalog writes; lists every matching repository-relative path |
+| R8 | `skill add owner/repo --skill <repository-relative-path>` | Installs exactly that nested skill; receipt preserves the path and `skill refresh` follows it on the remote default branch |
+| R9 | A matching library copy exists for one of several same-name remote skills | Name-only add still checks the repository and refuses ambiguity; the cache cannot choose a path implicitly |
+| R10 | A canonical nested skill and a directory/name-mismatched `SKILL.md` declare the same name | Name selection ignores the malformed candidate and installs the one valid tree; inspection may still diagnose both |
+| R11 | Root and nested skills share a name, then `--skill .` selects the listed root path | Installs the root skill and records receipt path `"."` |
 
 ### Skillsets
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ skill trees; catalog holds by-project **names** only.
 tink skill add ../my-skill
 tink skill add skill-name
 tink skill add owner/repository --skill skill-name
+tink skill add owner/repository --skill packages/group/skills/skill-name
 tink skill add jon-devlapaz/tink-skills --skill skill-eval-loop
 tink skillset add common-skillset
 tink skillset list
@@ -139,7 +140,11 @@ tink skill remove skill-name
 ```
 
 - Bare `skill-name` promotes from the library (`tink skill list --library`).
-- `--skill` when the source repo publishes several skills.
+- `--skill` recursively selects a unique skill name from a remote repository.
+  If that name occurs more than once, use the repository-relative path reported
+  by the error or by `tink inspect`.
+- GitHub tree URLs are inspection inputs, not `skill add` sources. Remote adds
+  follow the repository's default branch and record the selected skill path.
 - Refresh only clean GitHub imports; local edits are refused.
 - tink does not overwrite a project skill that differs from what it would
   install.

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -11,7 +11,7 @@ form for add, list, check, refresh, and remove.
 | Init + both | `tink init --with-zen --with-tink-skills` |
 | Init without embedded manage-tink | add `--no-manage-tink` |
 | Add one skill | `tink skill add SOURCE` |
-| Add from multi-skill repo | `tink skill add SOURCE --skill NAME` |
+| Add from multi-skill repo | `tink skill add SOURCE --skill NAME_OR_REPOSITORY_PATH` |
 | Add from library | `tink skill add NAME` |
 | Harvest harness skills into library | `tink skill harvest` |
 | Inspect a public GitHub repository or tree | `tink inspect GITHUB_URL` |

--- a/src/add.rs
+++ b/src/add.rs
@@ -100,6 +100,67 @@ fn select_one_skill(
     Ok(candidates.remove(0))
 }
 
+fn repository_relative_path(repository: &Path, skill: &Skill) -> Result<String, Error> {
+    let relative = skill
+        .path
+        .strip_prefix(repository)
+        .map_err(|_| {
+            Error::msg(format!(
+                "skill path {} is outside source {}",
+                skill.path.display(),
+                repository.display()
+            ))
+        })?
+        .to_string_lossy()
+        .replace('\\', "/");
+    Ok(if relative.is_empty() {
+        ".".to_string()
+    } else {
+        relative
+    })
+}
+
+fn select_remote_skill_path(
+    source_root: &Path,
+    source_display: &str,
+    selector: &str,
+) -> Result<String, Error> {
+    let discovery = skills::discover_recursive(source_root)?;
+    let mut candidates = discovery
+        .skills
+        .into_iter()
+        .map(|skill| {
+            let path = repository_relative_path(source_root, &skill)?;
+            Ok((skill, path))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    if selector == "." || selector.contains('/') {
+        candidates.retain(|(_, path)| path == selector);
+    } else {
+        candidates.retain(|(skill, path)| {
+            skill.name == selector
+                && (path == "."
+                    || skill.path.file_name().and_then(|name| name.to_str())
+                        == Some(skill.name.as_str()))
+        });
+    }
+    if candidates.is_empty() {
+        return Err(Error::msg(format!("Skill not found: {selector}")));
+    }
+    if candidates.len() != 1 {
+        let commands = candidates
+            .iter()
+            .map(|(_, path)| format!("  tink skill add {source_display} --skill {path}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(Error::msg(format!(
+            "Skill selector {selector:?} matches multiple skills. Choose one by repository path:\n{commands}"
+        )));
+    }
+    Ok(candidates.remove(0).1)
+}
+
 fn install_from_checkout(
     project_root: &Path,
     source_root: &Path,
@@ -108,24 +169,24 @@ fn install_from_checkout(
     selected_name: Option<&str>,
     source_url: Option<&str>,
     revision: Option<&str>,
-    locked_path: Option<&str>,
+    source_path: Option<&str>,
 ) -> Result<AddOutcome, Error> {
     let source_root = source_root
         .canonicalize()
         .map_err(|e| crate::paths::map_io(source_root, e))?;
-    let skill = if let Some(locked_path) = locked_path {
-        if locked_path.is_empty()
-            || locked_path.contains("..")
-            || locked_path.contains('\\')
-            || locked_path.starts_with('/')
+    let skill = if let Some(source_path) = source_path {
+        if source_path.is_empty()
+            || source_path.contains("..")
+            || source_path.contains('\\')
+            || source_path.starts_with('/')
         {
             return Err(Error::msg(format!(
-                "Invalid locked skill path: {locked_path}"
+                "Invalid locked skill path: {source_path}"
             )));
         }
-        let path = source_root.join(locked_path);
-        let skill = skills::read_skill(&path, true)?;
-        if selected_name != Some(skill.name.as_str()) {
+        let path = source_root.join(source_path);
+        let skill = skills::read_skill(&path, source_path != ".")?;
+        if selected_name != Some(skill.name.as_str()) && selected_name != Some(source_path) {
             return Err(Error::msg(format!(
                 "Locked skill path does not contain {selected_name:?}"
             )));
@@ -326,12 +387,18 @@ fn add_from_remote(
     remote: &RemoteSource,
     selected_name: Option<&str>,
 ) -> Result<AddOutcome, Error> {
-    // Cheap tip check: if library already has this exact remote revision, copy it.
-    let tip = git::remote_head(remote)?;
-    if let Some(cached) = library::for_remote_tip(&remote.url, &tip, selected_name)? {
-        return place_from_library(project_root, &cached, destination_root);
+    // A selected name may be ambiguous in the repository, so discovery must run
+    // before the library can be trusted. Preserve the root-skill no-clone path.
+    if selected_name.is_none() {
+        let tip = git::remote_head(remote)?;
+        if let Some(cached) = library::for_remote_tip(&remote.url, &tip, None)? {
+            return place_from_library(project_root, &cached, destination_root);
+        }
     }
     let (_temp, source_root, revision) = git::checkout(remote)?;
+    let selected_path = selected_name
+        .map(|selector| select_remote_skill_path(&source_root, &remote.display, selector))
+        .transpose()?;
     install_from_checkout(
         project_root,
         &source_root,
@@ -340,6 +407,6 @@ fn add_from_remote(
         selected_name,
         Some(&remote.url),
         Some(&revision),
-        None,
+        selected_path.as_deref(),
     )
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -61,7 +61,36 @@ pub fn inspect(url: &str) -> Result<InspectionReport, Error> {
 
     let mut diagnostics = Vec::new();
     let mut discovered = Vec::new();
-    discover_skills(&checkout, &boundary, &mut discovered, &mut diagnostics)?;
+    let scan = skills::discover_recursive(&boundary)?;
+    for invalid in scan.invalid {
+        let relative_directory = relative_posix(&checkout, &invalid.path);
+        let skill_file = invalid.path.join("SKILL.md");
+        let relative_skill_file = format!("{relative_directory}/SKILL.md");
+        let detail = invalid
+            .detail
+            .replace(skill_file.to_string_lossy().as_ref(), &relative_skill_file);
+        diagnostics.push(format!(
+            "invalid SKILL.md at {relative_directory}: {detail}"
+        ));
+    }
+    for skill in scan.skills {
+        let path = relative_posix(&checkout, &skill.path);
+        let directory_name = skill
+            .path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("");
+        if skill.name != directory_name {
+            diagnostics.push(format!(
+                "skill name {} does not match directory {directory_name} at {path}",
+                skill.name
+            ));
+        }
+        discovered.push(DiscoveredSkill {
+            name: skill.name,
+            path,
+        });
+    }
     discovered.sort_by(|left, right| left.path.cmp(&right.path));
     diagnostics.extend(duplicate_diagnostics(&discovered));
     diagnostics.extend(overlap_diagnostics(&discovered));
@@ -204,86 +233,6 @@ fn valid_part(part: &str) -> bool {
         && part
             .chars()
             .all(|character| character.is_ascii_alphanumeric() || "_.-".contains(character))
-}
-
-fn discover_skills(
-    checkout: &Path,
-    directory: &Path,
-    discovered: &mut Vec<DiscoveredSkill>,
-    diagnostics: &mut Vec<String>,
-) -> Result<(), Error> {
-    let skill_file = directory.join("SKILL.md");
-    match fs::symlink_metadata(&skill_file) {
-        Ok(metadata) if metadata.file_type().is_symlink() => {}
-        Ok(metadata) if metadata.is_file() => match skills::read_skill(directory, false) {
-            Ok(skill) => discovered.push(DiscoveredSkill {
-                name: skill.name.clone(),
-                path: relative_posix(checkout, directory),
-            }),
-            Err(error) => {
-                let relative_directory = relative_posix(checkout, directory);
-                let relative_skill_file = format!("{relative_directory}/SKILL.md");
-                let detail = error
-                    .to_string()
-                    .replace(skill_file.to_string_lossy().as_ref(), &relative_skill_file);
-                diagnostics.push(format!(
-                    "invalid SKILL.md at {relative_directory}: {detail}"
-                ));
-            }
-        },
-        _ => {}
-    }
-
-    if let Some(name) = discovered
-        .last()
-        .filter(|skill| skill.path == relative_posix(checkout, directory))
-        .map(|skill| skill.name.as_str())
-    {
-        let directory_name = directory
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or("");
-        if name != directory_name {
-            diagnostics.push(format!(
-                "skill name {name} does not match directory {directory_name} at {}",
-                relative_posix(checkout, directory)
-            ));
-        }
-    }
-
-    let mut children = Vec::new();
-    for entry in fs::read_dir(directory).map_err(|error| {
-        Error::msg(format!(
-            "Could not read inspection boundary {}: {error}",
-            directory.display()
-        ))
-    })? {
-        let entry = entry.map_err(|error| {
-            Error::msg(format!(
-                "Could not inspect source {}: {error}",
-                directory.display()
-            ))
-        })?;
-        let path = entry.path();
-        if path.file_name().and_then(|name| name.to_str()) == Some(".git") {
-            continue;
-        }
-        let metadata = fs::symlink_metadata(&path).map_err(|error| {
-            Error::msg(format!(
-                "Could not inspect source {}: {error}",
-                path.display()
-            ))
-        })?;
-        if metadata.file_type().is_symlink() || !metadata.is_dir() {
-            continue;
-        }
-        children.push(path);
-    }
-    children.sort();
-    for child in children {
-        discover_skills(checkout, &child, discovered, diagnostics)?;
-    }
-    Ok(())
 }
 
 fn relative_posix(root: &Path, path: &Path) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub enum SkillCommand {
         /// Local path, `owner/repo`, public GitHub HTTPS URL, or library skill name
         #[arg(add = ArgValueCompleter::new(add_source_candidates))]
         source: String,
-        /// Skill name when the source contains several skills
+        /// Unique skill name or repository-relative skill path
         #[arg(long)]
         skill: Option<String>,
     },

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -170,6 +170,66 @@ pub fn discover(source: &Path) -> Result<Vec<Skill>, Error> {
     Ok(skills)
 }
 
+#[derive(Debug)]
+pub struct InvalidSkill {
+    pub path: PathBuf,
+    pub detail: String,
+}
+
+#[derive(Debug)]
+pub struct RecursiveDiscovery {
+    pub skills: Vec<Skill>,
+    pub invalid: Vec<InvalidSkill>,
+}
+
+/// Find every valid skill below `source` without following symlink directories.
+pub fn discover_recursive(source: &Path) -> Result<RecursiveDiscovery, Error> {
+    let source = source.canonicalize().map_err(|e| map_io(source, e))?;
+    let mut discovery = RecursiveDiscovery {
+        skills: Vec::new(),
+        invalid: Vec::new(),
+    };
+
+    fn walk(directory: &Path, discovery: &mut RecursiveDiscovery) -> Result<(), Error> {
+        let skill_file = directory.join("SKILL.md");
+        match fs::symlink_metadata(&skill_file) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {}
+            Ok(metadata) if metadata.is_file() => match read_skill(directory, false) {
+                Ok(skill) => discovery.skills.push(skill),
+                Err(error) => discovery.invalid.push(InvalidSkill {
+                    path: directory.to_path_buf(),
+                    detail: error.to_string(),
+                }),
+            },
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(map_io(&skill_file, error)),
+        }
+
+        let mut children = Vec::new();
+        for entry in fs::read_dir(directory).map_err(|error| map_io(directory, error))? {
+            let entry = entry.map_err(|error| map_io(directory, error))?;
+            let path = entry.path();
+            if path.file_name().and_then(|name| name.to_str()) == Some(".git") {
+                continue;
+            }
+            let metadata = fs::symlink_metadata(&path).map_err(|error| map_io(&path, error))?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                continue;
+            }
+            children.push(path);
+        }
+        children.sort();
+        for child in children {
+            walk(&child, discovery)?;
+        }
+        Ok(())
+    }
+
+    walk(&source, &mut discovery)?;
+    Ok(discovery)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum EntryKind {
     Dir,

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -681,6 +681,62 @@ fn a8_add_uses_library_when_remote_tip_matches() {
 }
 
 #[test]
+fn a13_add_uses_library_for_non_root_skill_without_cloning() {
+    let ws = Workspace::new();
+    let first_project = ws.project("first");
+    let second_project = ws.project("second");
+    for project in [&first_project, &second_project] {
+        ws.cmd(project)
+            .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+            .assert()
+            .success();
+    }
+
+    let remote = ws.root.join("non-root-cache-repo");
+    init_repo(&remote);
+    write_skill(
+        &remote.join("skills/non-root-skill"),
+        "non-root-skill",
+        "cached non-root skill",
+    );
+    commit_all(&remote, "non-root skill");
+    let public = "https://github.com/example/non-root-cache.git";
+    let redirect = github_redirect(&remote, public);
+
+    let mut first_add = ws.cmd(&first_project);
+    first_add.args(["skill", "add", "example/non-root-cache"]);
+    first_add.envs(redirect.clone());
+    first_add.assert().success();
+
+    let tree_output = StdCommand::new("git")
+        .args(["rev-parse", "HEAD^{tree}"])
+        .current_dir(&remote)
+        .output()
+        .unwrap();
+    assert!(tree_output.status.success());
+    let tree = String::from_utf8(tree_output.stdout).unwrap();
+    let tree = tree.trim();
+    let tree_object = remote
+        .join(".git/objects")
+        .join(&tree[..2])
+        .join(&tree[2..]);
+    assert!(tree_object.is_file(), "missing loose tree object {tree}");
+    fs::remove_file(tree_object).unwrap();
+    let mut second_add = ws.cmd(&second_project);
+    second_add.args(["skill", "add", "example/non-root-cache"]);
+    second_add.envs(redirect);
+    second_add
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("from library"));
+    assert!(
+        Workspace::skill_path(&second_project, "non-root-skill")
+            .join("SKILL.md")
+            .is_file()
+    );
+}
+
+#[test]
 fn a9_add_catalog_failure_is_resumable() {
     let ws = Workspace::new();
     let project = ws.project("app");
@@ -1384,6 +1440,321 @@ fn r5_add_root_level_skill_writes_dot_path_check_and_refresh() {
             .unwrap();
     assert!(receipt.contains(&new_rev));
     assert!(receipt.contains("\"path\": \".\"") || receipt.contains("\"path\":\".\""));
+}
+
+#[test]
+fn r6_add_finds_unique_nested_remote_skill_by_name() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let remote = ws.root.join("nested-skills-repo");
+    init_repo(&remote);
+    write_skill(
+        &remote.join("packages/shared/skills/nested-skill"),
+        "nested-skill",
+        "selected nested skill",
+    );
+    write_skill(
+        &remote.join("packages/other/skills/unrelated-skill"),
+        "unrelated-skill",
+        "unrelated nested skill",
+    );
+    let revision = commit_all(&remote, "nested skills");
+    let public = "https://github.com/example/nested-skills.git";
+
+    let mut add = ws.cmd(&project);
+    add.args([
+        "skill",
+        "add",
+        "example/nested-skills",
+        "--skill",
+        "nested-skill",
+    ]);
+    add.envs(github_redirect(&remote, public));
+    add.assert().success();
+
+    let installed = Workspace::skill_path(&project, "nested-skill");
+    assert!(
+        fs::read_to_string(installed.join("SKILL.md"))
+            .unwrap()
+            .contains("selected nested skill")
+    );
+    let receipt: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(installed.join(".tink-source.json")).unwrap())
+            .unwrap();
+    assert_eq!(receipt["source"], public);
+    assert_eq!(receipt["revision"], revision);
+    assert_eq!(receipt["path"], "packages/shared/skills/nested-skill");
+    ws.assert_cataloged("app", "nested-skill");
+    ws.cmd(&project).args(["skill", "check"]).assert().success();
+}
+
+#[test]
+fn r7_add_refuses_ambiguous_nested_skill_name_without_writes() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let remote = ws.root.join("duplicate-skills-repo");
+    init_repo(&remote);
+    write_skill(
+        &remote.join("packages/one/skills/same-skill"),
+        "same-skill",
+        "first duplicate",
+    );
+    write_skill(
+        &remote.join("packages/two/skills/same-skill"),
+        "same-skill",
+        "second duplicate",
+    );
+    commit_all(&remote, "duplicate skills");
+    let public = "https://github.com/example/duplicate-skills.git";
+
+    let mut add = ws.cmd(&project);
+    add.args([
+        "skill",
+        "add",
+        "example/duplicate-skills",
+        "--skill",
+        "same-skill",
+    ]);
+    add.envs(github_redirect(&remote, public));
+    add.assert().failure().stderr(
+        predicate::str::contains("multiple skills")
+            .and(predicate::str::contains("packages/one/skills/same-skill"))
+            .and(predicate::str::contains("packages/two/skills/same-skill")),
+    );
+
+    assert!(!Workspace::skill_path(&project, "same-skill").exists());
+    assert!(!ws.library_skill("same-skill").exists());
+    let catalog = fs::read_to_string(ws.catalog_meta("app")).unwrap_or_default();
+    assert!(!catalog.contains("same-skill"), "{catalog}");
+}
+
+#[test]
+fn r8_add_selects_nested_remote_skill_by_repository_path_and_refreshes() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let remote = ws.root.join("path-selected-skills-repo");
+    init_repo(&remote);
+    let selected_path = "packages/shared-skills/skills/git-master";
+    write_skill(
+        &remote.join(selected_path),
+        "git-master",
+        "shared implementation v1",
+    );
+    write_skill(
+        &remote.join("packages/generated/skills/git-master"),
+        "git-master",
+        "generated duplicate",
+    );
+    let revision = commit_all(&remote, "duplicate git-master skills");
+    let public = "https://github.com/example/path-selected-skills.git";
+    let redirect = github_redirect(&remote, public);
+
+    let mut add = ws.cmd(&project);
+    add.args([
+        "skill",
+        "add",
+        "example/path-selected-skills",
+        "--skill",
+        selected_path,
+    ]);
+    add.envs(redirect.clone());
+    add.assert().success();
+
+    let installed = Workspace::skill_path(&project, "git-master");
+    let receipt: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(installed.join(".tink-source.json")).unwrap())
+            .unwrap();
+    assert_eq!(receipt["source"], public);
+    assert_eq!(receipt["revision"], revision);
+    assert_eq!(receipt["path"], selected_path);
+    assert!(
+        fs::read_to_string(installed.join("SKILL.md"))
+            .unwrap()
+            .contains("shared implementation v1")
+    );
+
+    write_skill(
+        &remote.join(selected_path),
+        "git-master",
+        "shared implementation v2",
+    );
+    commit_all(&remote, "update selected git-master");
+    let mut refresh = ws.cmd(&project);
+    refresh.args(["skill", "refresh", "git-master"]);
+    refresh.envs(redirect);
+    refresh.assert().success();
+    assert!(
+        fs::read_to_string(installed.join("SKILL.md"))
+            .unwrap()
+            .contains("shared implementation v2")
+    );
+}
+
+#[test]
+fn r9_cached_duplicate_does_not_bypass_remote_name_ambiguity() {
+    let ws = Workspace::new();
+    let first_project = ws.project("first");
+    let second_project = ws.project("second");
+    for project in [&first_project, &second_project] {
+        ws.cmd(project)
+            .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+            .assert()
+            .success();
+    }
+
+    let remote = ws.root.join("cached-duplicate-skills-repo");
+    init_repo(&remote);
+    let selected_path = "packages/shared/skills/same-skill";
+    write_skill(
+        &remote.join(selected_path),
+        "same-skill",
+        "cached duplicate",
+    );
+    write_skill(
+        &remote.join("packages/other/skills/same-skill"),
+        "same-skill",
+        "other duplicate",
+    );
+    commit_all(&remote, "cached duplicate skills");
+    let public = "https://github.com/example/cached-duplicate-skills.git";
+    let redirect = github_redirect(&remote, public);
+
+    let mut first_add = ws.cmd(&first_project);
+    first_add.args([
+        "skill",
+        "add",
+        "example/cached-duplicate-skills",
+        "--skill",
+        selected_path,
+    ]);
+    first_add.envs(redirect.clone());
+    first_add.assert().success();
+    assert!(ws.library_skill("same-skill").join("SKILL.md").is_file());
+
+    let mut second_add = ws.cmd(&second_project);
+    second_add.args([
+        "skill",
+        "add",
+        "example/cached-duplicate-skills",
+        "--skill",
+        "same-skill",
+    ]);
+    second_add.envs(redirect);
+    second_add.assert().failure().stderr(
+        predicate::str::contains("multiple skills")
+            .and(predicate::str::contains(selected_path))
+            .and(predicate::str::contains("packages/other/skills/same-skill")),
+    );
+    assert!(!Workspace::skill_path(&second_project, "same-skill").exists());
+}
+
+#[test]
+fn r10_mismatched_directory_name_does_not_create_false_name_ambiguity() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let remote = ws.root.join("mismatched-name-repo");
+    init_repo(&remote);
+    write_skill(
+        &remote.join("packages/valid/skills/target-skill"),
+        "target-skill",
+        "installable target",
+    );
+    write_skill(
+        &remote.join("packages/invalid/skills/wrong-directory"),
+        "target-skill",
+        "mismatched directory",
+    );
+    commit_all(&remote, "valid and mismatched targets");
+    let public = "https://github.com/example/mismatched-name.git";
+
+    let mut add = ws.cmd(&project);
+    add.args([
+        "skill",
+        "add",
+        "example/mismatched-name",
+        "--skill",
+        "target-skill",
+    ]);
+    add.envs(github_redirect(&remote, public));
+    add.assert().success();
+    assert!(
+        fs::read_to_string(Workspace::skill_path(&project, "target-skill").join("SKILL.md"))
+            .unwrap()
+            .contains("installable target")
+    );
+}
+
+#[test]
+fn r11_dot_path_selects_root_skill_when_name_is_ambiguous() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let remote = ws.root.join("root-duplicate-repo");
+    init_repo(&remote);
+    write_skill(&remote, "same-skill", "root implementation");
+    let nested_path = "packages/nested/skills/same-skill";
+    write_skill(
+        &remote.join(nested_path),
+        "same-skill",
+        "nested implementation",
+    );
+    commit_all(&remote, "root and nested duplicate");
+    let public = "https://github.com/example/root-duplicate.git";
+    let redirect = github_redirect(&remote, public);
+
+    let mut ambiguous = ws.cmd(&project);
+    ambiguous.args([
+        "skill",
+        "add",
+        "example/root-duplicate",
+        "--skill",
+        "same-skill",
+    ]);
+    ambiguous.envs(redirect.clone());
+    ambiguous
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--skill .").and(predicate::str::contains(nested_path)));
+
+    let mut add_root = ws.cmd(&project);
+    add_root.args(["skill", "add", "example/root-duplicate", "--skill", "."]);
+    add_root.envs(redirect);
+    add_root.assert().success();
+
+    let installed = Workspace::skill_path(&project, "same-skill");
+    assert!(
+        fs::read_to_string(installed.join("SKILL.md"))
+            .unwrap()
+            .contains("root implementation")
+    );
+    let receipt: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(installed.join(".tink-source.json")).unwrap())
+            .unwrap();
+    assert_eq!(receipt["path"], ".");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- recursively discover valid skills in remote repositories for `tink skill add --skill`
- reject ambiguous manifest names and report repository-relative candidate paths
- support exact path selectors, including `--skill .` for a root skill
- preserve the selected repository path in receipts so refresh follows the same skill
- share recursive discovery between `skill add` and `inspect` while preserving the no-selector library fast path

## Why

Remote inspection could identify nested skills, but remote add only handled the repository root or a shallow conventional path. Name selection could therefore fail for valid nested skills, and a cached library entry could bypass ambiguity in the current repository revision.

## User impact

Users can install deeply nested remote skills by unique manifest name or exact repository-relative path. Ambiguous names now fail safely with executable path-based alternatives, and subsequent refreshes retain the selected path.

## Verification

- `cargo test --all-targets --all-features` — 58 unit and 114 acceptance tests passed
- `cargo check --all-targets --all-features`
- `cargo fmt -- --check`
- `git diff --check origin/main...HEAD`
- public-repository smoke test covering ambiguous name refusal, exact nested-path installation, receipt provenance, and `skill check`