### PR TITLE
Harden skillset ownership and release verification

### DIFF
--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -26,6 +26,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Verify
+        run: |
+          cargo fmt --check
+          cargo test --locked
+
       - name: Bump patch, tag, and dispatch release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -11,8 +11,12 @@ from GitHub Releases via `tink update`.
 **Authority:** This file is the evaluator. Implementation stops when every row
 below has an automated test that passes on macOS with `git` on `PATH`.
 
+**Delivery gate:** The automatic `main`-push release path runs formatting and
+tests on Ubuntu before version, tag, push, or dispatch mutations. Direct tag
+pushes and manual release dispatches remain outside that behavior gate.
+
 **Out of v1:** weekly GitHub update workflows, private GitHub auth, Windows,
-Linux CI as a gate, pruning the library.
+branch-wide Linux CI beyond the automatic release gate, pruning the library.
 
 **Dogfood:** Prefer an installed `tink` from this repo, or `cargo run -q -- …`.
 
@@ -27,7 +31,7 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill add <source> [--skill <name-or-path>]` | Install one local path, public GitHub skill, or library skill by name; remote selectors may be unique names or repository-relative paths |
 | `tink skill list` | List project skills under `.agents/skills/` (read-only) |
 | `tink skill list --catalog` | List offline by-project catalog (`project`, `root`, `skill` TSV) |
-| `tink skill list --library` | List skill names in the library (`skills/<name>/` with `SKILL.md`) |
+| `tink skill list --library` | List standalone skill names in the library; receipt-backed skillset roots are excluded |
 | `tink skill harvest` | Copy complete skill trees from known harness roots into the library (create-only; no project writes) |
 | `tink skill check` | Validate project skills; no network; no writes |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
@@ -167,6 +171,9 @@ Ids are stable. Tests must name or comment the id they prove.
 | H8 | `skill harvest` skips library sources and unsafe (symlink-inside) skill trees; still harvests cwd skills under `TINK_HOME` outside `skills/` | Library/unsafe omitted; non-library path under home deposited |
 | H9 | Shell completion for `tink skill add <prefix>` | Offers matching names from the current library without creating the home or library |
 | H10 | `skill list --library` when a valid library skill contains a nested symlink | Exit ≠ 0; mentions the symlink; does not advertise the unsafe skill or alter either side of the link |
+| H11 | A library root contains both `SKILL.md` and `.tink-skillset.json` | `skill list --library` excludes it; `skill add <name>` exits nonzero and directs the user to `tink skillset add <name>` |
+| H12 | `skill add <source>` would deposit a standalone skill over a receipt-bearing library root with the same name | Exit nonzero before project publication; preserve every existing library file and identify the standalone/skillset collision |
+| H13 | `skill add <source>` exactly matches a receipt-bearing library root with the same name | Do not reuse the managed root as a standalone cache hit; exit nonzero, preserve the library bytes, and publish no project tree |
 
 ### CLI surface
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ tink skill refresh skill-name
 tink skill remove skill-name
 ```
 
-- Bare `skill-name` promotes from the library (`tink skill list --library`).
+- A bare standalone `skill-name` promotes from the library (`tink skill list --library`).
+  Receipt-backed roots remain skillsets and require `tink skillset ...` commands.
 - `--skill` recursively selects a unique skill name from a remote repository.
   If that name occurs more than once, use the repository-relative path reported
   by the error or by `tink inspect`.
@@ -169,7 +170,8 @@ drift is repaired only from a valid project tree.
 shared catalog definition and home library copy.
 `skillset list` groups each receipt-backed project skillset with its member
 skills. `skillset list --library` shows the same grouped view for the home
-library.
+library. Receipt ownership takes precedence over a root `SKILL.md`: standalone
+library list/add commands never expose, promote, or replace that skillset root.
 
 `tink inspect <GITHUB_URL>` performs a read-only inspection of a public GitHub
 repository, folder, or skill URL. It reports directories containing valid
@@ -196,8 +198,8 @@ tink update
 **Breaking in 0.3.0:** `skill list --home` → `--catalog`; `skill list --stash` → `--library`. On-disk layout is still `$TINK_HOME/skills/` and `catalog/by-project/`. After a major CLI upgrade, refresh the live project skill: `tink skill remove manage-tink && tink init --no-zen --no-tink-skills`.
 
 If the GitHub tip is already in the library and matches the tip byte-for-byte,
-`skill add` may install from the library. If the library differs, tink repairs it
-and warns. A bare skill name (not a path and not `owner/repo`) promotes from
+`skill add` may install from the library. If a standalone library skill differs,
+tink repairs it and warns. A bare standalone skill name (not a path and not `owner/repo`) promotes from
 the library into the project. `skill remove` deletes the project skill
 directory and drops that name from the by-project catalog; it does not delete
 library trees. `destroy` also drops this project's catalog entry.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,40 +1,132 @@
-# Architecture Notes (Interim)
+# Architecture
 
-## Intent of this run
-Keep the CLI behavior-safe while improving module boundaries so that high-risk command
-orchestration does not sit directly on raw infrastructure details.
+Tink is a local CLI that installs Agent Skills into a project's
+`.agents/skills/`. That project directory is the only live agent-discovery root.
+`$TINK_HOME` (default `~/.tink`) is offline inventory: it stores reusable skill
+trees, project-name indexes, and pinned skillset definitions.
 
-## Layer map (practical)
-- **Edge / orchestration (`src/lib.rs`, `src/main.rs`)**
-  Parses arguments and routes into skill commands.
-- **Application flow (`src/add.rs`, `src/remove.rs`, `src/check.rs`, `src/refresh.rs`, `src/update.rs`, `src/list.rs`, `src/harvest.rs`, `src/destroy.rs`)
-  Owns command-specific validation, sequencing, and side effects.
-- **Domain helpers (`src/skills.rs`, `src/catalog.rs`, `src/provenance.rs`, `src/home.rs`)
-  Encapsulate project/library policy and path/domain contracts.
-- **Infrastructure adapters (`src/git.rs`, `src/sources.rs`, `src/paths.rs`)
-  Perform external process and filesystem operations, exposing narrow result contracts.
+This document is the current navigation map. [`ACCEPTANCE.md`](../ACCEPTANCE.md)
+records intended CLI and on-disk behavior, the workflow files own delivery automation,
+[`TESTING.md`](TESTING.md) maps their executable sensors and known drift, and
+[`DEEP-REFACTOR-LOG.md`](DEEP-REFACTOR-LOG.md) preserves experiment history.
 
-## Notable boundary clarifications in this phase
-- **Catalog aggregate (Phase 8)**: `src/catalog.rs` now models by-project catalog data as
-  `CatalogMeta` (`name`, `root`, `skills`) and centralizes ownership checks + mutation for install/withdraw/forget.
+## State and authority
 
