### PR TITLE
Enforce acceptance traceability

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -8,8 +8,9 @@ imports, removes a project skill on request, ensures a home root at `~/.tink`
 harness locations into that library (create-only), and can update the CLI binary
 from GitHub Releases via `tink update`.
 
-**Authority:** This file is the evaluator. Implementation stops when every row
-below has an automated test that passes on macOS with `git` on `PATH`.
+**Authority:** This file is the evaluator. A row is complete when its named automated
+sensor passes on macOS with `git` on `PATH`. Rows explicitly marked
+`Sensor: manual` remain known gaps rather than implied automated proof.
 
 **Delivery gate:** The automatic `main`-push release path runs formatting and
 tests on Ubuntu before version, tag, push, or dispatch mutations. Direct tag
@@ -34,6 +35,9 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill list --library` | List standalone skill names in the library; receipt-backed skillset roots are excluded |
 | `tink skill harvest` | Copy complete skill trees from known harness roots into the library (create-only; no project writes) |
 | `tink skill check` | Validate project skills; no network; no writes |
+| `tink skill lock [--source <name=source>]` | Record the installed project skills in `.tink/skills.toml` and `.tink/skills.lock` |
+| `tink skill sync` | Restore the locked project skills from their typed sources |
+| `tink skill verify` | Verify installed project skills against the manifest and lockfile |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
 | `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` and drop that name from the by-project catalog (not library) |
 | `tink inspect <GITHUB_URL>` | Inspect skills and source-defined skillsets in a public GitHub URL without writing project or home state |
@@ -78,6 +82,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | A1 | `skill add` valid local skill dir | Installs under `.agents/skills/<name>/`; records name in catalog; copies tree into library at `$TINK_HOME/skills/<name>/` |
 | A2 | `skill add` same skill again (byte-identical) | Success noop; project + library unchanged |
 | A3 | `skill add` when project target exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |
+| A3B | Re-add an unchanged local skill whose stale `.tink-source.json` is its only divergence | Exit 0; removes the inapplicable remote-source sidecar |
 | A4 | `skill add` skill tree containing a symlink | Exit ≠ 0; refuse |
 | A5 | `skill add` multi-skill source without `--skill` | Exit ≠ 0; lists choices |
 | A6 | `skill add` when library has same name but different tree (project missing) | Exit 0; installs project; repairs library; warns on stderr that the home copy was updated |
@@ -104,14 +109,15 @@ Ids are stable. Tests must name or comment the id they prove.
 | R9 | A matching library copy exists for one of several same-name remote skills | Name-only add still checks the repository and refuses ambiguity; the cache cannot choose a path implicitly |
 | R10 | A canonical nested skill and a directory/name-mismatched `SKILL.md` declare the same name | Name selection ignores the malformed candidate and installs the one valid tree; inspection may still diagnose both |
 | R11 | Root and nested skills share a name, then `--skill .` selects the listed root path | Installs the root skill and records receipt path `"."` |
+| R12 | `skill add tink:embedded/manage-tink` through the free-form add boundary | Exit ≠ 0; embedded lock sources are not accepted as remote add sources |
 
 ### Skillsets
 
 | Id | Action | Expect |
 |---|---|---|
 | K1 | `skillset add <name>-skillset` with `$TINK_HOME/catalog/by-skillset/<name>-skillset/meta.json` | Installs the pinned members under `.agents/skills/<name>-skillset/`, validates the project, then mirrors that exact tree to `$TINK_HOME/skills/<name>-skillset/`; matching re-add is a no-op; library drift is repaired from the valid project |
-| K2 | `skillset remove <name>-skillset` after K1 | Removes only the project skillset tree; preserves the shared catalog definition and home library copy; `skill remove` refuses the skillset root |
-| K3 | `skillset list [--library]` after K1 | Groups each receipt-backed project or library skillset with its member skill names without network or writes |
+| K2 | `skillset remove <name>-skillset` after K1 | Removes only the project skillset tree; preserves the shared catalog definition and home library copy; `skill remove` refuses the skillset root. Sensor: K1. |
+| K3 | `skillset list [--library]` after K1 | Groups each receipt-backed project or library skillset with its member skill names without network or writes. Sensor: K1. |
 | K4 | Any skillset command receives a name without `-skillset` | Exit ≠ 0; clear canonical-name error; no skillset tree written |
 | K5 | `skillset add` finds an ordinary or unowned library entry at the canonical name | Exit ≠ 0 before network/project publication; preserve the library entry |
 | K6 | `skillset remove` finds a missing or invalid receipt | Exit ≠ 0; preserve the complete project directory |
@@ -129,6 +135,10 @@ Ids are stable. Tests must name or comment the id they prove.
 | G2 | `inspect` a group tree URL | Reports only the one inferred skillset and skills beneath that boundary |
 | G3 | `inspect` a skill tree URL | Reports one skill and zero skillsets |
 | G4 | `inspect` a repository with one non-`skills` structural wrapper | Infers grouped skillsets without relying on a literal `skills/` directory |
+| G4B | `inspect` a flat repository containing multiple root skills | Proposes one unnamed skillset without exposing the temporary checkout directory name |
+| G4C | `inspect` a mixed root with one root skill and a separate `skills/` collection | Refuses to collapse unrelated levels; reports standalone skills and requests a narrower URL |
+| G4D | `inspect` a repository or tree rooted at a literal `skills/` collection | Treats `skills` as a collection root rather than proposing `skills-skillset` |
+| G4E | `inspect` a grouped repository whose derived canonical name would exceed the name limit | Leaves that proposal unnamed and explains that no valid canonical name is available |
 | G5 | `inspect` duplicate names and invalid `SKILL.md` files | Succeeds with visible diagnostics and excludes invalid candidates from the skill count |
 | G6 | `inspect` an empty valid directory | Succeeds with zero skills and a structural diagnostic |
 | G7 | `inspect` unsupported URLs, missing or ambiguous slash-containing refs, and missing boundaries | Exits nonzero with actionable errors |
@@ -141,7 +151,19 @@ Ids are stable. Tests must name or comment the id they prove.
 | C1 | `skill check` after valid `init` + `skill add` | Exit 0 |
 | C2 | `skill check` without `.agents/skills` | Exit ≠ 0 |
 | C3 | `skill check` when `.agents` is a symlink | Exit ≠ 0; refuse |
-| C4 | `skill check` | Performs no network I/O and no filesystem writes (manual / future instrumentation; not automated in v1 harness) |
+| C4 | `skill check` | Performs no network I/O and no filesystem writes. Sensor: manual. |
+| C5 | `skill check` after an installed skill's frontmatter name is corrupted | Exit ≠ 0; reports the skill-name mismatch |
+
+### Project manifest
+
+| Id | Action | Expect |
+|---|---|---|
+| M1 | `skill verify` with matching empty manifest and lockfile in an empty project | Exit 0; reports zero verified manifest skills |
+| M2 | `skill lock --source reviewer=fixture/reviewer` after adding that local skill | Writes manifest and lockfile; subsequent `skill verify` succeeds |
+| M3 | `skill sync` after deleting an installed locked local skill whose source remains | Restores the skill; subsequent `skill verify` succeeds |
+| M4 | `skill sync` after deleting locked embedded `manage-tink` | Restores the embedded skill; subsequent `skill verify` succeeds |
+| M5 | `skill sync` after a slash-containing local source disappears | Exit ≠ 0 as a missing local path; does not reinterpret it as GitHub shorthand |
+| M6 | `skill verify` without a project manifest | Exit ≠ 0; reports the missing manifest |
 
 ### List
 
@@ -181,6 +203,7 @@ Ids are stable. Tests must name or comment the id they prove.
 |---|---|---|
 | V1 | `skill add` local skill | Installs under `.agents/skills/<name>/` |
 | V2 | `skill check` after valid project | Exit 0; stdout includes `OK` |
+| V3 | Run top-level `--help`, then a project command, after each command's current directory is removed | Help succeeds without resolving a project; the project command fails closed with a current-directory error |
 
 ### Refresh
 
@@ -227,8 +250,8 @@ Ids are stable. Tests must name or comment the id they prove.
 
 | Id | Action | Expect |
 |---|---|---|
-| S1 | Any successful command | Does not `git init`, stage, commit, or push |
-| S2 | Home root | Never treated as an agent discovery root |
+| S1 | Any successful command | Does not `git init`, stage, commit, or push. Sensor: S1 (partial: `init` only). |
+| S2 | Home root | Never treated as an agent discovery root. Sensor: manual. |
 | S3 | `skill remove` or `destroy --yes` when neither `TINK_HOME` nor `HOME` can resolve an inventory | Exit 0; completes local cleanup without creating or mutating inventory state |
 
 ## Proof
@@ -237,5 +260,5 @@ Ids are stable. Tests must name or comment the id they prove.
 cargo test
 ```
 
