### PR TITLE
Prevent partial skill refresh updates

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -216,6 +216,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | P5 | `skill refresh` when library body diverges from project | Exit ≠ 0; "library diverges"; project unchanged |
 | P6 | `skill refresh` when upstream revision moves but skill tree bytes match | Exit 0; bumps project + library receipts |
 | P7 | `skill refresh` when project already at HEAD but library is stale | Exit 0; repairs library from project |
+| P8 | `skill refresh` for all when a later imported skill has local modifications | Exit ≠ 0; no project skill is updated |
 
 ### Remove
 

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -46,11 +46,35 @@ fn checkout_reference_skill(
     Ok((checkout, Some(temp)))
 }
 
-/// Returns whether the installed skill tree changed (receipt-only bumps are false).
-fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
+enum RefreshPlan {
+    Local {
+        name: String,
+    },
+    Unchanged {
+        installed: Skill,
+    },
+    Update {
+        installed: Skill,
+        new_skill: Skill,
+        next: Provenance,
+        tree_changed: bool,
+        _clone_temp: TempDir,
+    },
+}
+
+impl RefreshPlan {
+    fn name(&self) -> &str {
+        match self {
+            Self::Local { name } => name,
+            Self::Unchanged { installed } | Self::Update { installed, .. } => &installed.name,
+        }
+    }
+}
+
+fn prepare_refresh(installed: Skill) -> Result<RefreshPlan, Error> {
     let name = installed.name.clone();
-    let Some(provenance) = provenance::read(installed)? else {
-        return Ok(None);
+    let Some(provenance) = provenance::read(&installed)? else {
+        return Ok(RefreshPlan::Local { name });
     };
     let remote = sources::parse_remote(&provenance["source"])?;
     let destination_root = installed
@@ -60,7 +84,7 @@ fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
         .to_path_buf();
 
     // Keep clone (and optional worktree) alive for the whole update.
-    let (_clone_temp, current_repository, current_revision) = git::checkout(&remote)?;
+    let (clone_temp, current_repository, current_revision) = git::checkout(&remote)?;
     let current_repository = current_repository
         .canonicalize()
         .map_err(|e| Error::msg(format!("repository: {e}")))?;
@@ -93,9 +117,7 @@ fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
     }
 
     if current_revision == provenance["revision"] {
-        // No upstream move — still keep the library honest.
-        library::sync_from_installed(installed)?;
-        return Ok(Some(false));
+        return Ok(RefreshPlan::Unchanged { installed });
     }
 
     let new_skill = skills::read_skill(
@@ -114,9 +136,40 @@ fn refresh_one(installed: &Skill) -> Result<Option<bool>, Error> {
 
     let tree_changed = !skills::skill_contents_equal(&old_skill.path, &new_skill.path)?;
     library::preflight_refresh(&installed.path, &new_skill, &next)?;
-    let _installed = skills::replace_verified(&new_skill, &destination_root, &next)?;
-    library::deposit_refresh(&new_skill, &next)?;
-    Ok(Some(tree_changed))
+    Ok(RefreshPlan::Update {
+        installed,
+        new_skill,
+        next,
+        tree_changed,
+        _clone_temp: clone_temp,
+    })
+}
+
+/// Returns whether the installed skill tree changed (receipt-only bumps are false).
+fn apply_refresh(plan: RefreshPlan) -> Result<Option<bool>, Error> {
+    match plan {
+        RefreshPlan::Local { .. } => Ok(None),
+        RefreshPlan::Unchanged { installed } => {
+            // No upstream move — still keep the library honest.
+            library::sync_from_installed(&installed)?;
+            Ok(Some(false))
+        }
+        RefreshPlan::Update {
+            installed,
+            new_skill,
+            next,
+            tree_changed,
+            ..
+        } => {
+            let destination_root = installed
+                .path
+                .parent()
+                .ok_or_else(|| Error::msg("skill has no parent"))?;
+            let _installed = skills::replace_verified(&new_skill, destination_root, &next)?;
+            library::deposit_refresh(&new_skill, &next)?;
+            Ok(Some(tree_changed))
+        }
+    }
 }
 
 pub fn refresh_skill(root: &Path, name: &str) -> Result<bool, Error> {
@@ -127,7 +180,7 @@ pub fn refresh_skill(root: &Path, name: &str) -> Result<bool, Error> {
     let installed = skills
         .get(name)
         .ok_or_else(|| Error::msg(format!("Installed skill not found: {name}")))?;
-    match refresh_one(installed)? {
+    match apply_refresh(prepare_refresh(installed.clone())?)? {
         None => Err(Error::msg(format!(
             "Local skill has no remote source: {name}"
         ))),
@@ -140,15 +193,20 @@ pub fn refresh_skill(root: &Path, name: &str) -> Result<bool, Error> {
 
 pub fn refresh_all(root: &Path) -> Result<Vec<String>, Error> {
     let installed = check::check_project(root)?;
+    let plans = installed
+        .into_iter()
+        .map(prepare_refresh)
+        .collect::<Result<Vec<_>, _>>()?;
     let mut refreshed = Vec::new();
-    for skill in &installed {
-        match refresh_one(skill)? {
+    for plan in plans {
+        let name = plan.name().to_string();
+        match apply_refresh(plan)? {
             Some(true) => {
-                catalog::deposit_skill(root, &skill.name)?;
-                refreshed.push(skill.name.clone());
+                catalog::deposit_skill(root, &name)?;
+                refreshed.push(name);
             }
             Some(false) => {
-                catalog::deposit_skill(root, &skill.name)?;
+                catalog::deposit_skill(root, &name)?;
             }
             None => {}
         }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -3111,6 +3111,61 @@ fn p6_refresh_identical_tree_new_revision_bumps_receipts() {
     assert!(archive_receipt.contains(&new_rev));
 }
 
+#[test]
+fn p8_refresh_all_preflights_before_updating_any_skill() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+
+    let remote = ws.root.join("remote-repo");
+    init_repo(&remote);
+    write_skill(&remote.join("skills/aaa-clean"), "aaa-clean", "v1");
+    write_skill(&remote.join("skills/zzz-dirty"), "zzz-dirty", "v1");
+    commit_all(&remote, "v1");
+    let public = "https://github.com/example/skills.git";
+    let redirect = github_redirect(&remote, public);
+
+    for name in ["aaa-clean", "zzz-dirty"] {
+        let mut add = ws.cmd(&project);
+        add.args(["skill", "add", "example/skills", "--skill", name]);
+        for (k, v) in &redirect {
+            add.env(k, v);
+        }
+        add.assert().success();
+    }
+
+    write_skill(&remote.join("skills/aaa-clean"), "aaa-clean", "v2");
+    write_skill(&remote.join("skills/zzz-dirty"), "zzz-dirty", "v2");
+    commit_all(&remote, "v2");
+
+    let dirty = Workspace::skill_path(&project, "zzz-dirty").join("SKILL.md");
+    let mut body = fs::read_to_string(&dirty).unwrap();
+    body.push_str("\nlocal edit\n");
+    fs::write(&dirty, body).unwrap();
+
+    let mut refresh = ws.cmd(&project);
+    refresh.args(["skill", "refresh"]);
+    for (k, v) in &redirect {
+        refresh.env(k, v);
+    }
+    refresh
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("local modifications"));
+
+    let clean =
+        fs::read_to_string(Workspace::skill_path(&project, "aaa-clean").join("SKILL.md")).unwrap();
+    assert!(clean.contains("v1"), "earlier skill must remain at v1");
+    assert!(
+        !clean.contains("v2"),
+        "refresh-all must not partially apply"
+    );
+    assert!(
+        fs::read_to_string(dirty).unwrap().contains("local edit"),
+        "dirty skill must remain untouched"
+    );
+}
+
 // --- D*: destroy ---
 
 #[test]


### PR DESCRIPTION
## What changed

- split skill refresh into preparation and application phases
- preflight every imported skill before replacing any project skill during `tink skill refresh`
- add acceptance contract P8 and a two-skill regression test

## Why

Refresh-all previously updated skills sequentially. If an earlier clean skill updated successfully and a later skill contained local modifications, the command exited with a refusal after already partially changing the project.

The new preparation phase retains verified upstream candidates in temporary checkouts. Application starts only after every imported skill passes preflight, so a later local-modification refusal leaves all project skills unchanged.

## Impact

`tink skill refresh NAME` keeps its existing behavior. An all-skill refresh now fails before project updates when any imported skill cannot safely refresh.

This prevents the confirmed partial-update failure while preserving local edits and existing library/catalog synchronization.

## Validation

- `cargo fmt -- --check`
- `cargo check --all-targets --all-features`
- `cargo test --all-targets --all-features` (178 passed)
- `git diff --check`
- `tink skill check` (`OK 15 skill(s)`)

Clippy was unavailable because the installed Rust toolchain does not include the component.