-- **Path layout ownership**: path rooting for project skill directories was moved to
-  `src/home.rs` (`project_agents_path`, `project_skills_path`) so callers do not build
-  `./.agents` fragments directly.
-- **Receipt naming ownership**: sidecar filename is now defined once as
-  `provenance::SIDECAR_FILE` and referenced by callers that interact with source
-  receipts.
-- **Git boundary extraction (Phase 5)**: `src/git.rs` now centralizes command invocation
-  and error shaping in internal helpers:
-  - `run_git` for command launch + process I/O preamble
-  - `git_detail` for stderr-last-line extraction
+| State | Owner | Authority and allowed direction |
+|---|---|---|
+| `<project>/.agents/skills/` | `home.rs`, `skills.rs`, `check.rs`, `skillsets.rs` | Sole live discovery root. Standalone project divergence blocks overwrite; skillsets use their validated nested lifecycle. |
+| `<project>/.tink/skills.toml` and `skills.lock` | `manifest.rs`, `sources.rs` | Project-owned standalone-skill intent and resolved pins for `lock`, `sync`, and `verify`. |
+| `$TINK_HOME/layout.json` and root directories | `home.rs` | Marks and migrates offline inventory; never an agent discovery root. |
+| `$TINK_HOME/skills/<name>/` | `library.rs`, `skillsets.rs` | Reusable standalone trees or derived skillset copies. A skillset receipt decides which lifecycle owns a root. |
+| `$TINK_HOME/catalog/by-project/<project>/meta.json` | `catalog.rs` | Derived project-name index. Add/refresh deposit names; remove/destroy withdraw them. It is not runtime state. |
+| `$TINK_HOME/catalog/by-skillset/<name>/meta.json` | `skillsets.rs` | Authored desired definition: HTTPS source, immutable revision, source root, and explicit members. Tink reads it but has no CLI writer for it. |
+| `.tink-source.json` | `provenance.rs` | Optional standalone remote provenance: source, revision, and path. It does not classify a root. |
+| `.tink-skillset.json` | `skillsets.rs` | Skillset ownership and digest evidence. Presence classifies; validated contents prove the installed tree. |
 
-  This keeps `remote_head`, `checkout`, and `checkout_revision` focused on intent while
-  preserving their existing error contracts and command semantics.
+Use the qualified terms **project-name index**, **skillset definition**, **source
+receipt**, and **skillset receipt**. Bare “catalog” and “receipt” hide different
+owners and should not carry architectural decisions.
 
-## Decision principle used
-Each module boundary change is additive and reversible:
-- extract one helper,
-- keep control flow and outputs unchanged,
-- verify with `cargo test -- --nocapture`,
-- then mark the phase complete.
+## Module ownership
+
+| Area | Modules | Responsibility |
+|---|---|---|
+| Process edge | `main.rs`, `lib.rs`, `style.rs`, `error.rs` | Completion and argument parsing, command dispatch, output narration, styling, and user-facing failure shape. |
+| Layout and persisted state | `home.rs`, `catalog.rs`, `manifest.rs`, `provenance.rs` | Project/home paths, project-name index, standalone manifest/lock, and source receipts. |
+| Skill mechanisms | `skills.rs`, `sources.rs`, `git.rs`, `paths.rs`, `library.rs` | Skill discovery/validation/copy/digest, typed source classification, Git checkout, filesystem refusals, and standalone library policy. |
+| Project workflows | `init.rs`, `add.rs`, `check.rs`, `refresh.rs`, `remove.rs`, `harvest.rs` | Bootstrap and the standalone skill lifecycle. |
+| Skillset workflow | `skillsets.rs` | Canonical names, definition validation, staged install/refresh, receipt validation, grouped listing, removal, and project-to-library mirroring. |
+| Read-only source inspection | `inspect.rs` | GitHub structure inspection and source-defined skillset inference; no project or home writes. |
+| Supporting workflows | `destroy.rs`, `update.rs`, `manage_tink.rs`, `templates.rs` | Project teardown, binary update, embedded `manage-tink`, and init templates/defaults. |
+
+`lib.rs` owns the public command vocabulary. There is no `skillset check` or
+`skillset status`: `skill check` validates both standalone and receipt-backed
+roots, while `skillset list` provides the grouped member view.
+
+## Cross-cutting invariants
+
+1. **Home is inventory, not runtime.** Skills become agent-visible only under the
+   current project's `.agents/skills/`.
+2. **Classification precedes trust.** `skillsets::has_receipt_entry` treats a
+   `.tink-skillset.json` entry—including a dangling symlink—as a claim on the root.
+   Parsing, member checks, and digest verification happen separately.
+3. **Existing managed roots route by receipt.** Project list/check/remove and library
+   list/load/deposit/cache operations route an existing receipt-classified root to the
+   skillset lifecycle. Standalone source discovery and project add preflight do not yet
+   provide the same categorical gate; see Known boundaries.
+4. **Standalone project state is protected first.** A source add rejects project
+   divergence before it may repair the reusable library and publish the project name.
+5. **Installed skillsets flow project to library.** A skillset definition selects the
+   desired pinned source. Once installed and validated, the project tree is primary;
+   it may create or repair the library copy, never the reverse.
+6. **Removal is scoped.** Standalone and skillset removal delete only their project
+   trees. Shared library trees and skillset definitions remain.
+7. **Filesystem safety bounds convenience.** Managed roots and copied trees reject
+   symlinks and unsafe path shapes before mutation.
+
+## Standalone `skill add`
+
+`lib.rs` dispatches to `add.rs`, which asks `sources.rs` to classify the input once:
+
+| Input | Route |
+|---|---|
+| Local path | Canonicalize, discover/select one valid skill, then use the source-install path. |
+| GitHub source | Resolve/checkout through `git.rs`, select one skill, and create a source receipt. |
+| Bare library name | `library.rs` loads one structurally validated standalone tree; receipt-classified roots are directed to `skillset add`. Source-receipt validation happens later during project checks. |
+
+For a local or GitHub source, the complete publication order is:
+
+1. Ensure the project layout and validate/select the source skill.
+2. Reuse an exact standalone library match when available; skillset roots cannot be
+   cache hits.
+3. Preflight the project target and refuse divergence.
+4. Deposit the source into the standalone library: create, no-op, or repair. A
+   receipt-classified target refuses before mutation.
+5. Install the project tree and then update the project-name index.
+
+A bare-name promotion starts from step 3 with the structurally validated library tree.
+Positive cache and repair behavior is intentional; receipt ownership is the boundary,
+not a ban on library reuse.
+
+## `skillset add`
+
+`lib.rs` dispatches directly to `skillsets.rs`:
+
+1. Validate the canonical `-skillset` name and read its authored skillset definition.
+2. Refuse an ordinary or invalidly owned library collision before network or project
+   publication.
+3. If a matching valid project tree already exists, keep the operation offline and
+   synchronize its library copy.
+4. Otherwise checkout the pinned revision, copy only the explicit members into a
+   staging tree, compute its digest, write the skillset receipt, and validate the
+   complete staged tree.
+5. Atomically rename the staged tree into the project and mirror that validated tree
+   to the library.
+
+`skillset refresh` reads the authored definition, then proves the installed project
+clean. It either repairs the library from an unchanged project or stages and replaces
+the project with best-effort rollback, then mirrors project to library. `skillset
+remove` requires a valid owned receipt and deletes only the project tree.
+
+## Other command owners
+
+| Command family | Owner and effect |
+|---|---|
+| `skill list` / `skill check` | `check.rs` reads project entries, `skillsets.rs` validates receipt roots, and `lib.rs` owns grouped counts/output. Standalone listing excludes skillset roots; check validates both lifecycles. |
+| `skill refresh` | `refresh.rs` uses the source receipt to prove the project clean. At an unchanged upstream revision it repairs the library directly from the project; after an upstream move it preflights the library, replaces the project, then updates the library and project-name index. |
+| `skill remove` | `remove.rs` refuses skillset roots, withdraws the project-name index first, deletes the project tree, and preserves the library. |
+| `skill harvest` | `harvest.rs` validates known harness trees and calls the create-only library path; it never writes a project. |
+| `skill lock` / `sync` / `verify` | `manifest.rs` records standalone intent and pins, installs missing pinned skills, and verifies declarations, pins, receipts, and tree hashes. |
+| `inspect` | `inspect.rs` reports GitHub structure without writing project or home state. |
+| `destroy` / `update` | `destroy.rs` removes project scaffolding and its name index; `update.rs` replaces only the CLI binary. |
+
+## Known boundaries
+
+- Standalone source discovery and generic project preflight do not classify a source or
+  project target by skillset receipt. With a missing library target, a receipt-bearing
+  arbitrary source can therefore publish when the project target is missing or
+  byte-identical. Its intended routing, and harvest's create-only reporting, remain
+  separate design questions.
+- Tink has no production inter-process library lock. Concurrent mutations are not a
+  proven operating mode.
+- Release sensors and their bypasses are documented in [`TESTING.md`](TESTING.md).