-A row is done only when its automated test passes. Passing tests prove only what
-they assert.
+A row is done only when its named automated sensor passes. Explicit manual or partial
+markers disclose remaining proof gaps. Passing tests prove only what they assert.

--- a/docs/DEEP-REFACTOR-LOG.md
+++ b/docs/DEEP-REFACTOR-LOG.md
@@ -217,3 +217,21 @@ Rebasing onto `origin/main` introduced an upstream H10 contract for rejecting ne
 library symlinks. The receipt-ownership acceptance rows and test functions are now
 H11-H13. Earlier DRSI-002 references to H10-H12 preserve the identifiers used when
 that experiment ran.
+
+## Acceptance traceability reconciliation - 2026-08-10
+
+- **Outcome / invariant:** Every executable acceptance sensor has a unique contract ID
+  represented in `ACCEPTANCE.md`; every non-manual row resolves to an executable
+  sensor. Bundled coverage and remaining manual or partial gaps are explicit.
+- **Repair:** Added the missing manifest, inspection, CLI, local-add, and remote-add
+  rows; renamed the colliding C4, M2, and R2 test IDs; retained K2/K3 as deliberately
+  bundled K1 coverage; and corrected the stale sensor-gap inventory.
+- **Guard:** Added `tests/acceptance_traceability.rs`, which rejects duplicate row or
+  test IDs, missing named sensors, and executable sensors with no row or explicit
+  reference. It does not claim to detect semantic mismatches inside prose or test
+  assertions.
+- **Remaining gaps:** C4 remains manual, S1 remains partial, and S2 remains manual.
+  Concurrency and direct release-entrypoint gaps remain unchanged.
+- **Verification:** `cargo fmt --check`, `cargo test --locked`, and `git diff --check`
+  pass. The locked suite contains 59 unit tests, 117 behavioral acceptance tests, and
+  one traceability test.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,8 +2,9 @@
 
 Tests are Tink's behavior sensors. [`ACCEPTANCE.md`](../ACCEPTANCE.md) records the
 intended CLI and on-disk boundary; workflow files define delivery automation. Unit and
-acceptance tests provide executable evidence, with known traceability drift recorded
-below. A passing check proves only its assertions.
+acceptance tests provide executable evidence. A repository-local traceability test
+keeps row and sensor identifiers unique and exposes explicit manual or partial gaps.
+A passing check proves only its assertions.
 
 ## Required local gate
 
@@ -15,8 +16,9 @@ cargo test --locked
 git diff --check
 ```
 
-`cargo test --locked` runs module unit tests and `tests/acceptance.rs`. Use a focused
-acceptance filter while iterating, then run the complete gate before closure:
+`cargo test --locked` runs module unit tests, `tests/acceptance.rs`, and the acceptance
+traceability guard. Use a focused acceptance filter while iterating, then run the
+complete gate before closure:
 
 ```console
 cargo test --test acceptance h13_exact_cache_match_does_not_publish_skillset_as_standalone -- --nocapture
@@ -93,19 +95,17 @@ than copying every row here.
    [`ARCHITECTURE.md`](ARCHITECTURE.md). Record experiment history in
    [`DEEP-REFACTOR-LOG.md`](DEEP-REFACTOR-LOG.md).
 
-## Known sensor gaps
+## Traceability and known sensor gaps
 
-- Acceptance row C4 describes no-network/no-write instrumentation, while the current
-  `c4_check_fails_with_corrupt_installed_skill` test proves corrupt-frontmatter
-  refusal. The stated C4 sensor remains unautomated and its ID has drifted.
-- Manifest tests use `M*`, but `ACCEPTANCE.md` has no manifest section; two test
-  functions use the `M2` prefix. Two remote-add tests likewise use `R2`.
-  Traceability is therefore not one-to-one.
-- Additional useful tests (`A3b`, `V3`, `L6`, `X6`, and `G4b`-`G4e`) are executable but
-  not represented by distinct acceptance rows.
-- Acceptance S1 promises no Git mutation for every successful command, but the only
-  `S*` test covers `init` not creating `.git`; S2 (home is never discovery) has no
-  named acceptance test. Both cross-cutting claims have only partial sensor coverage.
+`tests/acceptance_traceability.rs` rejects duplicate row IDs, duplicate executable
+sensor IDs, missing named sensors, and executable sensors without a row. Most rows map
+to the same-named `tests/acceptance.rs` function. An explicit `Sensor: <ID>` marker
+records deliberate bundled coverage; `Sensor: manual` records an unresolved proof gap.
+
+- C4 still needs no-network/no-write instrumentation.
+- S1 is automated only for `init` not creating a Git repository; its command-wide
+  no-stage/commit/push claim remains partial.
+- S2 (home is never an agent discovery root) remains manual.
 - No automated test proves concurrent Tink mutations safe; production code has no
   inter-process library lock.
 - Direct-tag and manual release entrypoints bypass behavior verification, while a

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -1346,7 +1346,7 @@ fn r2_add_rejects_non_github_remote() {
 }
 
 #[test]