--- a/docs/DEEP-REFACTOR-LOG.md
+++ b/docs/DEEP-REFACTOR-LOG.md
@@ -1,0 +1,219 @@
+# Deep Refactor Log
+
+This is the canonical evidence ledger for `deep-refactor-system-design-improvement`.
+Its north star is: **make the next correct change clear and safe for someone new
+to the codebase.**
+
+Use one bounded loop at a time:
+
+`Understand -> Improve -> Verify -> Learn`
+
+This ledger owns experiment history and experiment-local findings, learnings, and
+antipatterns. Current architecture, test policy, reliability policy, and debt remain
+owned by their specialized documents. Promote unresolved actionable findings to
+[`TECH-DEBT.md`](TECH-DEBT.md); promote established boundaries or policies to their
+current-document owner. Corrections append a superseding entry instead of rewriting
+old evidence.
+
+## Evidence rules
+
+- Separate confirmed facts, inferences, and hypotheses.
+- Treat build, format, tests, and safety contracts as hard gates, not score inputs.
+- Score a fresh-reader probe one point each for: correct owner, correct contract,
+  reuse of an existing seam, minimal touch set, preserved invariants, and executable
+  verification. Record workspace files inspected as context cost.
+- Change one architectural coordinate per iteration. Stop or revert when it does not
+  improve the stated maintainability signal.
+- Never claim global or perfect architecture; report only the bounded result.
+
+## DRSI-2026-08-09-001 - Skillset receipt classification
+
+- **State:** verified locally; system-comprehension result mixed
+- **Scope / acceptance boundary:** Centralize the existing rule that a
+  `.tink-skillset.json` filesystem entry classifies an installed root as a skillset,
+  including when the entry is a dangling or unsafe symlink. Preserve all CLI behavior.
+- **Hard-gate baseline:** `cargo fmt --check` passed. `cargo test -- --nocapture`
+  passed 39 unit and 92 acceptance tests (131 total).
+- **Fresh-reader baseline:** A general `tink skillset check NAME-skillset` planning
+  probe scored 6/6 but inspected 13 workspace files. A focused classification probe
+  scored 6/6, found all five repeated production predicates plus two inconsistent
+  standalone-library paths, and inspected 11 workspace files.
+- **Confirmed finding:** The same `exists() || is_symlink()` receipt predicate appears
+  in [`check.rs`](../src/check.rs), [`remove.rs`](../src/remove.rs), and three places in
+  [`skillsets.rs`](../src/skillsets.rs).
+- **Antipattern:** One domain decision is duplicated across callers. A future caller
+  can omit the symlink half of the rule and allow an unsafe skillset root to fall
+  through to standalone-skill handling.
+- **Confirmed related finding:** [`library.rs`](../src/library.rs) does not apply this
+  classification before standalone library reads. Managed skillset installation copies
+  only declared member directories and the receipt, not a root `SKILL.md`; behavior for
+  a receipt-bearing library root presented to standalone APIs is not explicit. Changing
+  that behavior is outside this behavior-preserving iteration.
+- **Confirmed documentation finding:** [`ARCHITECTURE.md`](ARCHITECTURE.md) and
+  [`TESTING.md`](TESTING.md) omit shipped manifest, inspection, or skillset ownership.
+  They are not reliable complete newcomer maps. This is recorded, not repaired in this
+  one-coordinate iteration.
+- **Hypothesis:** A named helper owned by `skillsets` will reduce information leakage
+  from five predicates to one and make the fail-closed symlink rule discoverable.
+- **Experiment:** Add the narrow helper, route the five existing predicates through it,
+  and add a focused test for both a regular receipt and a dangling receipt symlink.
+- **Predicted maintainability effect:** A newcomer searching for receipt classification
+  should find one owner and should not need to reconstruct the symlink invariant from
+  multiple callers.
+- **Verification:** The focused dangling-symlink test passed. `cargo fmt --check` passed.
+  The full suite passed 40 unit and 92 acceptance tests (132 total). Clippy was not run
+  because `cargo-clippy` is not installed for the active toolchain. A repository-local
+  runtime smoke check returned `OK 13 skill(s)`.
+- **Fresh-reader result:** The post-change probe inspected 8 workspace files but scored
+  3/6: it found the single helper and all five migrated call sites, then incorrectly
+  concluded that every command was covered and missed the same two standalone-library
+  paths. The probe did not inspect this ledger, so the result was not contaminated by
+  the recorded hypothesis.
+- **Outcome:** Retain the refactor. It removes five copies of a safety-sensitive rule
+  without changing behavior, and its hard gates pass. Do not claim that the broader
+  comprehension hypothesis passed.
+- **Learning:** Correct planning and low context cost are independent. Centralizing a
+  rule reduced search surface but also made a fresh reader more likely to mistake local
+  consistency for system-wide completeness. A closed loop must measure semantic recall,
+  not only files read or architectural neatness.
+- **Next frontier or stop reason:** Decide whether receipt-bearing library roots must be
+  categorically excluded from standalone library operations. Treat stale owner maps as
+  a separate future coordinate.
+
+## DRSI-2026-08-09-002 - Receipt ownership at standalone library boundaries
+
+- **State:** verified locally within the existing managed-root boundary
+- **Scope / acceptance boundary:** When an existing Tink library root contains a
+  `.tink-skillset.json` entry, skillset ownership takes precedence over a root
+  `SKILL.md`. Standalone list, bare-name add, divergent source add, and exact-cache add
+  must not expose, promote, replace, or publish that root. External source discovery
+  remains unchanged.
+- **Hard-gate baseline:** DRSI-001 ended with 40 unit and 92 acceptance tests (132
+  total) passing. Its fresh-reader probe showed that centralizing a predicate had not
+  yet made the surrounding ownership contract complete.
+- **Decision:** Adopt one owner for this boundary: receipt presence classifies an
+  existing managed library root as a skillset before receipt validation or standalone
+  interpretation. A root `SKILL.md` does not create a second identity.
+- **Red evidence:** H10 first failed because `skill list --library` printed the managed
+  root as a standalone skill. H11 first failed because a divergent external standalone
+  source exited successfully, replaced the managed library tree, and published a
+  project skill. H12 first failed because a byte-identical external source took the
+  exact-cache path and published the receipt-bearing library root as a standalone
+  project skill.
+- **Antipattern:** A domain predicate was centralized without tracing every read,
+  write, and cache-reuse boundary that interpreted the classified object. Green local
+  tests made an incomplete owner contract look system-wide.
+- **Experiment:** Reuse `skillsets::has_receipt_entry` at standalone library
+  enumeration, bare-name loading, deposit, and exact-match lookup. Reject collisions
+  before mutation or project publication. Add H10-H12 and update the acceptance
+  contract, user documentation, and repository-managed skill guidance.
+- **Verification:** H10-H12 passed. `cargo fmt --check` and `git diff --check` passed.
+  The full suite passed 40 unit and 95 acceptance tests (135 total). A repository-local
+  runtime smoke check returned `OK 13 skill(s)`. Clippy was not run because
+  `cargo-clippy` is not installed for the active toolchain.
+- **Fresh-reader result:** A clean-context boundary probe scored 6/6 and found no
+  counterexample across list, bare-name promotion, divergent deposit, exact-cache
+  reuse, or remote-tip reuse. It inspected 20 workspace files and deliberately did not
+  inspect this ledger. A separate closure review scored 7/8 before this entry existed;
+  durable newcomer-visible design history was its only failed diagnostic.
+- **Outcome:** Retain the change. The bounded one-owner contract is executable and
+  proven for existing receipt-bearing managed library roots. Do not generalize this to
+  all receipt-bearing source trees or claim global architecture improvement.
+- **Learning:** A classifier becomes an architectural boundary only when every
+  interpretation path respects it. For mutable systems, inspect reads, writes, and
+  shortcuts such as caches independently; each deserves a red test when it can bypass
+  ownership.
+- **Next frontier or stop reason:** Stop this coordinate. Separately decide how a
+  receipt-bearing arbitrary source should behave when the managed target does not yet
+  exist, and whether harvest's create-only deposit should classify or report such
+  roots. Repair stale architecture and testing owner maps as another independent
+  coordinate.
+
+## DRSI-2026-08-09-003 - Automatic release verification gate
+
+- **State:** verified locally; first GitHub execution pending
+- **Scope / acceptance boundary:** Gate the automatic `main` push path before it
+  changes Cargo versions, commits, tags, pushes, or dispatches a release. Direct tag
+  pushes and manual `release.yml` dispatches remain outside this iteration.
+- **Confirmed finding:** `bump-release.yml` automatically shipped every non-release
+  push to `main` without running formatting or tests. The release workflow built
+  binaries but did not supply a pre-tag behavior gate.
+- **Antipattern:** Release safety depended on a contributor remembering local checks;
+  the irreversible transition was automated while its evidence was not.
+- **Experiment:** Reuse the repository's existing stable Rust action, request
+  `rustfmt`, and run only `cargo fmt --check` plus `cargo test --locked` immediately
+  after checkout and before the existing mutation step.
+- **Verification:** The red characterization found neither command in the bump
+  workflow. After the change, the YAML parsed and a focused order assertion proved
+  both checks precede the first Cargo mutation. Formatting, diff checks, 40 unit tests,
+  and 95 acceptance tests passed (135 total). `actionlint` is not installed locally,
+  so GitHub-specific workflow lint was not run.
+- **Fresh-reader result:** An independent workflow review scored 6/6 against the
+  ledger rubric with two workspace files of context. It confirmed the gate ordering,
+  preserved automatic release flow, minimal touch set, and the direct-tag/manual-
+  dispatch boundary.
+- **Outcome:** Retain the gate. It places executable evidence in the causal path before
+  the automatic release becomes difficult to reverse, without introducing a new CI
+  job, cache, matrix, or abstraction.
+- **Learning:** A local green suite is evidence for one change; a durable safety sensor
+  must execute automatically before the transition it protects.
+- **Next frontier or stop reason:** Stop this coordinate. Gate `release.yml` separately
+  only if every direct-tag and manual release entrypoint must share the same policy.
+  Repair the stale architecture and testing maps as an independent comprehension
+  coordinate.
+
+## DRSI-2026-08-09-004 - Current system and sensor maps
+
+- **State:** verified locally; documentation-only behavior preservation
+- **Scope / acceptance boundary:** Replace historical phase notes in
+  `docs/ARCHITECTURE.md` and `docs/TESTING.md` with current owner, authority, command
+  flow, sensor, and delivery-boundary maps. Change no production or workflow behavior.
+- **Baseline:** A source-restricted reader using only `ZEN.md`, `ARCHITECTURE.md`, and
+  `TESTING.md` scored 0/6 supported answers. It could not identify receipt ownership,
+  project/library authority, either complete add path, collision/cache sensors, or the
+  automated release boundary.
+- **Confirmed finding:** The old documents described prior numbered phases and omitted
+  shipped modules and state. “Catalog” conflated a derived project-name index with an
+  authored skillset definition; “receipt” conflated optional source provenance with
+  skillset ownership and digest evidence.
+- **Confirmed sensor finding:** Acceptance and executable test identifiers have drifted:
+  C4 describes a different sensor than the `c4_*` test; manifest tests have no
+  acceptance section; `M2` and `R2` are duplicated; several useful tests lack distinct
+  rows; S1/S2 have only partial or unnamed coverage. The acceptance file's historical
+  Linux-CI statement also differs from the current automatic release workflow.
+- **Antipattern:** Historical refactor narration was serving as a current architecture
+  map. A newcomer had to reconstruct live ownership from source while apparently
+  authoritative documents concealed ambiguity and sensor gaps.
+- **Experiment:** Document present-tense state authority, every source-module group,
+  qualified domain vocabulary, standalone and skillset add flows, cross-cutting
+  invariants, release predicates, executable sensor topology, and known gaps. Keep
+  detailed behavior rows in their existing acceptance owner.
+- **Verification:** All local documentation links resolve; historical phase markers are
+  absent from the two owner maps; formatting and diff checks passed; the full locked
+  suite passed 40 unit and 95 acceptance tests (135 total).
+- **Fresh-reader result:** The same three-file source-restricted probe improved from 0/6
+  to 6/6 and found no internal contradiction. It identified the classifier, authority
+  direction, both add flows, exact collision/cache sensors, and all three automatic
+  release-gate bypass classes without reading source.
+- **Accuracy result:** A separate code-to-document review found two P1 overclaims and
+  five P2 correction categories in the first draft. After narrowing receipt routing,
+  separating CLI behavior from delivery authority, and correcting validation, refresh,
+  ownership, sensor, and release wording, its final review found no remaining P1/P2 in
+  scope.
+- **Outcome:** Retain the maps. They reduce required onboarding context from an
+  open-ended source search to three named documents while exposing rather than hiding
+  the remaining contract and sensor debt.
+- **Learning:** Comprehensibility and truth require different feedback loops. A reader
+  probe tests whether the map can be followed; an independent implementation audit
+  tests whether the map deserves to be followed.
+- **Next frontier or stop reason:** Stop this coordinate. Reconcile acceptance rows with
+  executable test names and missing sensors as a separate traceability iteration.
+  Receipt-bearing arbitrary-source and create-only harvest semantics remain a separate
+  product decision.
+
+## Integration note - 2026-08-10
+
+Rebasing onto `origin/main` introduced an upstream H10 contract for rejecting nested
+library symlinks. The receipt-ownership acceptance rows and test functions are now
+H11-H13. Earlier DRSI-002 references to H10-H12 preserve the identifiers used when
+that experiment ran.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,58 +1,113 @@
 # Testing
 