-fn r2_add_rejects_embedded_lock_source() {
+fn r12_add_rejects_embedded_lock_source() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -1848,7 +1848,7 @@ fn c3_check_refuses_agents_symlink() {
 }
 
 #[test]
-fn c4_check_fails_with_corrupt_installed_skill() {
+fn c5_check_fails_with_corrupt_installed_skill() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
@@ -2018,7 +2018,7 @@ fn m5_skill_sync_keeps_missing_local_source_local() {
 }
 
 #[test]
-fn m2_skill_verify_requires_manifest() {
+fn m6_skill_verify_requires_manifest() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project)

--- a/tests/acceptance_traceability.rs
+++ b/tests/acceptance_traceability.rs
@@ -1,0 +1,95 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+
+fn contract_id(value: &str) -> Option<String> {
+    let id = value.trim().to_ascii_uppercase();
+    let mut chars = id.chars();
+    if !chars.next().is_some_and(|ch| ch.is_ascii_alphabetic()) {
+        return None;
+    }
+    if !chars.next().is_some_and(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    if !chars.all(|ch| ch.is_ascii_alphanumeric()) {
+        return None;
+    }
+    Some(id)
+}
+
+fn sensor_override(expectation: &str) -> Option<Option<String>> {
+    let (_, suffix) = expectation.split_once("Sensor: ")?;
+    let value = suffix
+        .split(|ch: char| ch == '.' || ch == ' ' || ch == ')')
+        .next()
+        .expect("sensor marker has a value");
+    if value.eq_ignore_ascii_case("manual") {
+        Some(None)
+    } else {
+        Some(Some(
+            contract_id(value).unwrap_or_else(|| panic!("invalid sensor id {value:?}")),
+        ))
+    }
+}
+
+#[test]
+fn acceptance_rows_and_test_sensors_remain_traceable() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let acceptance = fs::read_to_string(root.join("ACCEPTANCE.md")).expect("read ACCEPTANCE.md");
+    let tests =
+        fs::read_to_string(root.join("tests/acceptance.rs")).expect("read tests/acceptance.rs");
+
+    let mut rows = BTreeMap::<String, String>::new();
+    for line in acceptance.lines().filter(|line| line.starts_with('|')) {
+        let cells: Vec<_> = line.split('|').map(str::trim).collect();
+        let Some(id) = cells.get(1).and_then(|cell| contract_id(cell)) else {
+            continue;
+        };
+        let expectation = cells.get(3).copied().unwrap_or_default();
+        assert!(
+            rows.insert(id.clone(), expectation.to_owned()).is_none(),
+            "duplicate acceptance row {id}"
+        );
+    }
+
+    let mut sensors = BTreeMap::<String, String>::new();
+    for line in tests.lines().map(str::trim) {
+        let Some(function) = line
+            .strip_prefix("fn ")
+            .and_then(|line| line.split('(').next())
+        else {
+            continue;
+        };
+        let Some(id) = function.split('_').next().and_then(contract_id) else {
+            continue;
+        };
+        assert!(
+            sensors.insert(id.clone(), function.to_owned()).is_none(),
+            "duplicate acceptance test id {id}"
+        );
+    }
+
+    let mut referenced = BTreeSet::new();
+    for (row, expectation) in &rows {
+        let sensor = match sensor_override(expectation) {
+            Some(sensor) => sensor,
+            None => Some(row.clone()),
+        };
+        if let Some(sensor) = sensor {
+            assert!(
+                sensors.contains_key(&sensor),
+                "acceptance row {row} names missing sensor {sensor}"
+            );
+            referenced.insert(sensor);
+        }
+    }
+
+    let orphaned: Vec<_> = sensors
+        .keys()
+        .filter(|id| !referenced.contains(*id))
+        .collect();
+    assert!(
+        orphaned.is_empty(),
+        "acceptance tests without a row or explicit sensor reference: {orphaned:?}"
+    );
+}


### PR DESCRIPTION
## What changed

- reconcile acceptance rows with executable sensor identifiers
- give the colliding C4, M2, and R2 tests truthful unique IDs
- document intentional K1 coverage for K2 and K3 and expose remaining manual or partial gaps
- add a deterministic repository-local traceability guard
- update the testing map and refactor record

## Why

The acceptance map had drifted from the executable suite. Duplicate identifiers, orphaned tests, and one semantic collision made green test results less trustworthy as evidence for specific contracts.

## Impact

Runtime behavior is unchanged. The locked test gate now rejects duplicate or orphaned acceptance sensor identifiers and missing named sensors while retaining explicit bundled coverage.

## Validation

- `cargo fmt --check`
- `cargo test --locked` (59 unit, 117 behavioral acceptance, 1 traceability)
- `git diff --check`