-## Test Strategy
-- Stack baseline: Rust 2024 CLI, validated with `cargo test`.
-- Verification ladder:
-  1. keep current suite green,
-  2. map entrypoint behavior with characterizing tests,
-  3. only then refactor in the smallest complete unit.
-- Green gate: any refactor keeps `cargo test -- --nocapture` green before acceptance.
-- Tooling: unit tests in `src/*` modules and acceptance tests in `tests/acceptance.rs`.
+Tests are Tink's behavior sensors. [`ACCEPTANCE.md`](../ACCEPTANCE.md) records the
+intended CLI and on-disk boundary; workflow files define delivery automation. Unit and
+acceptance tests provide executable evidence, with known traceability drift recorded
+below. A passing check proves only its assertions.
 
-## Entry Effect Sketch (Phase 1)
-- `main.rs::main` parses `Cli` with `clap` and calls `run(cli, cwd)`.
-- `run` delegates to `dispatch`:
-  - `Init {}` path: validates project layout and optional flags
-  - `Skill { ... }` path: route to `dispatch_skill`
-  - `Destroy {}` path: remove project scaffolding + catalog entry
-  - `Update` path: perform binary replacement from GitHub release metadata
-- `dispatch_skill` routes to `add`, `list`, `check`, `refresh`, `remove`, `harvest`.
+## Required local gate
 
-### Pinch points identified
-- **`dispatch_skill` routing** — the central control fan-out for all operational behavior.
-- **`add_skill_inner` branching** — local path vs filesystem-ish path vs remote vs library name.
-- **Catalog side-effects ordering** (`add` deposit before/while install; `remove` withdraw-before-delete) and failure safety.
-- **`check_project` preflight** — symlink/structure refusals and `ZEN` coupling checks.
+Run from the repository root:
 
-### Chosen seams
-- Do not change `run -> dispatch` signatures or command enums in Phase 1.
-- Characterize first, then isolate changes to one behavior path per iteration.
+```console
+cargo fmt --check
+cargo test --locked
+git diff --check
+```
 
-## Safety Net Map
-| Module | Pinned behaviors | Test files | Gaps |
-|---|---|---|---|
-| `src/lib.rs` | CLI dispatch is exhaustive by command enum; success prints are constrained and failures return exit code 1 via error pathway. | `tests/acceptance.rs` (`i*`, `a*`, `c*`, `l*`, `x*`) | No unit coverage for exact styled output in each branch (intentional for now). |
-| `src/add.rs` | Add source resolution precedence: local path/remote/library; idempotence and divergence refusal semantics are preserved. | `tests/acceptance.rs` (`a1..a8`, `r*`) | Receipt-only drift on unchanged local trees is repaired without replacing the skill body (`a3b_add_local_repair_sidecar_only_divergence`). |
-| `src/check.rs` | `skill check` requires `.agents/skills` and validates each installed skill directory/name, and enforces ZEN/AGENTS coupling rule. | `tests/acceptance.rs` (`c1`, `c2`, `c3`, `c4`, `l4`, `l5`) | Add targeted checks for additional malformed installed-skill states (e.g., non-YAML metadata variants, missing required fields). |
-| `src/remove.rs` | `remove` withdraws catalog entry before deleting project tree; never touches library content. | `tests/acceptance.rs` (`x1`, `x2`, `x4`), plus malformed-catalog regression (`x6_remove_fails_when_catalog_meta_is_malformed`) | Explicitly covers malformed catalog state behavior on remove. |
-| `src/refresh.rs` | `refresh_one` computes old/new remote skill repositories and refresh logic without mutating project state until checks pass. | `tests/acceptance.rs` (`p1`, `p2`, `p3`, `p4`, `p5`, `p6`, `p7`) | Refactor extraction added for clarity; now verify this invariant remains covered. |
-| `src/update.rs` | `replace_binary` staging and replacement behavior is clear and single-purpose (`staging_binary_path`, `stage_new_binary`, `commit_staged_binary`). | `tests/update.rs` (`asset_name_*`) | Add a direct behavior test only if binary replacement edge-cases appear in future. |
-| `src/catalog.rs` | `CatalogMeta` models catalog persistence as a domain aggregate (`name`, `root`, `skills`) and owns ownership/purge logic for by-project entries. | `tests/acceptance.rs` (`a*`, `l*`, `x*`) + `catalog::tests::catalog_meta_models_skill_set_and_ownership` | Keep behavior compatibility by preserving existing catalog JSON schema and legacy fallback behavior for legacy/non-JSON skips. |
-| `src/git.rs` | `run_git` centralizes command execution and status/error translation while preserving `remote_head`, `checkout`, and `checkout_revision` error contracts. | `tests/acceptance.rs` (`r*`, `p*`) | Continue to rely on acceptance flows as end-to-end behavior proof; add unit coverage only if message-contract changes appear. |
-| `src/update.rs` | `curl_to_file` applies bounded timeouts and bounded retries on external artifact/API fetch, so update can fail fast instead of hanging. | `tests/acceptance.rs` (`u1`, `u2`, `u3`) + unit `curl_transport_args_*` | Keep behavior compatibility by leaving success path unchanged; add failure-path telemetry if needed by CI pipelines. |
-| `src/main.rs` | Binary entrypoint fails gracefully if process working directory is unavailable, rather than panicking. | `tests/acceptance.rs` (`v*`, including `v3_main_fails_when_current_directory_is_unavailable`) | Pin startup failure-path behavior and confirm exact failure class and exit code without path-dependent timing assumptions. |
-| `src/check.rs` | `load_project_skills` explicitly distinguishes ignorable entries (`README.md`, hidden dirs/files) from malformed entries before skill read/validate. | `tests/acceptance.rs` (`c3`, `c4`, `l*`) | New helper split is design-oriented; existing tests already cover key entry/validation failures. |
+`cargo test --locked` runs module unit tests and `tests/acceptance.rs`. Use a focused
+acceptance filter while iterating, then run the complete gate before closure:
 
-## Characterization Backlog
-- [x] Pin add idempotence on unchanged local source (`tink skill add`, no-op path). (`a2_add_identical_is_noop`)
-- [x] Pin behavior when removing project skill leaves library intact and updates catalog. (`x1_remove_deletes_project_skill_keeps_library_drops_catalog`)
-- [x] Pin `tink skill check` pass path after install and failure path without `.agents/skills`. (`c1_check_passes_valid_project`, `c2_check_fails_without_skills_dir`)
-- [x] Add characterization test for a deliberately corrupted installed `SKILL.md` (`c4_check_fails_with_corrupt_installed_skill`).
-- [x] Pin behavior for malformed catalog metadata entries during catalog listing (`l6_skill_list_catalog_skips_malformed_meta_entries`).
-- [x] Pin malformed-catalog behavior for remove (`x6_remove_fails_when_catalog_meta_is_malformed`).
-- [x] Pin receipt-only repair for unchanged local skill bodies (`a3b_add_local_repair_sidecar_only_divergence`).
+```console
+cargo test --test acceptance h13_exact_cache_match_does_not_publish_skillset_as_standalone -- --nocapture
+```
 
-## CI Gates
-- `cargo test -- --nocapture`
-- `./tink-test` acceptance smoke path when integration behavior changes.
+`./tink-test <args>` builds and executes this checkout with an isolated Tink home. It
+is a dogfood runner, not an automated test suite by itself.
 
+## Automated release gate
+
+`.github/workflows/bump-release.yml` handles non-release pushes to `main`. Before it
+changes `Cargo.toml` or `Cargo.lock`, commits, tags, pushes, or dispatches a release, it
+installs stable Rust with `rustfmt` and runs:
+
+```console
+cargo fmt --check
+cargo test --locked
+```
+
+That gate protects the automatic `main`-push release path. It does **not** protect the
+two direct entrypoints accepted by `.github/workflows/release.yml`:
+
+- a direct `v*` tag push;
+- a manual `workflow_dispatch`.
+
+Those two paths perform locked release builds but do not run formatting or behavior
+tests. Separately, the entire bump job skips a `main` push whose head message starts
+with `chore: release v`; such a push is neither verified nor released by these
+workflows. External branch/tag protection is outside this repository and must not be
+assumed.
+
+## Test topology
+
+| Boundary | Primary executable sensors |
+|---|---|
+| Bootstrap and layout | `I*` acceptance tests; `home.rs` unit tests |
+| Local and remote standalone add | `A*`, `R*`; `sources.rs` and `skills.rs` unit tests |
+| Skillsets | `K*`; `skillsets.rs` validation and receipt-classification unit tests |
+| GitHub inspection | `G*` |
+| Project validation and listing | `C*`, `L*` |
+| Library, promotion, cache, and harvest | `H*`; `library.rs` unit tests |
+| Standalone refresh and removal | `P*`, `X*` |
+| Manifest lock/sync/verify | `M*`; `manifest.rs` unit tests |
+| CLI surface and lifecycle safety | `V*`, `D*`, `U*`, `S*`; `update.rs`, `style.rs`, and `git.rs` unit tests |
+
+The most important ownership sensors are:
+
+- `skillsets::tests::receipt_entry_presence_includes_dangling_symlinks` pins
+  classification before validation.
+- H11 excludes a receipt-classified library root from standalone listing and directs a
+  bare-name add to `skillset add`.
+- H12 refuses a divergent standalone collision before mutation or project publication
+  and preserves all seeded library bytes.
+- H13 prevents an exact-cache hit from publishing a skillset root as a standalone
+  project skill.
+- A6 and A8 preserve the positive standalone library repair and cache paths; ownership
+  protection must not disable legitimate reuse.
+- K1, K5, K6, K8, K10, and K11 cover pinned install, collision refusal, receipt safety,
+  offline re-add, staged refresh, and member-name validation.
+- P1-P7 cover clean-project proof and project/library refresh direction.
+
+Use [`ACCEPTANCE.md`](../ACCEPTANCE.md) for detailed input/output contracts rather
+than copying every row here.
+
+## Change workflow
+
+1. State the outcome, invariant, and acceptance boundary.
+2. For a behavior change or bug fix, add a failing acceptance test first. For a pure
+   refactoring, begin and end on a green suite.
+3. Change the smallest complete owner; do not distribute a domain decision across
+   callers.
+4. Run the focused sensor, then the complete local gate.
+5. When ownership or proof changes, update this map and
+   [`ARCHITECTURE.md`](ARCHITECTURE.md). Record experiment history in
+   [`DEEP-REFACTOR-LOG.md`](DEEP-REFACTOR-LOG.md).
+
+## Known sensor gaps
+
+- Acceptance row C4 describes no-network/no-write instrumentation, while the current
+  `c4_check_fails_with_corrupt_installed_skill` test proves corrupt-frontmatter
+  refusal. The stated C4 sensor remains unautomated and its ID has drifted.
+- Manifest tests use `M*`, but `ACCEPTANCE.md` has no manifest section; two test
+  functions use the `M2` prefix. Two remote-add tests likewise use `R2`.
+  Traceability is therefore not one-to-one.
+- Additional useful tests (`A3b`, `V3`, `L6`, `X6`, and `G4b`-`G4e`) are executable but
+  not represented by distinct acceptance rows.
+- Acceptance S1 promises no Git mutation for every successful command, but the only
+  `S*` test covers `init` not creating `.git`; S2 (home is never discovery) has no
+  named acceptance test. Both cross-cutting claims have only partial sensor coverage.
+- No automated test proves concurrent Tink mutations safe; production code has no
+  inter-process library lock.
+- Direct-tag and manual release entrypoints bypass behavior verification, while a
+  `chore: release v` head-message prefix skips both verification and automatic release,
+  as described above.

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -59,9 +59,10 @@ canonical name is missing, stop and ask for the missing authority or name.
 ### Step 3: Execute the Primary Mutation
 
 Run the selected command once. Honor create-only and divergence refusals. Use
-`tink skill add NAME` to promote a bare library skill, `tink skill harvest` to
-fill the library from known harness roots, and only the matching `tink
-skillset add`, `refresh`, or `remove` command for a skillset mutation.
+`tink skill add NAME` to promote a bare library skill. Receipt-backed roots
+remain skillsets. Use `tink skill harvest` to fill the library from known
+harness roots, and only the matching `tink skillset add`, `refresh`, or
+`remove` command for a skillset mutation.
 
 **Expected:** The command finishes and its stdout, stderr, and exit status are
 known.
@@ -136,6 +137,7 @@ from the mutation command alone.
 ## Common Pitfalls
 
 - Treating the home library as an agent discovery root.
+- Treating a receipt-backed library skillset as a standalone skill.
 - Inferring a skillset suffix or definition from inspection output.
 - Combining a binary update with project-skill replacement without approval.
 - Hand-editing receipts, catalog metadata, or divergent managed trees.
@@ -171,7 +173,8 @@ from the mutation command alone.
 
 - Leave `.tink-source.json` untouched — it is the refresh **receipt**.
 - Leave `.tink-skillset.json` untouched — it is skillset ownership and digest
-  evidence.
+  evidence. Its presence takes precedence over a root `SKILL.md`; standalone
+  library commands must not expose, promote, or replace that root.
 - On a refusal, stop and report it. Authorized deletes are only:
   - `tink skill remove NAME` → `.agents/skills/<name>/` and drops that name
     from the by-project catalog

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -44,7 +44,8 @@ form for add, list, check, refresh, and remove.
 - Home (`$TINK_HOME` or `~/.tink`) is not an agent discovery root. Installs
   library trees at `skills/<name>/`. List the library with
   `tink skill list --library`; promote into a project with
-  `tink skill add NAME` (bare library skill name). `tink skill harvest` copies complete trees
+  `tink skill add NAME` (bare standalone library skill name). Receipt-backed
+  roots are excluded from both standalone operations. `tink skill harvest` copies complete trees
   from known harness roots into the library create-only (never overwrites a
   divergent library entry). Global roots include `~/.agents/skills`,
   `~/.claude/skills`, `~/.codex/skills`, `~/.cursor/skills`,
@@ -78,5 +79,7 @@ form for add, list, check, refresh, and remove.
   full revision, source root, and explicit members. Installed project and
   library trees carry `.tink-skillset.json`. A valid project tree is primary:
   it may repair its library copy, while library state never overwrites a
-  divergent project. `skillset remove` deletes only the project tree and keeps
+  divergent project. Receipt presence owns the root even when it also contains
+  `SKILL.md`; standalone skill commands never expose, promote, or replace it.
+  `skillset remove` deletes only the project tree and keeps
   both the definition and library copy.

--- a/src/check.rs
+++ b/src/check.rs
@@ -22,9 +22,7 @@ fn read_skill_entry(path: &Path) -> Result<Option<Skill>, Error> {
             "Unexpected entry in .agents/skills: {name}"
         )));
     }
-    if path.join(crate::skillsets::RECEIPT_FILE).exists()
-        || path.join(crate::skillsets::RECEIPT_FILE).is_symlink()
-    {
+    if crate::skillsets::has_receipt_entry(path) {
         crate::skillsets::validate_installed(path)?;
         return Ok(None);
     }

--- a/src/library.rs
+++ b/src/library.rs
@@ -53,7 +53,8 @@ fn library_root(home: Option<&Path>) -> Result<PathBuf, Error> {
     Ok(root)
 }
 
-/// Validated skill trees currently in the library (skips reserved / unreadable).
+/// Validated standalone skill trees currently in the library.
+/// Skips reserved, unreadable, and receipt-backed skillset roots.
 fn iter_library_skills(library: &Path) -> Result<Vec<Skill>, Error> {
     if !library.exists() {
         return Ok(Vec::new());
@@ -78,6 +79,9 @@ fn iter_library_skills(library: &Path) -> Result<Vec<Skill>, Error> {
         if path.is_symlink() || !path.is_dir() {
             continue;
         }
+        if crate::skillsets::has_receipt_entry(&path) {
+            continue;
+        }
         if let Ok(skill) = skills::read_skill(&path, true) {
             skills::validate_skill_tree(&path)?;
             skills.push(skill);
@@ -91,11 +95,19 @@ fn iter_library_skills(library: &Path) -> Result<Vec<Skill>, Error> {
 ///
 /// Identical → noop; missing → create; divergent → replace (caller should warn).
 /// Project installs still refuse overwrites separately.
+/// Receipt-backed skillset roots are never replaced by standalone skills.
 pub fn deposit(
     skill: &Skill,
     provenance: Option<&Provenance>,
 ) -> Result<(PathBuf, LibraryWrite), Error> {
     let library = library_root(None)?;
+    let target = library.join(&skill.name);
+    if crate::skillsets::has_receipt_entry(&target) {
+        return Err(Error::msg(format!(
+            "Library entry is a skillset; refusing standalone skill collision: {}",
+            skill.name
+        )));
+    }
     match skills::preflight_install(skill, &library, provenance)? {
         PreflightOutcome::Ready => {
             let (path, _) = skills::install_local(skill, &library, provenance)?;
@@ -139,11 +151,12 @@ pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), 
     }
 }
 
-/// When the library already holds the exact tree we would install, return it.
+/// When the library already holds the exact standalone tree we would install, return it.
+/// Receipt-backed roots remain owned by the skillset lifecycle and are never cache hits.
 pub fn matching(skill: &Skill, provenance: Option<&Provenance>) -> Result<Option<Skill>, Error> {
     let library = library_root(None)?;
     let target = library.join(&skill.name);
-    if !target.is_dir() {
+    if !target.is_dir() || crate::skillsets::has_receipt_entry(&target) {
         return Ok(None);
     }
     match skills::preflight_install(skill, &library, provenance)? {
@@ -154,9 +167,10 @@ pub fn matching(skill: &Skill, provenance: Option<&Provenance>) -> Result<Option
     }
 }
 
-/// List skill names present in the home library.
+/// List standalone skill names present in the home library.
 ///
-/// Creates nothing; empty when home or library root is missing.
+/// Creates nothing; empty when home or library root is missing. Receipt-backed
+/// skillset roots are excluded.
 pub fn list_names(home: Option<&Path>) -> Result<Vec<String>, Error> {
     let Some(home) = existing_inventory_root(home)? else {
         return Ok(Vec::new());
@@ -168,7 +182,8 @@ pub fn list_names(home: Option<&Path>) -> Result<Vec<String>, Error> {
         .collect())
 }
 
-/// Load one skill from the library by directory name.
+/// Load one standalone skill from the library by directory name.
+/// Receipt-backed roots remain owned by the skillset lifecycle.
 pub fn load(name: &str) -> Result<Skill, Error> {
     let library = library_root(None)?;
     let path = library.join(name);
@@ -180,6 +195,11 @@ pub fn load(name: &str) -> Result<Skill, Error> {
     }
     if !path.is_dir() {
         return Err(Error::msg(format!("Library skill not found: {name}")));
+    }
+    if crate::skillsets::has_receipt_entry(&path) {
+        return Err(Error::msg(format!(
+            "Library entry is a skillset; use `tink skillset add {name}`"
+        )));
     }
     skills::read_skill(&path, true)
 }

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -42,9 +42,7 @@ pub fn remove_skill(project_root: &Path, name: &str) -> Result<RemoveReport, Err
             target.display()
         )));
     }
-    if target.join(crate::skillsets::RECEIPT_FILE).exists()
-        || target.join(crate::skillsets::RECEIPT_FILE).is_symlink()
-    {
+    if crate::skillsets::has_receipt_entry(&target) {
         return Err(Error::msg(format!(
             "Skillset root detected; use `tink skillset remove {name}`"
         )));

--- a/src/skillsets.rs
+++ b/src/skillsets.rs
@@ -1,4 +1,8 @@
-//! Pinned nested skillset installation.
+//! Pinned nested skillset lifecycle.
+//!
+//! Receipt entry presence classifies a root as a skillset before receipt contents are
+//! trusted. The project tree is authoritative; library copies are derived from a
+//! validated project tree.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -14,8 +18,18 @@ use crate::paths::{map_io, refuse_symlink};
 use crate::skills;
 use crate::sources;
 
-pub const RECEIPT_FILE: &str = ".tink-skillset.json";
+const RECEIPT_FILE: &str = ".tink-skillset.json";
 const NAME_SUFFIX: &str = "-skillset";
+
+/// Whether `path` contains a skillset receipt entry.
+///
+/// This is classification, not validation. Receipt presence claims the root for the
+/// skillset domain and prevents standalone handling; callers that need valid contents
+/// must validate them separately.
+pub(crate) fn has_receipt_entry(path: &Path) -> bool {
+    let receipt = path.join(RECEIPT_FILE);
+    receipt.exists() || receipt.is_symlink()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LibraryWrite {
@@ -457,7 +471,7 @@ pub fn list_installed(project_root: &Path) -> Result<Vec<ListedSkillset>, Error>
                 "Unexpected entry in .agents/skills: {name}"
             )));
         }
-        if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
+        if has_receipt_entry(&path) {
             let installed = read_installed(&path)?;
             skillsets.push(ListedSkillset {
                 name: installed.name,
@@ -476,7 +490,7 @@ pub fn project_counts(project_root: &Path) -> Result<(usize, usize), Error> {
     let mut member_count = 0;
     for entry in fs::read_dir(&skills_root).map_err(|e| map_io(&skills_root, e))? {
         let path = entry.map_err(|e| map_io(&skills_root, e))?.path();
-        if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
+        if has_receipt_entry(&path) {
             let installed = read_installed(&path)?;
             skillset_count += 1;
             member_count += installed.receipt.members.len();
@@ -592,7 +606,7 @@ pub fn list_library(home_root: Option<&Path>) -> Result<Vec<ListedSkillset>, Err
         if path.is_symlink() || !path.is_dir() {
             continue;
         }
-        if path.join(RECEIPT_FILE).exists() || path.join(RECEIPT_FILE).is_symlink() {
+        if has_receipt_entry(&path) {
             let installed = read_installed(&path)?;
             skillsets.push(ListedSkillset {
                 name: installed.name,
@@ -637,5 +651,19 @@ mod tests {
         assert!(parse_source("https://git.example.test/team/skills.git").is_ok());
         assert!(parse_source("owner/skills").is_err());
         assert!(parse_source("https://user@git.example.test/skills.git").is_err());
+    }
+
+    #[test]
+    fn receipt_entry_presence_includes_dangling_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        let receipt = root.path().join(RECEIPT_FILE);
+
+        assert!(!has_receipt_entry(root.path()));
+        fs::write(&receipt, "receipt").unwrap();
+        assert!(has_receipt_entry(root.path()));
+
+        fs::remove_file(&receipt).unwrap();
+        std::os::unix::fs::symlink(root.path().join("missing"), &receipt).unwrap();
+        assert!(has_receipt_entry(root.path()));
     }
 }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -2631,6 +2631,117 @@ fn h9_completion_offers_current_library_matches_without_creating_home() {
         );
 }
 
+#[test]
+fn h11_receipt_bearing_library_root_is_not_a_standalone_skill() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let root = ws.library_skill("bundle-skillset");
+    write_skill(
+        &root,
+        "bundle-skillset",
+        "root skill must not override skillset ownership",
+    );
+    fs::write(root.join(".tink-skillset.json"), "{}\n").unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "list", "--library"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bundle-skillset").not());
+
+    ws.cmd(&project)
+        .args(["skill", "add", "bundle-skillset"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Library entry is a skillset").and(
+            predicate::str::contains("tink skillset add bundle-skillset"),
+        ));
+    assert!(!Workspace::skill_path(&project, "bundle-skillset").exists());
+}
+
+#[test]
+fn h12_standalone_add_preserves_receipt_bearing_library_root() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let library_root = ws.library_skill("bundle-skillset");
+    write_skill(&library_root, "bundle-skillset", "managed root");
+    fs::write(library_root.join(".tink-skillset.json"), "owned receipt\n").unwrap();
+    fs::write(library_root.join("keep.txt"), "preserve me\n").unwrap();
+    let before_skill = fs::read(library_root.join("SKILL.md")).unwrap();
+    let before_receipt = fs::read(library_root.join(".tink-skillset.json")).unwrap();
+    let before_keep = fs::read(library_root.join("keep.txt")).unwrap();
+
+    let source = ws.root.join("incoming-skill");
+    write_skill(&source, "bundle-skillset", "standalone collision");
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Library entry is a skillset").and(
+            predicate::str::contains("refusing standalone skill collision"),
+        ));
+
+    assert_eq!(
+        fs::read(library_root.join("SKILL.md")).unwrap(),
+        before_skill
+    );
+    assert_eq!(
+        fs::read(library_root.join(".tink-skillset.json")).unwrap(),
+        before_receipt
+    );
+    assert_eq!(
+        fs::read(library_root.join("keep.txt")).unwrap(),
+        before_keep
+    );
+    assert!(!Workspace::skill_path(&project, "bundle-skillset").exists());
+}
+
+#[test]
+fn h13_exact_cache_match_does_not_publish_skillset_as_standalone() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let library_root = ws.library_skill("bundle-skillset");
+    write_skill(&library_root, "bundle-skillset", "identical managed root");
+    fs::write(library_root.join(".tink-skillset.json"), "owned receipt\n").unwrap();
+    let before_skill = fs::read(library_root.join("SKILL.md")).unwrap();
+    let before_receipt = fs::read(library_root.join(".tink-skillset.json")).unwrap();
+
+    let source = ws.root.join("identical-source");
+    write_skill(&source, "bundle-skillset", "identical managed root");
+    fs::write(source.join(".tink-skillset.json"), "owned receipt\n").unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Library entry is a skillset"));
+
+    assert_eq!(
+        fs::read(library_root.join("SKILL.md")).unwrap(),
+        before_skill
+    );
+    assert_eq!(
+        fs::read(library_root.join(".tink-skillset.json")).unwrap(),
+        before_receipt
+    );
+    assert!(!Workspace::skill_path(&project, "bundle-skillset").exists());
+}
+
 // --- V*: CLI surface (skill nest) ---
 
 #[test]


### PR DESCRIPTION
## What changed
- centralize skillset receipt-entry classification and route project/library operations through it
- prevent receipt-backed library roots from being listed, promoted, cached, or overwritten as standalone skills
- add H11-H13 acceptance coverage and refresh architecture/testing/managed-skill documentation
- gate automatic main-push releases with format/tests and pin the third-party Rust toolchain action
- reconcile the documented delivery boundary

## Why
Receipt-backed skillset roots could be interpreted through standalone library paths, allowing exposure, cache reuse, or replacement. The automatic release path also mutated versions/tags before running behavioral verification.

## Impact
Standalone skill behavior remains unchanged for ordinary library entries. Receipt-bearing managed roots now remain under the skillset lifecycle, and automatic releases fail before mutation when formatting/tests fail.

## Validation
- `cargo fmt --check`
- `cargo test --locked` (59 unit + 117 acceptance; 176 total)
- `git diff --check origin/main..HEAD`
- workflow YAML parse
- OCR delegation review: 6/6 reviewable files, no remaining findings
- manual documentation review: 7/7 files, local links valid

## Known follow-up
`.github/workflows/release.yml` still has a pre-existing unpinned `dtolnay/rust-toolchain@stable`; it is intentionally outside this PR.