### PR TITLE
Harden CLI integrity and release reliability

### DIFF
--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -1,7 +1,8 @@
 name: bump-release
 
-# Every push to main ships a patch release: bump Cargo version, tag, then
-# dispatch the existing tag/ref-based release workflow.
+# Every push to main ships a patch release after the quality and native-platform
+# gates: bump Cargo version, atomically publish main plus its tag, then dispatch
+# the tag/ref-based release workflow.
 # GITHUB_TOKEN pushes do not re-trigger workflows; we still skip our own
 # release commits and dispatch release.yml explicitly.
 
@@ -14,28 +15,87 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 jobs:
-  bump:
+  verify:
     if: "${{ !startsWith(github.event.head_commit.message, 'chore: release v') }}"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Install Rust
+      - name: Install Rust 1.95.0
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          toolchain: stable
-          components: rustfmt
+          toolchain: 1.95.0
+          components: rustfmt, clippy
 
       - name: Verify
         run: |
-          cargo fmt --check
-          cargo test --locked
+          cargo fmt --all -- --check
+          cargo check --workspace --all-targets --locked
+          cargo clippy --workspace --all-targets --locked -- -D warnings
+          cargo test --workspace --all-targets --locked
+          cargo test --workspace --locked --doc
+          cargo build --workspace --release --locked
+          sh -n install.sh
+          shellcheck -x install.sh
+
+  audit:
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: release v') }}"
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Dependency audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  platform:
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: release v') }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-15
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.95.0
+          targets: ${{ matrix.target }}
+
+      - name: Test
+        run: cargo test --workspace --all-targets --locked --target ${{ matrix.target }}
+
+      - name: Build release
+        run: cargo build --workspace --release --locked --target ${{ matrix.target }}
+
+  bump:
+    needs: [verify, audit, platform]
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: release v') }}"
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
 
       - name: Bump patch, tag, and dispatch release
         env:
@@ -44,6 +104,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main --tags
 
           current="$(sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)"/\1/p' Cargo.toml | head -n1)"
           if [ -z "${current}" ]; then
@@ -51,13 +112,54 @@ jobs:
             exit 1
           fi
 
+          current_tag="v${current}"
+          if git rev-parse --verify --quiet "refs/tags/${current_tag}" >/dev/null; then
+            current_tagged_version="$(git show "${current_tag}:Cargo.toml" | sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)"/\1/p' | head -n1)"
+            if [ "${current_tagged_version}" != "${current}" ]; then
+              echo "Existing tag ${current_tag} does not contain Cargo version ${current}" >&2
+              exit 1
+            fi
+            current_tag_commit="$(git rev-parse "${current_tag}^{commit}")"
+            if ! git merge-base --is-ancestor "${current_tag_commit}" origin/main; then
+              echo "Existing tag ${current_tag} is not contained in origin/main" >&2
+              exit 1
+            fi
+            current_release_draft="$(gh release view "${current_tag}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+            if [ "${current_release_draft}" != "false" ]; then
+              gh workflow run release.yml --ref "${current_tag}"
+              echo "Re-dispatched incomplete release ${current_tag}; rerun this bump after it publishes." >&2
+              exit 1
+            fi
+          fi
+
           IFS=. read -r major minor patch <<< "${current}"
           new="${major}.${minor}.$((patch + 1))"
           tag="v${new}"
 
           if git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
-            echo "Tag ${tag} already exists; skipping."
+            tagged_version="$(git show "${tag}:Cargo.toml" | sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)"/\1/p' | head -n1)"
+            if [ "${tagged_version}" != "${new}" ]; then
+              echo "Existing tag ${tag} does not contain Cargo version ${new}" >&2
+              exit 1
+            fi
+            tag_commit="$(git rev-parse "${tag}^{commit}")"
+            if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+              echo "Existing tag ${tag} is not contained in origin/main" >&2
+              exit 1
+            fi
+            release_draft="$(gh release view "${tag}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+            if [ "${release_draft}" = "false" ]; then
+              echo "Release ${tag} is already published."
+              exit 0
+            fi
+            gh workflow run release.yml --ref "${tag}"
+            echo "Re-dispatched incomplete release ${tag}."
             exit 0
+          fi
+
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+            echo "origin/main advanced after this workflow started; a newer run owns the next bump" >&2
+            exit 1
           fi
 
           sed -i "s/^version = \"${current}\"/version = \"${new}\"/" Cargo.toml
@@ -79,8 +181,7 @@ jobs:
           git add Cargo.toml Cargo.lock
           git commit -m "chore: release v${new}"
           git tag "${tag}"
-          git push origin HEAD:main
-          git push origin "${tag}"
+          git push --atomic origin HEAD:main "refs/tags/${tag}:refs/tags/${tag}"
 
           # Token pushes do not cascade to on.push.tags; dispatch explicitly.
           gh workflow run release.yml --ref "${tag}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: 1.95.0
+          components: rustfmt, clippy
+
+      - name: Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check
+        run: cargo check --workspace --all-targets --locked
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+      - name: Installer lint
+        run: |
+          sh -n install.sh
+          shellcheck -x install.sh
+
+      - name: Documentation tests
+        run: cargo test --workspace --locked --doc
+
+  audit:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Dependency audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  platform:
+    name: ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-15
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04-arm
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: 1.95.0
+          targets: ${{ matrix.target }}
+
+      - name: Test
+        run: cargo test --workspace --all-targets --locked --target ${{ matrix.target }}
+
+      - name: Release build
+        run: cargo build --workspace --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,45 +6,103 @@ on:
       - "v*"
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  quality:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Validate release ref
+        env:
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+
+          ref_name = os.environ["RELEASE_REF_NAME"]
+          if os.environ["RELEASE_REF_TYPE"] != "tag" or not ref_name.startswith("v"):
+              raise SystemExit("release workflow must run from a v-prefixed tag")
+          with open("Cargo.toml", encoding="utf-8") as source:
+              manifest = source.read()
+          package = re.search(r"(?ms)^\[package\]\s*$.*?^version\s*=\s*\"([^\"]+)\"\s*$", manifest)
+          if package is None:
+              raise SystemExit("could not read [package] version from Cargo.toml")
+          package_version = package.group(1)
+          if ref_name[1:] != package_version:
+              raise SystemExit(
+                  f"release tag {ref_name} does not match Cargo.toml version {package_version}"
+              )
+          PY
+
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: 1.95.0
+          components: rustfmt, clippy
+
+      - name: Verify
+        run: |
+          cargo fmt --all -- --check
+          cargo check --workspace --all-targets --locked
+          cargo clippy --workspace --all-targets --locked -- -D warnings
+          cargo test --workspace --all-targets --locked
+          cargo test --workspace --locked --doc
+          sh -n install.sh
+          shellcheck -x install.sh
+
+  audit:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Dependency audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: ${{ matrix.target }}
+    needs: [quality, audit]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-15-intel
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04
-            cross: true
+            os: ubuntu-22.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust 1.95.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
         with:
+          toolchain: 1.95.0
           targets: ${{ matrix.target }}
 
-      - name: Install aarch64 Linux linker
-        if: matrix.cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Test
+        run: cargo test --workspace --all-targets --locked --target ${{ matrix.target }}
 
       - name: Build
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --release --locked --target ${{ matrix.target }}
+        run: cargo build --workspace --release --locked --target ${{ matrix.target }}
 
       - name: Package
         run: |
@@ -57,7 +115,7 @@ jobs:
           echo "ASSET=dist/${ASSET}" >> "$GITHUB_ENV"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: tink-${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -66,11 +124,13 @@ jobs:
     name: publish release
     needs: build
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
@@ -79,6 +139,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
           VERSION="${GITHUB_REF_NAME#v}"
           NOTES="tink ${VERSION}
 
@@ -92,7 +154,92 @@ jobs:
           tink update
           \`\`\`
           "
-          gh release create "$GITHUB_REF_NAME" \
-            artifacts/*.tar.gz \
+
+          expected_assets=(
+            "artifacts/tink-${VERSION}-aarch64-apple-darwin.tar.gz"
+            "artifacts/tink-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+            "artifacts/tink-${VERSION}-x86_64-apple-darwin.tar.gz"
+            "artifacts/tink-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          )
+          expected_names=()
+          expected_uploads=()
+          for asset in "${expected_assets[@]}"; do
+            if [ ! -f "${asset}" ] || [ -L "${asset}" ]; then
+              echo "Missing regular release artifact: ${asset}" >&2
+              exit 1
+            fi
+            name="${asset##*/}"
+            digest="sha256:$(sha256sum "${asset}" | awk '{print $1}')"
+            expected_names+=("${name}")
+            expected_uploads+=("${name}"$'\t'"uploaded"$'\t'"${digest}")
+          done
+
+          actual_assets=()
+          mapfile -t actual_assets < <(find artifacts -maxdepth 1 -type f -printf '%f\n' | sort)
+          if [ "${#actual_assets[@]}" -ne "${#expected_names[@]}" ]; then
+            echo "Downloaded artifact inventory does not contain exactly four assets" >&2
+            exit 1
+          fi
+          for index in "${!expected_names[@]}"; do
+            if [ "${actual_assets[$index]}" != "${expected_names[$index]}" ]; then
+              echo "Unexpected downloaded release artifact: ${actual_assets[$index]}" >&2
+              exit 1
+            fi
+          done
+
+          release_draft="$(gh release view "${tag}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+          if [ "${release_draft}" = "false" ]; then
+            published_assets=()
+            mapfile -t published_assets < <(
+              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+                --jq '.assets[] | [.name, .state, (.digest // "")] | @tsv' |
+                sort
+            )
+            if [ "${#published_assets[@]}" -ne "${#expected_names[@]}" ]; then
+              echo "Published release ${tag} has an incomplete asset inventory" >&2
+              exit 1
+            fi
+            for index in "${!expected_names[@]}"; do
+              IFS=$'\t' read -r name state digest <<<"${published_assets[$index]}"
+              if [ "${name}" != "${expected_names[$index]}" ] || \
+                [ "${state}" != "uploaded" ] || \
+                [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "Published release ${tag} has unexpected or unverifiable assets" >&2
+                exit 1
+              fi
+            done
+            echo "Release ${tag} is already complete."
+            exit 0
+          fi
+
+          if [ -z "${release_draft}" ]; then
+            gh release create "${tag}" \
+              --verify-tag --draft \
+              --title "tink ${VERSION}" \
+              --notes "$NOTES"
+          elif [ "${release_draft}" != "true" ]; then
+            echo "Could not determine release state for ${tag}" >&2
+            exit 1
+          fi
+
+          gh release upload "${tag}" "${expected_assets[@]}" --clobber
+          uploaded_assets=()
+          mapfile -t uploaded_assets < <(
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+              --jq '.assets[] | [.name, .state, (.digest // "")] | @tsv' |
+              sort
+          )
+          if [ "${#uploaded_assets[@]}" -ne "${#expected_uploads[@]}" ]; then
+            echo "Release asset state or digest does not match the local artifact" >&2
+            exit 1
+          fi
+          for index in "${!expected_uploads[@]}"; do
+            if [ "${uploaded_assets[$index]}" != "${expected_uploads[$index]}" ]; then
+              echo "Release asset state or digest does not match the local artifact" >&2
+              exit 1
+            fi
+          done
+
+          gh release edit "${tag}" --draft=false --latest \
             --title "tink ${VERSION}" \
             --notes "$NOTES"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,9 @@ jobs:
     name: publish release
     needs: build
     runs-on: ubuntu-22.04
+    concurrency:
+      group: tink-release-publication
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -187,6 +190,28 @@ jobs:
             fi
           done
 
+          latest_tag="$(gh release view --json tagName --jq '.tagName' 2>/dev/null || true)"
+          if [ -n "${latest_tag}" ] && [ "${latest_tag}" != "${tag}" ]; then
+            if ! python3 - "${VERSION}" "${latest_tag}" <<'PY'
+          import re
+          import sys
+
+          target, latest_tag = sys.argv[1:]
+          pattern = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+          if not latest_tag.startswith("v") or pattern.fullmatch(latest_tag[1:]) is None:
+              raise SystemExit(1)
+          if pattern.fullmatch(target) is None:
+              raise SystemExit(1)
+          target_version = tuple(int(part) for part in target.split("."))
+          latest_version = tuple(int(part) for part in latest_tag[1:].split("."))
+          raise SystemExit(0 if target_version > latest_version else 1)
+          PY
+            then
+              echo "Refusing to publish older release ${tag} over latest ${latest_tag}" >&2
+              exit 1
+            fi
+          fi
+
           release_draft="$(gh release view "${tag}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
           if [ "${release_draft}" = "false" ]; then
             published_assets=()
@@ -200,10 +225,7 @@ jobs:
               exit 1
             fi
             for index in "${!expected_names[@]}"; do
-              IFS=$'\t' read -r name state digest <<<"${published_assets[$index]}"
-              if [ "${name}" != "${expected_names[$index]}" ] || \
-                [ "${state}" != "uploaded" ] || \
-                [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              if [ "${published_assets[$index]}" != "${expected_uploads[$index]}" ]; then
                 echo "Published release ${tag} has unexpected or unverifiable assets" >&2
                 exit 1
               fi

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -289,6 +289,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | U15 | Interrupt `tink update` while its release candidate is running | Exit ≠ 0; terminate the candidate process group; preserve the running binary |
 | U16 | `tink update` runs from a path containing terminal control characters | Exit 0 for an up-to-date binary; stdout renders controls as visible escapes with one stable output row |
 | U17 | `install.sh` receives a candidate whose probe output exceeds the capture limit | Reject before publication within the bounded probe budget; retain at most 16 MiB per stream; preserve the existing binary |
+| U18 | The installer candidate signals the supervisor while the candidate process is still being spawned | Exit nonzero without traceback; terminate and reap the candidate process group; preserve the existing binary |
 
 ### Safety (cross-cutting)
 

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -9,15 +9,24 @@ harness locations into that library (create-only), and can update the CLI binary
 from GitHub Releases via `tink update`.
 
 **Authority:** This file is the evaluator. A row is complete when its named automated
-sensor passes on macOS with `git` on `PATH`. Rows explicitly marked
+sensor passes on a supported CI host with `git` on `PATH`. Rows explicitly marked
 `Sensor: manual` remain known gaps rather than implied automated proof.
 
-**Delivery gate:** The automatic `main`-push release path runs formatting and
-tests on Ubuntu before version, tag, push, or dispatch mutations. Direct tag
-pushes and manual release dispatches remain outside that behavior gate.
+**Delivery gate:** Pull requests and `main` run the pinned Rust 1.95.0 formatting,
+check, Clippy (`-D warnings`), documentation, audit, test, and release-build gates.
+Native tests and release builds cover macOS and Linux on x86_64 and arm64. The
+tag release workflow (including a manual dispatch from the matching `v*` tag)
+repeats the quality gate before building all four artifacts.
 
 **Out of v1:** weekly GitHub update workflows, private GitHub auth, Windows,
-branch-wide Linux CI beyond the automatic release gate, pruning the library.
+pruning the library, concurrent Tink mutations in one project/home, and
+cross-filesystem rollback after an unexpected I/O failure. Expected validation
+and ownership failures are preflighted before multi-skill publication; rerunning
+an interrupted idempotent command is the recovery model.
+
+**Process contract:** Success data and summaries go to stdout; warnings and
+errors go to stderr. Command failures exit 1, Clap usage errors exit 2, and a
+closed stdout is a normal pipeline termination that exits 0 without panic.
 
 **Dogfood:** Prefer an installed `tink` from this repo, or `cargo run -q -- …`.
 
@@ -41,8 +50,8 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
 | `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` and drop that name from the by-project catalog (not library) |
 | `tink inspect <GITHUB_URL>` | Inspect skills and source-defined skillsets in a public GitHub URL without writing project or home state |
-| `tink update` | Replace this binary with the latest public GitHub Release (requires `curl` + `tar`) |
-| `tink destroy [--yes]` | Remove `.agents/`, `ZEN.md`, and `AGENTS.md`; drop this project's by-project catalog entry (not library) |
+| `tink update` | Replace this binary with a newer verified public GitHub Release (requires `curl` + `tar`) |
+| `tink destroy [--yes]` | Remove `.agents/skills/` and an empty `.agents/`; preserve `AGENTS.md`, `ZEN.md`, unrelated `.agents/` siblings, and the library; drop this project's catalog entry |
 
 ## On-disk contracts
 
@@ -52,7 +61,9 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | Receipt | `.tink-source.json` with exactly `source`, `revision`, `path` (non-empty strings) |
 | Home root | `$TINK_HOME` or `~/.tink` (relative `$TINK_HOME` absolutized against cwd), with `layout.json` (`kind`: `tink-skill-inventory`) |
 | Library | `skills/<name>/` skill trees copied on successful add (rebuildable collection; identical tip may install project from library; divergent → repair + warn; project overwrite still refused; not an agent discovery root) |
-| Offline catalog | `catalog/by-project/<project>/meta.json` with `name`, `root`, `skills` name list (not skill trees); `skill remove` drops a name; `destroy` drops the project entry |
+| Offline catalog | `catalog/by-project/<bounded-name>-<sha256(raw-canonical-root)>/meta.json` with display `name`, `root`, raw-path `identity`, and `skills` name list; owned basename-only entries migrate on the next deposit |
+| Project lock | `.tink/skills.lock` version 2; a domain-separated, length-framed SHA-256 pins path bytes, entry kind, canonical executable/non-executable mode, and contents (receipt excluded). Version 1 must be regenerated with `skill lock`. |
+| Skillset receipt | `.tink-skillset.json` digest version 2 pins the same tree semantics; `skillset refresh` is the migration path for a legacy receipt. |
 
 ## Rows
 
@@ -86,6 +97,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | A4 | `skill add` skill tree containing a symlink | Exit ≠ 0; refuse |
 | A5 | `skill add` multi-skill source without `--skill` | Exit ≠ 0; lists choices |
 | A6 | `skill add` when library has same name but different tree (project missing) | Exit 0; installs project; repairs library; warns on stderr that the home copy was updated |
+| A6B | Close stderr while `skill add` emits its post-repair warning | Exit 0 after the completed project/library/catalog mutation; advisory output failure cannot create retry ambiguity |
 | A7 | `skill add` skill named `by-project` | Exit ≠ 0; reserved name; no project/library write |
 | A8 | `skill add` same GitHub tip already in library | Exit 0; installs project from library (no clone); stdout notes library |
 | A9 | `skill add` when catalog metadata is malformed, repair the catalog, then rerun the same command | First run fails after preserving valid project/library copies; second run exits 0, catalogs the skill, and leaves those copies byte-identical |
@@ -93,6 +105,9 @@ Ids are stable. Tests must name or comment the id they prove.
 | A11 | `skill add` when the matching project target is a symlink | Exit ≠ 0; leaves the symlink untouched; creates no library or catalog entry |
 | A12 | `skill add` with `TINK_HOME` pointed at an unrelated non-empty directory | Exit ≠ 0; refuses to claim the directory and leaves its existing files byte-identical |
 | A13 | `skill add owner/repo` when one non-root remote skill at the same tip is already in the library | Exit 0 without cloning; installs from library and reports that source |
+| A14 | `skill add` regular executable and non-executable files | Preserves executable semantics in project and library using portable `0o755`/`0o644` modes while stripping special bits and umask-only variation |
+| A15 | `skill add` a tree with two distinct non-UTF-8 Unix filenames | On filesystems that admit opaque names, preserves both names and their distinct contents in project and library; macOS/APFS may reject the fixture before Tink writes |
+| A16 | `skill add` a standalone-looking source with a regular or dangling `.tink-skillset.json` entry | Exit ≠ 0 before project, home, library, or catalog creation; direct the user to `tink skillset add NAME` |
 
 ### Remote add
 
@@ -115,7 +130,7 @@ Ids are stable. Tests must name or comment the id they prove.
 
 | Id | Action | Expect |
 |---|---|---|
-| K1 | `skillset add <name>-skillset` with `$TINK_HOME/catalog/by-skillset/<name>-skillset/meta.json` | Installs the pinned members under `.agents/skills/<name>-skillset/`, validates the project, then mirrors that exact tree to `$TINK_HOME/skills/<name>-skillset/`; matching re-add is a no-op; library drift is repaired from the valid project |
+| K1 | `skillset add <name>-skillset` with `$TINK_HOME/catalog/by-skillset/<name>-skillset/meta.json` | Installs the pinned members under `.agents/skills/<name>-skillset/`, writes a mode-aware digest-version-2 receipt, validates the project, then mirrors that exact tree to `$TINK_HOME/skills/<name>-skillset/`; matching re-add is a no-op; library drift is repaired from the valid project |
 | K2 | `skillset remove <name>-skillset` after K1 | Removes only the project skillset tree; preserves the shared catalog definition and home library copy; `skill remove` refuses the skillset root. Sensor: K1. |
 | K3 | `skillset list [--library]` after K1 | Groups each receipt-backed project or library skillset with its member skill names without network or writes. Sensor: K1. |
 | K4 | Any skillset command receives a name without `-skillset` | Exit ≠ 0; clear canonical-name error; no skillset tree written |
@@ -124,7 +139,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | K7 | `skillset list` or `add` runs before project/catalog setup | List explains how to initialize; missing catalog leaves the project untouched |
 | K8 | Re-add a valid unchanged project skillset while its remote is unavailable | Succeeds offline as unchanged and synchronizes the library from the project |
 | K9 | `skill check` / `skill list` with grouped members only | Check reports standalone, skillset, and member counts; list says there are no standalone skills and points to `skillset list` |
-| K10 | `skillset refresh <name>-skillset` after the pinned catalog definition changes | Atomically replaces the clean project tree, then mirrors the validated result to the library; refuses local project modifications |
+| K10 | `skillset refresh <name>-skillset` after the pinned catalog definition changes | Stages and rename-replaces the clean project tree with best-effort rollback, then mirrors the validated result to the library; refuses local project modifications |
 | K11 | A declared member folder and its `SKILL.md` name differ | Exit ≠ 0 before project or library publication; explain the name mismatch |
 
 ### GitHub inspection
@@ -143,6 +158,8 @@ Ids are stable. Tests must name or comment the id they prove.
 | G6 | `inspect` an empty valid directory | Succeeds with zero skills and a structural diagnostic |
 | G7 | `inspect` unsupported URLs, missing or ambiguous slash-containing refs, and missing boundaries | Exits nonzero with actionable errors |
 | G8 | `inspect` with existing project and home state | Leaves both project and `$TINK_HOME` absent or byte-for-byte unchanged |
+| G9 | Send SIGTERM only to `tink inspect` while its Git subprocess is running | Exits nonzero; terminates and reaps the Git process group; no delayed child side effect |
+| G10 | `inspect` a repository with control characters in a directory name | Succeeds without emitting raw terminal controls; path fields use visible backslash escapes |
 
 ### Check
 
@@ -164,6 +181,9 @@ Ids are stable. Tests must name or comment the id they prove.
 | M4 | `skill sync` after deleting locked embedded `manage-tink` | Restores the embedded skill; subsequent `skill verify` succeeds |
 | M5 | `skill sync` after a slash-containing local source disappears | Exit ≠ 0 as a missing local path; does not reinterpret it as GitHub shorthand |
 | M6 | `skill verify` without a project manifest | Exit ≠ 0; reports the missing manifest |
+| M7 | `skill sync` with a bad hash on a later locked skill | Exit ≠ 0 before any project, library, or catalog publication for earlier skills |
+| M8 | `skill sync` with a symlink or unsafe library target for a later locked skill | Exit ≠ 0 before publishing any earlier project, library, or catalog entry |
+| M9 | `skill verify` with a version-1 lockfile, followed by `skill lock` | Verify refuses the legacy ambiguous digest with an actionable relock instruction; lock rewrites version 2 and verify succeeds |
 
 ### List
 
@@ -171,13 +191,17 @@ Ids are stable. Tests must name or comment the id they prove.
 |---|---|---|
 | L1 | `skill list` after `init` | Exit 0; stdout includes `manage-tink` |
 | L2 | `skill list` without `.agents/skills` | Exit ≠ 0 |
-| L3 | `skill list --catalog` after init+add | Exit 0; header `project\\troot\\tskill` plus TSV rows for cataloged skills |
+| L3 | `skill list --catalog` after init+add | Exit 0; header `project\\troot\\tskill` plus three-column TSV rows for cataloged skills |
 | L4 | `skill list` when `ZEN.md` exists without `AGENTS.md` reference | Exit 0; lists skills; warns on stderr about ZEN/AGENTS; `skill check` still fails |
 | L5 | `skill list --stash` or `skill list --home` | Exit ≠ 0; stderr mentions the flag or unexpected argument (removed in 0.3.0; use `--library` / `--catalog`) |
 | L6 | `skill list --catalog` with valid and malformed project metadata | Exit 0; lists valid rows and omits malformed entries |
 | L7 | Insert a nested symlink into an installed standalone skill, then run `skill list` and `skill check` | Both exit ≠ 0 and mention the symlink; the installed tree is untouched |
 | L8 | `skill list --library` or `--catalog` with an existing non-empty unmarked `TINK_HOME` | Exit ≠ 0; refuses the unrelated directory and leaves it byte-identical |
 | L9 | `skill list --library` or `--catalog` when the corresponding direct home owner (`skills/` or `catalog/`) is a symlink | Exit ≠ 0; refuses the symlink without following or replacing it |
+| L10 | Two projects share a basename and use one Tink home | Both retain distinct catalog identities and appear with their own canonical root and skills |
+| L11 | A project directory name begins with `.` | Its hashed catalog identity remains visible in `skill list --catalog`; hidden project names are not mistaken for staging entries |
+| L12 | A cataloged project name or root contains tab, CR, LF, backslash, or another terminal control | `skill list --catalog` emits visible backslash escapes (including `\\t`, `\\r`, `\\n`, `\\\\`, and `\\x1b`); every data row remains exactly three TSV columns and contains no raw terminal controls |
+| L13 | `skill list --catalog` with no catalog entries | Exit 0; emits the TSV header and no data rows |
 
 ### Library
 
@@ -196,6 +220,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | H11 | A library root contains both `SKILL.md` and `.tink-skillset.json` | `skill list --library` excludes it; `skill add <name>` exits nonzero and directs the user to `tink skillset add <name>` |
 | H12 | `skill add <source>` would deposit a standalone skill over a receipt-bearing library root with the same name | Exit nonzero before project publication; preserve every existing library file and identify the standalone/skillset collision |
 | H13 | `skill add <source>` exactly matches a receipt-bearing library root with the same name | Do not reuse the managed root as a standalone cache hit; exit nonzero, preserve the library bytes, and publish no project tree |
+| H14 | `skill harvest` discovers a standalone-looking source with a regular or dangling `.tink-skillset.json` entry | Skip with actionable `skillset add` guidance; do not publish it into the standalone library or create project state |
 
 ### CLI surface
 
@@ -204,6 +229,9 @@ Ids are stable. Tests must name or comment the id they prove.
 | V1 | `skill add` local skill | Installs under `.agents/skills/<name>/` |
 | V2 | `skill check` after valid project | Exit 0; stdout includes `OK` |
 | V3 | Run top-level `--help`, then a project command, after each command's current directory is removed | Help succeeds without resolving a project; the project command fails closed with a current-directory error |
+| V4 | Close stdout before a successful listing command writes | Exit 0; no panic and no exit 101 |
+| V5 | Close stderr while an underlying command fails | Exit 1; diagnostic delivery failure does not hide the command failure |
+| V6 | Close `install.sh` stdout after a verified installation reaches advisory reporting | Exit 0 with the verified destination intact; broken advisory output cannot turn completed installation into retry ambiguity |
 
 ### Refresh
 
@@ -234,10 +262,11 @@ Ids are stable. Tests must name or comment the id they prove.
 
 | Id | Action | Expect |
 |---|---|---|
-| D1 | `destroy --yes` after `init --with-zen` (extra skill allowed) | Removes `.agents/`, `ZEN.md`, `AGENTS.md`; leaves library + `layout.json` intact; drops this project's by-project catalog entry (`skill list --catalog` has no rows for it) |
+| D1 | `destroy --yes` after `init --with-zen` (extra skill allowed) | Removes `.agents/skills/` and the now-empty `.agents/`; preserves `ZEN.md` and `AGENTS.md` byte-for-byte; leaves library + `layout.json` intact; drops this project's catalog entry |
 | D2 | `destroy` without `--yes` (non-TTY) | Exit ≠ 0; refuses without confirmation; project files unchanged |
 | D3 | `destroy --yes` when `.agents` is a symlink | Exit ≠ 0; mentions symlink |
 | D4 | `destroy --yes` when `$TINK_HOME/catalog` is a symlink | Exit ≠ 0; mentions the symlink; project scaffolding and external catalog target remain byte-identical |
+| D5 | `destroy --yes` when `.agents/` contains an unrelated sibling | Removes `.agents/skills/`, preserves the sibling byte-for-byte, and leaves `.agents/` in place |
 
 ### Update (CLI binary)
 
@@ -246,6 +275,18 @@ Ids are stable. Tests must name or comment the id they prove.
 | U1 | `update` when releases API is unreachable | Exit ≠ 0; clear download/metadata failure; binary unchanged |
 | U2 | `update` when latest release version matches this binary | Exit 0; stdout notes up to date; binary unchanged |
 | U3 | `update` when a newer release asset exists for this host | Exit 0; replaces the running binary; stdout notes updated version |
+| U4 | `update` receives a valid-digest archive whose payload fails the exact version probe | Exit ≠ 0; running binary remains byte-identical; no success output |
+| U5 | `update` metadata names an older semantic version | Exit ≠ 0; refuses downgrade before publication; running binary remains unchanged |
+| U6 | `install.sh` receives an invalid or non-executable verified payload while a binary exists | Exit ≠ 0; existing binary remains byte-identical; no success output |
+| U7 | `install.sh` receives a valid verified payload | Publishes with atomic replace semantics, probes the published path, exits 0, and prints the exact installed version |
+| U8 | `install.sh` receives malformed JSON or a non-SemVer tag | Exit ≠ 0 with a concise metadata error and no Python traceback; existing binary remains unchanged |
+| U9 | `install.sh` receives a credential-bearing or query-bearing release API URL | Exit ≠ 0 before network/filesystem mutation; stderr does not disclose credentials or query secrets |
+| U10 | `install.sh` receives a verified candidate whose version probe hangs | Terminates within the bounded probe budget, exits nonzero, and preserves the existing binary |
+| U11 | `install.sh` metadata uses non-ASCII digits in the semantic-version core | Exit ≠ 0 with a clean semantic-version error; existing binary remains unchanged |
+| U12 | `install.sh` candidate exits but leaves a descendant holding probe pipes | The five-second bound kills the process group, reaps the direct child, leaves no descendant side effect, and preserves the existing binary |
+| U13 | `install.sh` candidate passes staging probes but fails only at the published path | Exit ≠ 0; restore the prior binary bytes and executable mode; print no install success |
+| U14 | Interrupt `install.sh` while its release candidate is running | Exit ≠ 0 without a Python traceback; terminate the candidate process group; preserve the prior binary |
+| U15 | Interrupt `tink update` while its release candidate is running | Exit ≠ 0; terminate the candidate process group; preserve the running binary |
 
 ### Safety (cross-cutting)
 
@@ -258,7 +299,13 @@ Ids are stable. Tests must name or comment the id they prove.
 ## Proof
 
 ```console
-cargo test
+cargo fmt --all -- --check
+cargo check --workspace --all-targets --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --all-targets --locked
+cargo test --workspace --locked --doc
+cargo build --workspace --release --locked
+cargo audit --file Cargo.lock
 ```
 
 A row is done only when its named automated sensor passes. Explicit manual or partial

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -287,6 +287,8 @@ Ids are stable. Tests must name or comment the id they prove.
 | U13 | `install.sh` candidate passes staging probes but fails only at the published path | Exit ≠ 0; restore the prior binary bytes and executable mode; print no install success |
 | U14 | Interrupt `install.sh` while its release candidate is running | Exit ≠ 0 without a Python traceback; terminate the candidate process group; preserve the prior binary |
 | U15 | Interrupt `tink update` while its release candidate is running | Exit ≠ 0; terminate the candidate process group; preserve the running binary |
+| U16 | `tink update` runs from a path containing terminal control characters | Exit 0 for an up-to-date binary; stdout renders controls as visible escapes with one stable output row |
+| U17 | `install.sh` receives a candidate whose probe output exceeds the capture limit | Reject before publication within the bounded probe budget; retain at most 16 MiB per stream; preserve the existing binary |
 
 ### Safety (cross-cutting)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +580,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "signal-hook",
  "tempfile",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tink"
 version = "0.3.14"
 edition = "2024"
+rust-version = "1.95"
 description = "Install Agent Skills into a project's .agents/skills/"
 license = "MIT"
 repository = "https://github.com/jon-devlapaz/tink"
@@ -16,6 +17,7 @@ clap_complete = { version = "4.6.8", features = ["unstable-dynamic"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.151"
 sha2 = "0.10"
+signal-hook = "0.3.18"
 toml = "0.8"
 tempfile = "3.27.0"
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ curl -fsSL https://raw.githubusercontent.com/jon-devlapaz/tink/main/install.sh |
 ```
 
 That installs a release binary into `~/.local/bin/tink` (override with
-`TINK_INSTALL_DIR`). Requires `curl` and `tar`. Supported hosts: macOS and
-Linux on x86_64/arm64.
+`TINK_INSTALL_DIR`). Requires `curl`, `tar`, and Python 3. The installer checks
+GitHub's SHA-256 asset digest, accepts exactly one regular `tink` archive entry,
+probes the advertised version, and atomically replaces the destination.
+Supported hosts: macOS and Linux on x86_64/arm64.
 
 Update later with:
 
@@ -30,8 +32,8 @@ tink update
 
 ### From source
 
-You need a current Rust toolchain. For GitHub skill sources, `git` must be on
-`PATH`.
+The checkout pins Rust 1.95.0 with rustfmt and Clippy. For GitHub skill sources,
+`git` must be on `PATH`.
 
 ```console
 cargo install --git https://github.com/jon-devlapaz/tink.git --locked
@@ -151,6 +153,11 @@ tink skill remove skill-name
   install.
 - tink never inits Git, stages, commits, or pushes.
 
+Executable intent is preserved when Tink copies complete skill trees. Regular
+files are canonicalized to Git-portable `0644` or `0755` modes, while Unix path
+identity remains byte-exact even for non-UTF-8 names. Symlinks and special files
+are refused.
+
 ### Skillsets
 
 Skillset names are explicit and canonical: every name must end in `-skillset`;
@@ -195,14 +202,30 @@ tink destroy --yes
 tink update
 ```
 
+`tink skill list --catalog` always emits the `project`, `root`, `skill` TSV
+header, including for an empty catalog. Within fields, backslash, tab, carriage
+return, and newline are escaped as `\\\\`, `\\t`, `\\r`, and `\\n` so every
+skill remains one three-column row.
+
 **Breaking in 0.3.0:** `skill list --home` → `--catalog`; `skill list --stash` → `--library`. On-disk layout is still `$TINK_HOME/skills/` and `catalog/by-project/`. After a major CLI upgrade, refresh the live project skill: `tink skill remove manage-tink && tink init --no-zen --no-tink-skills`.
+
+Project lockfiles now use digest format/version 2 so file boundaries and Unix
+executable modes are actually pinned. An older lock is deliberately refused;
+run `tink skill lock` to regenerate it, then commit the result. Existing
+skillset receipts migrate through `tink skillset refresh NAME-skillset`.
 
 If the GitHub tip is already in the library and matches the tip byte-for-byte,
 `skill add` may install from the library. If a standalone library skill differs,
 tink repairs it and warns. A bare standalone skill name (not a path and not `owner/repo`) promotes from
 the library into the project. `skill remove` deletes the project skill
 directory and drops that name from the by-project catalog; it does not delete
-library trees. `destroy` also drops this project's catalog entry.
+library trees. `destroy` removes `.agents/skills/`, removes `.agents/` only when
+it is then empty, and drops this project's catalog entry. It preserves
+`AGENTS.md`, `ZEN.md`, unrelated `.agents/` siblings, and all library trees.
+
+Successful output goes to stdout; warnings and failures go to stderr. A closed
+stdout is normal pipeline termination (exit 0), while command and usage failures
+remain exit 1 and exit 2 respectively.
 
 ### Uninstall the CLI
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@ records intended CLI and on-disk behavior, the workflow files own delivery autom
 | `<project>/.tink/skills.toml` and `skills.lock` | `manifest.rs`, `sources.rs` | Project-owned standalone-skill intent and resolved pins for `lock`, `sync`, and `verify`. |
 | `$TINK_HOME/layout.json` and root directories | `home.rs` | Marks and migrates offline inventory; never an agent discovery root. |
 | `$TINK_HOME/skills/<name>/` | `library.rs`, `skillsets.rs` | Reusable standalone trees or derived skillset copies. A skillset receipt decides which lifecycle owns a root. |
-| `$TINK_HOME/catalog/by-project/<project>/meta.json` | `catalog.rs` | Derived project-name index. Add/refresh deposit names; remove/destroy withdraw them. It is not runtime state. |
+| `$TINK_HOME/catalog/by-project/<bounded-name>-<identity>/meta.json` | `catalog.rs` | Derived project-name index. `identity` is SHA-256 of the canonical project path (raw bytes on Unix), so same-basename projects do not collide. Add/refresh deposit names; remove/destroy withdraw them. It is not runtime state. |
 | `$TINK_HOME/catalog/by-skillset/<name>/meta.json` | `skillsets.rs` | Authored desired definition: HTTPS source, immutable revision, source root, and explicit members. Tink reads it but has no CLI writer for it. |
 | `.tink-source.json` | `provenance.rs` | Optional standalone remote provenance: source, revision, and path. It does not classify a root. |
 | `.tink-skillset.json` | `skillsets.rs` | Skillset ownership and digest evidence. Presence classifies; validated contents prove the installed tree. |
@@ -31,9 +31,9 @@ owners and should not carry architectural decisions.
 
 | Area | Modules | Responsibility |
 |---|---|---|
-| Process edge | `main.rs`, `lib.rs`, `style.rs`, `error.rs` | Completion and argument parsing, command dispatch, output narration, styling, and user-facing failure shape. |
+| Process edge | `main.rs`, `lib.rs`, `output.rs`, `style.rs`, `error.rs`, `process.rs` | Completion and argument parsing, command dispatch, fallible and control-safe output, user-facing failure/exit shape, and bounded subprocess-group supervision. |
 | Layout and persisted state | `home.rs`, `catalog.rs`, `manifest.rs`, `provenance.rs` | Project/home paths, project-name index, standalone manifest/lock, and source receipts. |
-| Skill mechanisms | `skills.rs`, `sources.rs`, `git.rs`, `paths.rs`, `library.rs` | Skill discovery/validation/copy/digest, typed source classification, Git checkout, filesystem refusals, and standalone library policy. |
+| Skill mechanisms | `skills.rs`, `sources.rs`, `git.rs`, `paths.rs`, `library.rs` | Skill discovery/validation/copy/digest, typed source classification, supervised Git checkout, filesystem refusals, and standalone library policy. |
 | Project workflows | `init.rs`, `add.rs`, `check.rs`, `refresh.rs`, `remove.rs`, `harvest.rs` | Bootstrap and the standalone skill lifecycle. |
 | Skillset workflow | `skillsets.rs` | Canonical names, definition validation, staged install/refresh, receipt validation, grouped listing, removal, and project-to-library mirroring. |
 | Read-only source inspection | `inspect.rs` | GitHub structure inspection and source-defined skillset inference; no project or home writes. |
@@ -50,10 +50,10 @@ roots, while `skillset list` provides the grouped member view.
 2. **Classification precedes trust.** `skillsets::has_receipt_entry` treats a
    `.tink-skillset.json` entry—including a dangling symlink—as a claim on the root.
    Parsing, member checks, and digest verification happen separately.
-3. **Existing managed roots route by receipt.** Project list/check/remove and library
-   list/load/deposit/cache operations route an existing receipt-classified root to the
-   skillset lifecycle. Standalone source discovery and project add preflight do not yet
-   provide the same categorical gate; see Known boundaries.
+3. **Managed roots route by receipt presence.** Project list/check/remove,
+   library list/load/deposit/cache, direct standalone add, manifest preparation, and
+   harvest classify a `.tink-skillset.json` entry before trusting its contents. A
+   regular or dangling receipt entry cannot cross a standalone publication boundary.
 4. **Standalone project state is protected first.** A source add rejects project
    divergence before it may repair the reusable library and publish the project name.
 5. **Installed skillsets flow project to library.** A skillset definition selects the
@@ -62,7 +62,18 @@ roots, while `skillset list` provides the grouped member view.
 6. **Removal is scoped.** Standalone and skillset removal delete only their project
    trees. Shared library trees and skillset definitions remain.
 7. **Filesystem safety bounds convenience.** Managed roots and copied trees reject
-   symlinks and unsafe path shapes before mutation.
+   symlinks and special files before mutation. Copy/equality/digest operations preserve
+   distinct raw Unix path bytes and canonicalize regular files to Git-portable `0o755`
+   executable or `0o644` non-executable modes; special and umask-only bits do not propagate.
+8. **Persisted identity is versioned.** Project lockfiles and skillset receipts use
+   tree digest version 2: a domain-separated, length-framed stream containing path
+   bytes, entry kind, regular-file mode, and contents. A version-1 lock requires an
+   explicit `skill lock`; a legacy skillset receipt can migrate only through a clean
+   `skillset refresh`.
+9. **Multi-owner publication is sequential and retryable, not transactional.** Tink
+   preflights expected ownership and validation refusals before publication where the
+   workflow spans project, library, and catalog state. Unexpected operational failures
+   can still interrupt later writes; rerunning the idempotent command is recovery.
 
 ## Standalone `skill add`
 
@@ -77,12 +88,13 @@ roots, while `skillset list` provides the grouped member view.
 For a local or GitHub source, the complete publication order is:
 
 1. Ensure the project layout and validate/select the source skill.
-2. Reuse an exact standalone library match when available; skillset roots cannot be
+2. Refuse a receipt-owned source before project, library, or catalog publication.
+3. Reuse an exact standalone library match when available; skillset roots cannot be
    cache hits.
-3. Preflight the project target and refuse divergence.
-4. Deposit the source into the standalone library: create, no-op, or repair. A
+4. Preflight the project target and refuse divergence.
+5. Deposit the source into the standalone library: create, no-op, or repair. A
    receipt-classified target refuses before mutation.
-5. Install the project tree and then update the project-name index.
+6. Install the project tree and then update the project-name index.
 
 A bare-name promotion starts from step 3 with the structurally validated library tree.
 Positive cache and repair behavior is intentional; receipt ownership is the boundary,
@@ -100,8 +112,9 @@ not a ban on library reuse.
 4. Otherwise checkout the pinned revision, copy only the explicit members into a
    staging tree, compute its digest, write the skillset receipt, and validate the
    complete staged tree.
-5. Atomically rename the staged tree into the project and mirror that validated tree
-   to the library.
+5. Rename the staged tree into the project, then mirror that validated tree to the
+   library. Refresh uses a same-parent backup and best-effort rename rollback, but Tink
+   does not claim a transaction across project and library publication.
 
 `skillset refresh` reads the authored definition, then proves the installed project
 clean. It either repairs the library from an unchanged project or stages and replaces
@@ -118,15 +131,37 @@ remove` requires a valid owned receipt and deletes only the project tree.
 | `skill harvest` | `harvest.rs` validates known harness trees and calls the create-only library path; it never writes a project. |
 | `skill lock` / `sync` / `verify` | `manifest.rs` records standalone intent and pins, installs missing pinned skills, and verifies declarations, pins, receipts, and tree hashes. |
 | `inspect` | `inspect.rs` reports GitHub structure without writing project or home state. |
-| `destroy` / `update` | `destroy.rs` removes project scaffolding and its name index; `update.rs` replaces only the CLI binary. |
+| `destroy` / `update` | `destroy.rs` removes `.agents/skills/`, removes `.agents/` only when empty, preserves project guidance/unrelated siblings, and drops the project name index. `update.rs` replaces only the verified CLI binary. |
+
+## Project manifest publication
+
+`manifest.rs` owns `.tink/skills.toml` version 1 and `.tink/skills.lock` version
+2. `skill lock` deterministically rewrites both files from installed standalone
+skills. The lock digest excludes `.tink-source.json`, because remote source identity is
+checked separately against the typed pin.
+
+`skill sync` establishes an exact prepared-source boundary before publishing:
+
+1. Validate the complete manifest/lock pair and classify every pin as local, pinned
+   GitHub, or embedded `manage-tink`.
+2. Snapshot local inputs, retain remote checkout guards, select the exact skill, and
+   verify every version-2 digest.
+3. Preflight every project destination, then every library destination, then the
+   project catalog boundary. Expected divergence, symlink, collision, or malformed
+   catalog failures therefore occur before the first skill is published.
+4. Publish prepared skills one at a time in deterministic manifest-name order. Each
+   publish updates library, project, and catalog using the ordinary add lifecycle.
+5. Run offline `skill verify` after the sequence.
+
+This is not cross-skill atomicity. An unexpected error such as permission loss or
+ENOSPC can stop the sequence after earlier skills completed. Prepared bytes remain
+exact for the duration of that invocation, and a later `skill sync` safely retries the
+remaining idempotent work.
 
 ## Known boundaries
 
-- Standalone source discovery and generic project preflight do not classify a source or
-  project target by skillset receipt. With a missing library target, a receipt-bearing
-  arbitrary source can therefore publish when the project target is missing or
-  byte-identical. Its intended routing, and harvest's create-only reporting, remain
-  separate design questions.
 - Tink has no production inter-process library lock. Concurrent mutations are not a
-  proven operating mode.
-- Release sensors and their bypasses are documented in [`TESTING.md`](TESTING.md).
+  supported or proven operating mode for a project or shared Tink home.
+- Staging and same-directory rename reduce exposure to incomplete individual files or
+  trees, but no transaction spans project, library, catalog, or the two manifest files.
+- CI and release sensors are documented in [`TESTING.md`](TESTING.md).

--- a/docs/PROJECT-MANIFEST-DESIGN.md
+++ b/docs/PROJECT-MANIFEST-DESIGN.md
@@ -2,52 +2,43 @@
 
 ## Status
 
-Proposed design for a first implementation of reproducible project skill state.
-This document is intentionally written before code changes so the manifest contract
-can be reviewed independently of the CLI implementation.
+Implemented. `tink skill lock`, `tink skill sync`, and `tink skill verify` own the
+project manifest contract described here. The manifest remains version 1; the lockfile
+is version 2 after the digest hardening migration.
 
-## Problem
+## Outcome and authority
 
-Tink currently installs skills into `.agents/skills/` and records machine-local
-catalog state under `$TINK_HOME`. Remote installs carry source receipts, but local
-sources do not have a committed declaration that another checkout or CI job can
-use to reconstruct the intended agent environment.
-
-The missing contract is a version-controlled project manifest that declares the
-skills a project intentionally owns and pins reproducible source information.
-
-## Goals
-
-- Make project skill dependencies reviewable in Git.
-- Reconstruct declared skills on a fresh machine without reading `$TINK_HOME`.
-- Detect missing, extra, modified, or incorrectly sourced installed skills.
-- Preserve current safety behavior: no symlink traversal, no silent divergent overwrite,
-  and no catalog mutation before a successful install.
-- Support local paths and public GitHub sources in the first version.
-- Keep the existing `.agents/skills/` layout and CLI behavior backward compatible.
-
-## Non-goals (v1)
-
-- Managing subagents or provider-specific agent profiles.
-- Replacing the existing by-project catalog.
-- Supporting arbitrary Git hosts, private credentials, or mutable branch pins.
-- Automatically deleting unlisted skills.
-- A network service, daemon, cache, or distributed coordination protocol.
-
-## Proposed project files
+Tink installs standalone skills into `.agents/skills/`, but the home library and
+by-project catalog are machine-local derived state. A repository needs committed intent
+and exact pins so another checkout or CI job can reconstruct and verify the same live
+skill trees without treating `$TINK_HOME` as authority.
 
 ```text
 .tink/
-  skills.toml       # human-reviewed dependency intent
-  skills.lock       # exact resolved revisions and content hashes
-.agents/skills/     # installed, checked-in skill trees remain the runtime input
+  skills.toml       # reviewed dependency intent, version 1
+  skills.lock       # exact source pins and version-2 tree digests
+.agents/skills/     # installed trees consumed by agents
 ```
 
-Both `.tink/skills.toml` and `.tink/skills.lock` are project-owned and should be
-committed. `$TINK_HOME` remains a cache/library and catalog location, not a source
-of truth.
+Both project files are intended to be committed. `$TINK_HOME` remains a rebuildable
+library/catalog and never becomes an agent discovery root.
 
-## Manifest and lockfile shape
+## Supported contract
+
+- Review project skill dependencies in Git.
+- Reconstruct local, pinned public-GitHub, and embedded `manage-tink` sources.
+- Detect missing, extra, modified, incorrectly sourced, or receipt-mismatched skills.
+- Refuse symlinks, special files, path traversal, and divergent project overwrites.
+- Refuse a skillset-receipt-owned source at the standalone manifest boundary.
+- Resolve and preflight every declared exact source before multi-skill publication.
+- Never delete unlisted skills as a side effect of sync.
+
+The implementation does not manage skillsets through the manifest, automatically edit
+the manifest after `skill add`/`remove`, support private credentials or arbitrary
+remote Git hosts, prune live skills, coordinate concurrent writers, or provide
+cross-skill rollback after an unexpected operational failure.
+
+## File shape
 
 `.tink/skills.toml` declares intent:
 
@@ -60,144 +51,131 @@ source = "https://github.com/example/skills.git"
 path = "skills/reviewer"
 ```
 
-`.tink/skills.lock` records resolution:
+`.tink/skills.lock` records exact resolution:
 
 ```toml
-version = 1
+version = 2
 
 [[skills]]
 name = "reviewer"
 source = "https://github.com/example/skills.git"
-revision = "40-character-full-git-commit-sha"
+revision = "40-character-full-git-object-id"
 path = "skills/reviewer"
-sha256 = "sha256-of-installed-tree-excluding-receipt"
+sha256 = "version-2-tree-digest"
 ```
+
+Local sources are normalized project-relative paths and omit `revision`/`path` in the
+lock entry. The embedded source is written as `tink:embedded/manage-tink` and is valid
+only through the typed lock-source boundary; free-form `skill add` does not accept it.
 
 Rules:
 
-- `name` must match the installed directory and `SKILL.md` metadata.
-- Remote entries require canonical GitHub HTTPS `source`, full immutable `revision`,
-  and normalized relative `path`.
-- Local entries require a project-relative path; absolute paths are rejected.
-- `sha256` covers the normalized skill tree excluding `.tink-source.json`; it detects
-  body drift without making the receipt part of content identity.
-- Duplicate names are invalid.
-- Unknown top-level fields are rejected in v1 to avoid silently ignored policy.
-- Manifest and lockfile ordering is stable by `name` when Tink writes them.
+- `name` must be a valid unique standalone skill name and match `SKILL.md`.
+- Remote entries use canonical public GitHub HTTPS source identity, a full immutable
+  revision, and a normalized repository-relative skill path.
+- Local entries must resolve inside the project; absolute paths outside it and path
+  traversal are rejected.
+- Unknown fields are rejected. Manifest and lock skill sets and typed source identity
+  must agree exactly.
+- Tink writes entries in stable name order.
+
+## Digest version 2
+
+`sha256` is a domain-separated, unambiguous encoding of the installed tree excluding
+the root `.tink-source.json` receipt. Each entry length-frames its path bytes and
+content, identifies directory versus regular file, and includes its canonical mode.
+On Unix, paths are hashed as raw bytes; any executable bit maps to `0o755`, while a
+non-executable file maps to `0o644`. Copy, equality, and digest operations share that
+Git-portable semantic mode and discard umask-only and special-bit variation.
+
+Excluding the receipt keeps content identity separate from the source pin. `verify`
+checks remote receipt source, revision, and path independently.
+
+A lockfile with `version = 1` is deliberately refused because its digest omitted mode
+and did not domain-separate the new encoding. Run `tink skill lock` with the required
+local `--source NAME=PATH` mappings to rewrite version 2, review the result, then commit
+it. Tink does not silently reinterpret a version-1 digest.
 
 ## Commands
 
-### `tink skill sync`
+### `tink skill lock [--source NAME=PATH ...]`
 
-Install or verify every manifest entry. Missing entries may be created. Existing
-entries are repaired only when their body is unchanged and only the receipt differs.
-Body divergence fails closed and leaves the project tree untouched. Unlisted live
-skills are reported but not deleted.
+Read all installed standalone project skills and deterministically rewrite both
+project files. Remote skills use validated `.tink-source.json` data; local skills
+require an explicit mapping, except embedded `manage-tink`, whose source is known.
+Source paths are normalized and every installed tree receives a version-2 digest.
 
-### `tink skill lock`
-
-Generate both project files from installed skills. Remote skills use their validated
-receipts; local skills require explicit repeatable mappings such as
-`--source reviewer=fixture/reviewer`. Sources are normalized to project-relative
-paths and both files are written through temporary files.
-
-### `tink skill sync`
-
-Consume the committed manifest and lockfile. Missing local or pinned remote skills are installed; divergent existing skill bodies are refused. Sync finishes by running verification and does not prune unlisted skills.
+The two files are staged separately beside their destinations. The manifest is renamed
+first and, if the lock rename fails, Tink attempts to restore the previous manifest.
+This protects the ordinary failure path but is not a crash-safe transaction across the
+pair.
 
 ### `tink skill verify`
 
-Read-only validation of the manifest and installed trees. It reports:
+Read-only and offline. It validates both schemas and versions, identical declaration
+sets and source identity, installed names and trees, digest equality, and remote
+receipt pins. Missing declared skills, unlisted installed standalone skills, and any
+receipt mismatch fail the command. Success exits 0; a command failure exits 1.
 
-- manifest syntax/schema errors;
-- missing declared skills;
-- name/path or metadata mismatches;
-- content hash drift;
-- invalid or stale remote receipts;
-- unlisted installed skills.
+### `tink skill sync`
 
-Exit code is 0 only when all declared skills are present and valid. This command
-must not require network access; remote reachability is not part of verification.
+Restore the complete locked set without pruning:
 
-### Existing commands
+1. Parse and validate the full manifest and lockfile before writes.
+2. Classify every lock entry as local, pinned GitHub, or embedded.
+3. Prepare exact source bytes for every entry. Local trees are copied into retained
+   snapshots; remote checkouts/worktrees stay alive through publication; embedded
+   `manage-tink` is prepared from the running binary.
+4. Validate every candidate name, safe tree, receipt, and version-2 digest.
+5. Preflight every project destination and refuse divergence.
+6. Reject installed standalone skills that are not declared.
+7. Preflight every library destination and the by-project catalog boundary.
+8. Publish prepared skills sequentially in manifest-name order through the ordinary
+   add lifecycle: library, project, then catalog.
+9. Run offline verification after all publications.
 
-- `skill add` remains supported and continues its current behavior.
-- Successful `skill add` should offer an explicit `--manifest` mode in v1 rather
-  than silently changing existing projects. Default behavior remains unchanged.
-- `skill remove` updates the manifest only when the removed skill is declared;
-  it must not remove an undeclared local tree.
+Expected bad hash, project divergence, unsafe library target, ownership collision, or
+malformed catalog failures occur before the first skill publication. Preparation also
+prevents a local source from changing between validation and later publication in the
+same run.
 
-## Installation and consistency model
+Publication is intentionally not a transaction across skills or state owners. ENOSPC,
+permission loss, interruption, or another unexpected operational error can leave an
+earlier skill completely published and a later one absent. No success is reported for
+that run; rerunning `tink skill sync` is the supported recovery path and converges the
+idempotent completed steps.
 
-Tink uses a local, filesystem-based transaction per skill:
+## Catalog and library effects
 
-1. Parse and validate the manifest and lockfile before writes.
-2. Resolve sources and stage each candidate outside the live skill directory.
-3. Validate names, trees, receipts, and hashes.
-4. Preflight every destination for missing, identical, receipt-only drift, or body drift.
-5. Refuse if any body-divergent destination exists.
-6. Commit staged trees and manifest changes.
-7. Update the existing catalog only after successful project installation.
+Each successfully published skill follows the existing add lifecycle. The reusable
+library is created, left identical, or repaired from the prepared source; the project
+tree is created or repaired only for receipt-only drift; then the project name is
+deposited in the by-project catalog. Catalog directories use a bounded project basename
+plus SHA-256 identity of the canonical project root, using raw bytes on Unix.
 
-A failed sync must not leave a partially rewritten manifest. Cross-skill rollback
-is intentionally deferred; the safe v1 contract is that each write is staged and
-manifest replacement is atomic, while an interrupted sync may leave some newly
-created skill trees that a later sync can reconcile.
+The catalog and library are not part of the committed manifest authority. A catalog
+failure can happen after valid library/project copies exist in an ordinary single-skill
+add, and retry repairs the missing derived state. Manifest sync preflights predictable
+catalog refusals before its first publication.
 
-## Security and safety
+## Security and operating limits
 
-- Reject symlinks and special files in manifests, source trees, and destinations.
-- Never execute skill content during sync or verify.
-- Reject path traversal, absolute local paths, and non-GitHub remotes.
-- Use temporary files plus atomic rename for manifest writes.
-- Preserve existing refusal messages for divergent project skill bodies.
-- Do not embed credentials or tokens in the manifest.
+- Skill contents are copied and hashed, never executed.
+- Symlinks and special files are rejected throughout managed trees.
+- GitHub network operations use pinned revisions for the lock result; verify is
+  network-free.
+- Typical operation is human/CI invoked and linear in declared tree bytes.
+- There is no daemon, database, cache protocol, inter-process lock, or concurrent
+  mutation guarantee.
+- Same-directory staging/rename narrows individual write hazards; no atomicity claim
+  spans project, library, catalog, or both project files.
 
-## Backward compatibility and migration
+## Executable evidence
 
-- Existing projects without `.tink/skills.toml` continue to use current commands.
-- `tink skill manifest import` may be added later to generate a manifest from the
-  current catalog and installed trees; it is not required for the first slice.
-- Existing remote receipts remain valid and are used as inputs when generating pins.
-- Local skills without receipts can be added to a manifest only with an explicit
-  source path and computed hash.
-
-## Scale and operational assumptions
-
-This is a repository-local tool, not a distributed service:
-
-- Typical manifest: 1–100 skills; upper target: 1,000 entries.
-- Typical skill tree: under 10 MB; hash calculation is linear in checked-in bytes.
-- Sync is human/CI invoked, not a long-running process.
-- No server availability or QPS requirement; GitHub/network failures must be bounded
-  and must not corrupt installed state.
-
-## Tradeoffs
-
-- **Manifest plus installed copies:** larger repositories, but offline execution and
-  reviewable agent context. Preferred for reliability.
-- **Manifest plus generated copies:** smaller repositories, but every checkout needs
-  network access and agent behavior becomes bootstrap-dependent. Deferred.
-- **Two files under `.tink/`:** separates human intent from machine resolution, following
-  the Cargo.toml/Cargo.lock model while preserving the native `.agents/skills/` convention.
-- **No automatic deletion:** avoids destructive surprises; a future `--prune` can be
-  explicit and separately designed.
-- **SHA-256 tree hash:** catches local tampering and drift, while remaining independent
-  of Git implementation details. It adds hashing cost but no meaningful cost at the
-  target scale.
-
-## Implementation slices
-
-1. Add manifest parser/validator and unit tests; no CLI changes.
-2. Add `skill verify` for read-only manifest and tree validation.
-3. Add `skill lock` to generate intent and resolved pins from installed trees. (done)
-4. Add manifest-aware `skill add --manifest` and atomic manifest updates.
-5. Add `skill sync` with staged installs and bounded remote resolution. (done for missing local and pinned remote entries)
-6. Add acceptance coverage, docs, and a migration/import command if needed.
-
-## System-design diagnostic
-
-This local tool scores 5/8 for the distributed-system checklist: requirements,
-reliability boundaries, deployment/rollback behavior, and observability are explicit;
-QPS, database scaling, caching, and queues are intentionally not applicable to a
-repository-local CLI. Adding distributed infrastructure would be overengineering.
+Acceptance rows M1-M9 cover empty verification, lock generation, local and embedded
+restore, missing-local source classification, missing manifests, all-entry hash
+preflight, later library refusal before publication, and explicit v1-to-v2 relock.
+Focused unit tests additionally cover ambiguous digest framing, mode sensitivity,
+exact prepared local snapshots, project/library/catalog preflights, and the embedded
+source path. See [`TESTING.md`](TESTING.md) for the complete gate and remaining fault-
+injection/concurrency gaps.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -123,7 +123,8 @@ are unsupported and untested. Networked Git operations have low-speed and five-m
 overall bounds. Git, curl, tar, and release-candidate subprocesses run in supervised
 process groups: timeout or HUP/INT/TERM directed only at Tink terminates and reaps the
 active group, while the default signal action remains in force outside supervision.
-Each subprocess stream is captured independently up to 16 MiB. Readers continue
-draining after that point so the child cannot block on a full pipe, then the command
-fails explicitly instead of retaining unbounded output in memory.
+The Rust subprocess supervisor and installer candidate probe retain each captured
+stream independently up to 16 MiB. Readers continue draining after that point so the
+child cannot block on a full pipe, then the command fails explicitly instead of
+retaining unbounded output in memory.
 No transaction spans separate filesystem owners.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -22,9 +22,10 @@ publishing its release commit and tag. Tag releases and manual dispatches from a
 matching `v*` tag repeat the quality gate before building those four artifacts. They
 upload an exact asset set to a draft and publish only after GitHub reports every asset
 as uploaded with a SHA-256 digest matching the local archive, so a failed or
-unverifiable upload remains hidden and retryable. A branch-based or
-version-mismatched manual dispatch fails before build or publication. Windows is not
-a claimed platform.
+unverifiable upload remains hidden and retryable. Publication is serialized across
+tags and refuses to make an older version the latest release. A branch-based,
+version-mismatched, or version-regressing manual dispatch fails before publication.
+Windows is not a claimed platform.
 
 ## Process output and exits
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -1,34 +1,129 @@
-# Reliability Notes
+# Reliability
 
-## Context
-- Intake date: 2026-08-07
-- Production profile: single-binary CLI with outbound calls to external process/tool chains.
-- Scope: harden integration calls at command boundaries and record operating policy.
-- Constraint: keep behavior-compatible for current flows; no schema or protocol redesign in this phase.
+Tink is a short-lived, single-process CLI. Reliability means deterministic command
+contracts, refusal before predictable unsafe writes, verifiable persisted state, and a
+clear retry path after an operational interruption. It does not mean distributed
+transactions or concurrent writers.
 
-## Integration-Point Audit
-| Dependency | Location | Timeout | Retry | Circuit Breaker | Bulkhead / isolation | Current Status |
-|---|---|---|---|---|---|---|
-| `curl` (GitHub API + artifact download) | `src/update.rs::curl_to_file`, `src/update.rs::update_binary` | `--connect-timeout 5`; metadata `--max-time 30`; asset `--max-time 300` | `--retry 2`, `--retry-delay 1` | `retry budget in-process` (bounded attempts) | Update call is isolated to explicit user command path | hardened |
-| `git` (remote head/clone/worktree) | `src/git.rs::run_git` | `http.lowSpeedLimit=1024`, `http.lowSpeedTime=30` (mid-transfer stall; no separate connect wall-clock) | not built into helper; command-level retries via existing user retry | bounded by low-speed transport config (single-call invocation) | all git operations isolated to explicit command path (`add/refresh`) | hardened |
-| `tar` (release archive extraction) | `src/update.rs::extract_tink_binary` | n/a (local filesystem) | n/a | n/a | CLI-local, no network | not applicable |
-| `env::current_exe/current_dir` process boundary | `src/main.rs`, `src/update.rs` | n/a | n/a | n/a | clap parse first so `--help`/`--version` work without cwd; remaining commands fail closed on missing cwd | hardened |
+## Build and platform gate
 
-## Query & Resource Findings
-- No outbound SQL or paginated list endpoints in this codebase.
-- Network work is bounded by explicit process-level commands with timeout/retry caps.
-- Archive and Git operations remain single-process and do not maintain pooled connections.
+`rust-toolchain.toml` pins Rust 1.95.0 with Rustfmt and Clippy. Pull requests and
+`main` pushes run formatting, locked workspace check, Clippy with warnings denied,
+installer syntax/ShellCheck, documentation tests, and RustSec audit. Native tests and
+release builds run on four hosts/targets:
 
-## Health Checks & Metrics
-- No dedicated long-lived service metrics are present in this CLI.
-- Immediate operational checks should remain exit code + stderr assertions (integration tests already cover major error/success paths).
-- If deployed in packaging pipelines, add external telemetry by wrapping process exit codes in caller scripts.
+- Apple silicon macOS (`aarch64-apple-darwin`)
+- Intel macOS (`x86_64-apple-darwin`)
+- arm64 Linux (`aarch64-unknown-linux-gnu`)
+- x86_64 Linux (`x86_64-unknown-linux-gnu`)
 
-## Deploy vs Release
-- **Release (`tink update`)** is explicit, user-initiated and non-automatic.
-- No automatic background rollout exists in this repository.
-- Runtime update behavior now degrades deterministically on integration timeout/failure instead of hanging.
+The automatic bump workflow passes that same four-platform gate before atomically
+publishing its release commit and tag. Tag releases and manual dispatches from a
+matching `v*` tag repeat the quality gate before building those four artifacts. They
+upload an exact asset set to a draft and publish only after GitHub reports every asset
+as uploaded with a SHA-256 digest matching the local archive, so a failed or
+unverifiable upload remains hidden and retryable. A branch-based or
+version-mismatched manual dispatch fails before build or publication. Windows is not
+a claimed platform.
 
-## Failure Strategy
-- Treat inbound command failures as hard failures with explicit messages.
-- Keep retries small and bounded so failures remain actionable and do not silently mask dependency problems.
+## Process output and exits
+
+Application output goes through fallible writers. Success data and summaries use
+stdout; warnings and failures use stderr. A closed stdout is normal pipeline control
+flow and exits 0 without a Rust printing panic. If the command itself fails, failure
+to deliver its stderr diagnostic does not hide that failure: the process still exits
+1. Clap owns usage errors and exits 2.
+
+Advisory warnings are best-effort after completed work; a closed warning pipe does not
+retroactively turn a successful mutation into failure. Clap parsing occurs before
+current-directory resolution, so `--help` and `--version` work even when the cwd has
+been removed; project commands fail closed if no cwd can be resolved.
+
+## Install and update supply chain
+
+`install.sh` and `tink update` share the same trust sequence:
+
+1. Accept an HTTPS release-metadata URL without credentials, query, fragment,
+   backslash, whitespace, or control characters. Absolute `file://` is allowed only
+   as an explicit `TINK_RELEASES_API` test/fixture mode; an HTTPS metadata source may
+   not redirect the asset to `file://`.
+2. Select exactly the host-specific asset named
+   `tink-<semver>-<target>.tar.gz`; require a lowercase `sha256:<64 hex>` digest.
+3. Download with curl restricted to the selected protocol, a five-second connect
+   timeout, at most 30 seconds for metadata or 300 seconds for the archive, and two
+   retries separated by one second. The Rust updater and shell installer run each
+   supervised subprocess in a separate process group, enforce the curl, tar, and probe
+   limits, terminate remaining group members, and reap the direct child.
+4. Verify the archive SHA-256 before extraction. Bounded tar inspection/extraction
+   (30 seconds) requires exactly one top-level regular file named `tink`.
+5. Run the candidate with a five-second bound and require exact stdout
+   `tink <version>\n`, first from extraction and again from destination-adjacent
+   staging. Refuse updater downgrades and non-regular replacement targets.
+6. Publish only the verified staged file. Both paths keep a same-directory backup,
+   probe the published path, and restore the backup on probe failure; if rollback
+   itself fails, they report the retained backup path. Success output is emitted only
+   after the published path passes its exact probe, and advisory installer output
+   cannot turn a completed installation into failure when stdout closes.
+
+The default publisher trust root is the repository's GitHub Release authority over
+HTTPS. The asset digest binds transfer bytes to that same release metadata; it is not
+an independent signature. Setting `TINK_RELEASES_API` deliberately changes that trust
+root, while `file://` remains an explicit local fixture mode. Process-group cleanup
+bounds ordinary timeouts and terminal interruption; it is lifecycle control, not a
+sandbox, and code trusted as a release candidate can deliberately create a new session
+outside that group.
+
+The installer depends on `curl`, `tar`, and `python3`; `tink update` depends on `curl`
+and `tar`. Neither runs automatically in the background.
+
+## Filesystem identity and integrity
+
+Skill trees reject symlinks and special files. On Unix, copy and equality preserve
+raw path bytes without lossy Unicode conversion. Regular files are canonicalized to
+`0o755` when any executable bit is present and `0o644` otherwise, matching the mode
+semantics Git can persist while removing umask-only and special-bit variation. Digest
+version 2 length-frames raw path bytes, entry kind, that canonical mode, byte length,
+and content, making boundaries unambiguous and executable-bit changes visible.
+
+Project lockfiles use version 2. Version 1 is refused with an instruction to rerun
+`tink skill lock`; there is no silent reinterpretation of the old digest. Skillset
+receipts carry `digestVersion: 2`. A legacy version-1 receipt is accepted only as the
+input to `tink skillset refresh`, after its old digest proves the project tree clean;
+refresh then installs a version-2 receipt and mirrors the validated project tree.
+
+By-project catalog directories combine a bounded display basename with SHA-256 of the
+canonical project path (raw path bytes on Unix). This distinguishes projects sharing a
+basename and keeps directory components below common filesystem limits. A legacy
+basename-only entry migrates on deposit only when its stored root proves ownership;
+ambiguous legacy metadata is refused rather than claimed.
+
+## Publication, interruption, and recovery
+
+Manifest sync resolves and retains exact source bytes for every declaration, validates
+every lock digest, and preflights all expected project, library, and catalog refusals
+before publishing the first skill. Publication is then sequential. An unexpected
+operational error can therefore leave earlier skills complete and later skills
+unpublished; cross-skill rollback is not promised. Rerun `tink skill sync` to converge.
+
+The same recovery principle applies to ordinary add/init flows: successful prior
+steps remain valid, and retry resumes idempotently. Individual writes commonly use
+destination-adjacent staging and rename, and some replacements attempt rollback, but
+Tink does not claim atomicity across project trees, the library, catalog metadata, or
+manifest/lock pairs.
+
+`tink destroy` preflights catalog cleanup before deleting project state. It removes
+only `.agents/skills/`, removes `.agents/` if that directory is then empty, and drops
+the owned by-project catalog entry. It preserves `AGENTS.md`, `ZEN.md`, unrelated
+`.agents/` siblings, the library, and other projects' catalog entries.
+
+## Explicit operating boundary
+
+Tink has no inter-process lock for a project or shared Tink home. Concurrent mutations
+are unsupported and untested. Networked Git operations have low-speed and five-minute
+overall bounds. Git, curl, tar, and release-candidate subprocesses run in supervised
+process groups: timeout or HUP/INT/TERM directed only at Tink terminates and reaps the
+active group, while the default signal action remains in force outside supervision.
+Each subprocess stream is captured independently up to 16 MiB. Readers continue
+draining after that point so the child cannot block on a full pipe, then the command
+fails explicitly instead of retaining unbounded output in memory.
+No transaction spans separate filesystem owners.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -140,10 +140,11 @@ The most important ownership sensors are:
 - A14 plus `skills.rs` unit tests cover portable executable-mode propagation, umask
   normalization, and distinct non-UTF-8 Unix names. Digest tests pin unambiguous
   framing and executable-mode sensitivity.
-- V4-V6 pin closed stdout/stderr exit semantics for the CLI and installer. U4-U15
+- V4-V6 pin closed stdout/stderr exit semantics for the CLI and installer. U4-U17
   cover invalid payloads, downgrade refusal, strict semantic versions, URL
-  redaction/policy, bounded candidate probes, exact published version probes, and
-  preservation or rollback of an existing binary.
+  redaction/policy, bounded candidate probes and output capture, exact published
+  version probes, terminal-safe update output, and preservation or rollback of an
+  existing binary.
 - G9-G10 pin Git process-group cleanup on parent-only termination and visible escaping
   of terminal controls in untrusted repository paths.
 - L10-L13 and `catalog.rs` unit tests cover hashed catalog identity, bounded

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -47,7 +47,9 @@ including manual dispatch from the matching `v*` tag, repeat quality and audit f
 then test and build all four artifacts. Publication uploads the exact asset set to an
 invisible draft and makes it public only after GitHub reports every asset as uploaded
 with a SHA-256 digest matching the local archive; reruns converge an incomplete draft.
-Branch-based or version-mismatched manual dispatches fail before build or publication.
+Publication is serialized across tags and refuses to replace GitHub's latest release
+with an older version. Branch-based, version-mismatched, or version-regressing manual
+dispatches fail before publication.
 
 The bump workflow intentionally skips its own `chore: release v*` commit to avoid a
 release loop. That commit was created only after the preceding bump job passed; direct
@@ -140,7 +142,7 @@ The most important ownership sensors are:
 - A14 plus `skills.rs` unit tests cover portable executable-mode propagation, umask
   normalization, and distinct non-UTF-8 Unix names. Digest tests pin unambiguous
   framing and executable-mode sensitivity.
-- V4-V6 pin closed stdout/stderr exit semantics for the CLI and installer. U4-U17
+- V4-V6 pin closed stdout/stderr exit semantics for the CLI and installer. U4-U18
   cover invalid payloads, downgrade refusal, strict semantic versions, URL
   redaction/policy, bounded candidate probes and output capture, exact published
   version probes, terminal-safe update output, and preservation or rollback of an

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -11,14 +11,22 @@ A passing check proves only its assertions.
 Run from the repository root:
 
 ```console
-cargo fmt --check
-cargo test --locked
+cargo fmt --all -- --check
+cargo check --workspace --all-targets --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --all-targets --locked
+cargo test --workspace --locked --doc
+cargo build --workspace --release --locked
+cargo audit --file Cargo.lock
+sh -n install.sh
+shellcheck -x install.sh
 git diff --check
 ```
 
-`cargo test --locked` runs module unit tests, `tests/acceptance.rs`, and the acceptance
-traceability guard. Use a focused acceptance filter while iterating, then run the
-complete gate before closure:
+The checked-in toolchain pins Rust 1.95.0. `cargo test` runs module unit tests,
+`tests/acceptance.rs`, and the acceptance traceability guard. `cargo audit` requires
+the separately installed `cargo-audit` binary. Use a focused acceptance filter while
+iterating, then run the complete gate before closure:
 
 ```console
 cargo test --test acceptance h13_exact_cache_match_does_not_publish_skillset_as_standalone -- --nocapture
@@ -27,42 +35,86 @@ cargo test --test acceptance h13_exact_cache_match_does_not_publish_skillset_as_
 `./tink-test <args>` builds and executes this checkout with an isolated Tink home. It
 is a dogfood runner, not an automated test suite by itself.
 
-## Automated release gate
+## Automated CI and release gates
 
-`.github/workflows/bump-release.yml` handles non-release pushes to `main`. Before it
-changes `Cargo.toml` or `Cargo.lock`, commits, tags, pushes, or dispatches a release, it
-installs stable Rust with `rustfmt` and runs:
+`.github/workflows/ci.yml` runs the pinned quality gate on pull requests and `main`.
+Its platform matrix runs native tests and release builds on macOS and Linux for both
+x86_64 and arm64. `.github/workflows/bump-release.yml` repeats the complete quality,
+audit, and release-build gate plus all four native test/build jobs before atomically
+publishing the release commit and tag. A rerun can safely retry dispatch for an
+existing incomplete tag. The tag `.github/workflows/release.yml` entrypoints,
+including manual dispatch from the matching `v*` tag, repeat quality and audit first,
+then test and build all four artifacts. Publication uploads the exact asset set to an
+invisible draft and makes it public only after GitHub reports every asset as uploaded
+with a SHA-256 digest matching the local archive; reruns converge an incomplete draft.
+Branch-based or version-mismatched manual dispatches fail before build or publication.
+
+The bump workflow intentionally skips its own `chore: release v*` commit to avoid a
+release loop. That commit was created only after the preceding bump job passed; direct
+tags and matching-tag manual release entrypoints no longer bypass repository
+verification. External branch/tag protection remains outside this repository and is
+not assumed.
+
+## Measured workload envelope
+
+The predeclared local workload envelope is either 100 installed skills with 10
+auxiliary 4 KiB files each, or one nested skill with 4,096 auxiliary 8 KiB files
+(32 MiB payload). For both shapes, `init`, local `skill add`, `skill check`, `skill
+lock`, and `skill verify` must succeed; every measured phase must finish in less than
+60 seconds and below 512 MiB peak resident memory. This is a verified operating
+envelope, not an input rejection limit or a performance promise beyond those shapes.
+
+The 2026-08-11 bounded experiment used native `arm64-apple-darwin`, macOS 26.6.1,
+Rust 1.95.0, base commit `00eb81e51001294cce5a99f1fb645796d8d10355`
+plus the evaluated worktree, and release-binary SHA-256
+`42b10bd83469f4a3242024d90816a4ffef71e7305dd09b845da0bb86993e564d`.
+Every command ran with a fresh temporary project and `TINK_HOME`, `NO_COLOR=1`, and
+`/usr/bin/time -l`. Sources lived below `source-fixtures/` inside the project so lock
+paths exercised the production containment rule. The breadth add row sums 100
+individually measured adds and reports their maximum RSS.
+
+| Shape and phase | Wall seconds | Peak RSS bytes |
+|---|---:|---:|
+| 100 skills: init | 0.00 | 2,719,744 |
+| 100 skills: add all | 0.29 | 3,276,800 |
+| 100 skills: check | 0.02 | 2,899,968 |
+| 100 skills: lock | 0.06 | 3,768,320 |
+| 100 skills: verify | 0.05 | 3,768,320 |
+| 4,096-file/32 MiB skill: init | 0.00 | 2,703,360 |
+| 4,096-file/32 MiB skill: add | 1.55 | 37,437,440 |
+| 4,096-file/32 MiB skill: check | 0.01 | 2,736,128 |
+| 4,096-file/32 MiB skill: lock | 0.23 | 37,306,368 |
+| 4,096-file/32 MiB skill: verify | 0.19 | 37,355,520 |
+
+To reproduce the fixture exactly, create each skill with the normal frontmatter plus
+the stated number of fixed-size files (`x` bytes for breadth, `y` bytes for depth;
+depth fans out 64 files into each of 64 directories). Run:
 
 ```console
-cargo fmt --check
-cargo test --locked
+tink init --with-zen --no-manage-tink --no-tink-skills
+tink skill add SOURCE                    # repeat once per source
+tink skill check
+tink skill lock --source NAME=SOURCE     # repeat --source for every skill
+tink skill verify
 ```
 
-That gate protects the automatic `main`-push release path. It does **not** protect the
-two direct entrypoints accepted by `.github/workflows/release.yml`:
-
-- a direct `v*` tag push;
-- a manual `workflow_dispatch`.
-
-Those two paths perform locked release builds but do not run formatting or behavior
-tests. Separately, the entire bump job skips a `main` push whose head message starts
-with `chore: release v`; such a push is neither verified nor released by these
-workflows. External branch/tag protection is outside this repository and must not be
-assumed.
+Wrap each command with `/usr/bin/time -l -o RESULT`; for the breadth add phase, sum
+the `real` values and take the maximum `maximum resident set size`. Network/update,
+concurrent writers, and larger shapes are outside this measurement.
 
 ## Test topology
 
 | Boundary | Primary executable sensors |
 |---|---|
 | Bootstrap and layout | `I*` acceptance tests; `home.rs` unit tests |
-| Local and remote standalone add | `A*`, `R*`; `sources.rs` and `skills.rs` unit tests |
+| Local and remote standalone add | `A*`, `R*`; `sources.rs` and `skills.rs` unit tests, including Unix path-byte/mode preservation |
 | Skillsets | `K*`; `skillsets.rs` validation and receipt-classification unit tests |
 | GitHub inspection | `G*` |
 | Project validation and listing | `C*`, `L*` |
 | Library, promotion, cache, and harvest | `H*`; `library.rs` unit tests |
 | Standalone refresh and removal | `P*`, `X*` |
-| Manifest lock/sync/verify | `M*`; `manifest.rs` unit tests |
-| CLI surface and lifecycle safety | `V*`, `D*`, `U*`, `S*`; `update.rs`, `style.rs`, and `git.rs` unit tests |
+| Manifest lock/sync/verify | `M*`; `manifest.rs` framing, mode, legacy-lock, exact-source, and preflight unit tests |
+| CLI surface and lifecycle safety | `V*`, `D*`, `U*`, `S*`; `output.rs`, `update.rs`, `destroy.rs`, `catalog.rs`, `style.rs`, and `git.rs` unit tests |
 
 The most important ownership sensors are:
 
@@ -76,9 +128,29 @@ The most important ownership sensors are:
   project skill.
 - A6 and A8 preserve the positive standalone library repair and cache paths; ownership
   protection must not disable legitimate reuse.
+- A16 and H14 prove regular and dangling skillset receipts are refused at direct add,
+  manifest preparation, and harvest boundaries before standalone publication.
 - K1, K5, K6, K8, K10, and K11 cover pinned install, collision refusal, receipt safety,
-  offline re-add, staged refresh, and member-name validation.
+  offline re-add, staged refresh, version-2 receipts, and member-name validation.
 - P1-P7 cover clean-project proof and project/library refresh direction.
+- M7-M9 cover all-entry hash validation before mutation, later library refusal before
+  publication, and the explicit version-1-to-version-2 relock path. Manifest unit tests
+  also preflight project and catalog owners and prove prepared local snapshots retain
+  exact bytes.
+- A14 plus `skills.rs` unit tests cover portable executable-mode propagation, umask
+  normalization, and distinct non-UTF-8 Unix names. Digest tests pin unambiguous
+  framing and executable-mode sensitivity.
+- V4-V6 pin closed stdout/stderr exit semantics for the CLI and installer. U4-U15
+  cover invalid payloads, downgrade refusal, strict semantic versions, URL
+  redaction/policy, bounded candidate probes, exact published version probes, and
+  preservation or rollback of an existing binary.
+- G9-G10 pin Git process-group cleanup on parent-only termination and visible escaping
+  of terminal controls in untrusted repository paths.
+- L10-L13 and `catalog.rs` unit tests cover hashed catalog identity, bounded
+  components, raw Unix paths, legacy migration ownership, same-basename projects,
+  and stable three-column catalog output for hidden, delimiter-bearing, and empty
+  project sets.
+- D1 and D5 prove guidance and unrelated `.agents/` siblings survive destroy.
 
 Use [`ACCEPTANCE.md`](../ACCEPTANCE.md) for detailed input/output contracts rather
 than copying every row here.
@@ -107,7 +179,7 @@ records deliberate bundled coverage; `Sensor: manual` records an unresolved proo
   no-stage/commit/push claim remains partial.
 - S2 (home is never an agent discovery root) remains manual.
 - No automated test proves concurrent Tink mutations safe; production code has no
-  inter-process library lock.
-- Direct-tag and manual release entrypoints bypass behavior verification, while a
-  `chore: release v` head-message prefix skips both verification and automatic release,
-  as described above.
+  inter-process project or library lock. Concurrent mutation is explicitly unsupported.
+- No fault-injection test proves recovery from every unexpected I/O failure between
+  sequential project, library, and catalog publications. Expected validation and
+  ownership refusals are preflighted; retry is the operational recovery model.

--- a/install.sh
+++ b/install.sh
@@ -309,8 +309,9 @@ run_bounded 30 tar -C "${tmp}/extract" -xzf "${tmp}/tink.tgz" \
   >"${tmp}/tar-extract-output.txt" 2>"${tmp}/tar-extract-error.txt" \
   || die "failed to extract release archive"
 candidate="${tmp}/extract/tink"
-[ -f "${candidate}" ] && [ ! -L "${candidate}" ] \
-  || die "archive did not contain a regular tink binary"
+if [ ! -f "${candidate}" ] || [ -L "${candidate}" ]; then
+  die "archive did not contain a regular tink binary"
+fi
 [ -x "${candidate}" ] || die "release candidate is not executable"
 probe_exact "${candidate}" "${version}" \
   || die "release candidate failed version probe"

--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,9 @@ probe_exact() {
   probe_path="$1"
   probe_version="$2"
   python3 - "${probe_path}" "${probe_version}" <<'PY'
-import os, signal, subprocess, sys
+import os, signal, subprocess, sys, threading, time
+
+CAPTURE_LIMIT = 16 * 1024 * 1024
 
 def terminate_group(process):
     try:
@@ -136,6 +138,34 @@ def close_pipes(process):
     except OSError:
         pass
 
+def drain_capped(name, pipe, results, overflow):
+    retained = bytearray()
+    exceeded = False
+    try:
+        while True:
+            chunk = pipe.read(64 * 1024)
+            if not chunk:
+                break
+            remaining = max(0, CAPTURE_LIMIT - len(retained))
+            retained.extend(chunk[:remaining])
+            if len(chunk) > remaining:
+                exceeded = True
+                overflow.set()
+    except (OSError, ValueError):
+        exceeded = True
+        overflow.set()
+    finally:
+        results[name] = (bytes(retained), exceeded)
+
+def join_drains(process, threads):
+    for thread in threads:
+        thread.join(timeout=1)
+    if any(thread.is_alive() for thread in threads):
+        close_pipes(process)
+        for thread in threads:
+            thread.join(timeout=1)
+    return not any(thread.is_alive() for thread in threads)
+
 try:
     process = subprocess.Popen(
         [sys.argv[1], "--version"],
@@ -149,21 +179,60 @@ def interrupt(_signum, _frame):
     raise KeyboardInterrupt
 for watched in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
     signal.signal(watched, interrupt)
+results = {}
+overflow = threading.Event()
+threads = [
+    threading.Thread(
+        target=drain_capped,
+        args=("stdout", process.stdout, results, overflow),
+        daemon=True,
+    ),
+    threading.Thread(
+        target=drain_capped,
+        args=("stderr", process.stderr, results, overflow),
+        daemon=True,
+    ),
+]
+for thread in threads:
+    thread.start()
+timed_out = False
 try:
-    stdout, _ = process.communicate(timeout=5)
-except (OSError, subprocess.TimeoutExpired):
+    deadline = time.monotonic() + 5
+    while process.poll() is None and not overflow.is_set():
+        if time.monotonic() >= deadline:
+            timed_out = True
+            break
+        time.sleep(0.01)
+except OSError:
     terminate_group(process)
-    close_pipes(process)
     reap_after_kill(process)
+    close_pipes(process)
+    join_drains(process, threads)
     sys.exit(1)
 except BaseException:
     terminate_group(process)
-    close_pipes(process)
     reap_after_kill(process)
+    close_pipes(process)
+    join_drains(process, threads)
     sys.exit(130)
 terminate_group(process)
+if process.returncode is None:
+    reap_after_kill(process)
+drains_finished = join_drains(process, threads)
+stdout, stdout_exceeded = results.get("stdout", (b"", True))
+_, stderr_exceeded = results.get("stderr", (b"", True))
 expected = f"tink {sys.argv[2]}\n".encode()
-sys.exit(0 if process.returncode == 0 and stdout == expected else 1)
+sys.exit(
+    0
+    if not timed_out
+    and not overflow.is_set()
+    and drains_finished
+    and not stdout_exceeded
+    and not stderr_exceeded
+    and process.returncode == 0
+    and stdout == expected
+    else 1
+)
 PY
 }
 

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ run_bounded() {
   process_timeout="$1"
   shift
   python3 - "${process_timeout}" "$@" <<'PY'
-import os, signal, subprocess, sys
+import os, signal, subprocess, sys, threading, time
 
 def terminate_group(process):
     try:
@@ -79,26 +79,37 @@ def reap_after_kill(process):
         except subprocess.TimeoutExpired:
             pass
 
-try:
-    process = subprocess.Popen(sys.argv[2:], start_new_session=True)
-except OSError:
-    sys.exit(126)
+interrupted = threading.Event()
 def interrupt(_signum, _frame):
-    raise KeyboardInterrupt
+    interrupted.set()
 for watched in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
     signal.signal(watched, interrupt)
 try:
-    returncode = process.wait(timeout=float(sys.argv[1]))
-except subprocess.TimeoutExpired:
-    terminate_group(process)
-    reap_after_kill(process)
-    sys.exit(124)
+    process = subprocess.Popen(sys.argv[2:], start_new_session=True)
+except OSError:
+    sys.exit(130 if interrupted.is_set() else 126)
+timed_out = False
+try:
+    deadline = time.monotonic() + float(sys.argv[1])
+    while process.poll() is None and not interrupted.is_set():
+        if time.monotonic() >= deadline:
+            timed_out = True
+            break
+        time.sleep(0.01)
 except BaseException:
     terminate_group(process)
     reap_after_kill(process)
     sys.exit(130)
+if interrupted.is_set():
+    terminate_group(process)
+    reap_after_kill(process)
+    sys.exit(130)
+if timed_out:
+    terminate_group(process)
+    reap_after_kill(process)
+    sys.exit(124)
 terminate_group(process)
-sys.exit(returncode)
+sys.exit(process.returncode)
 PY
 }
 
@@ -166,6 +177,11 @@ def join_drains(process, threads):
             thread.join(timeout=1)
     return not any(thread.is_alive() for thread in threads)
 
+interrupted = threading.Event()
+def interrupt(_signum, _frame):
+    interrupted.set()
+for watched in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(watched, interrupt)
 try:
     process = subprocess.Popen(
         [sys.argv[1], "--version"],
@@ -174,11 +190,7 @@ try:
         start_new_session=True,
     )
 except OSError:
-    sys.exit(1)
-def interrupt(_signum, _frame):
-    raise KeyboardInterrupt
-for watched in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
-    signal.signal(watched, interrupt)
+    sys.exit(130 if interrupted.is_set() else 1)
 results = {}
 overflow = threading.Event()
 threads = [
@@ -198,7 +210,11 @@ for thread in threads:
 timed_out = False
 try:
     deadline = time.monotonic() + 5
-    while process.poll() is None and not overflow.is_set():
+    while (
+        process.poll() is None
+        and not overflow.is_set()
+        and not interrupted.is_set()
+    ):
         if time.monotonic() >= deadline:
             timed_out = True
             break
@@ -222,6 +238,8 @@ drains_finished = join_drains(process, threads)
 stdout, stdout_exceeded = results.get("stdout", (b"", True))
 _, stderr_exceeded = results.get("stderr", (b"", True))
 expected = f"tink {sys.argv[2]}\n".encode()
+if interrupted.is_set():
+    sys.exit(130)
 sys.exit(
     0
     if not timed_out

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # Install tink from the latest GitHub Release into ~/.local/bin.
-# Requires: curl, tar.
+# Requires: curl, tar, python3.
 set -eu
 
 REPO="jon-devlapaz/tink"
@@ -18,6 +18,154 @@ need() {
 
 need curl
 need tar
+need python3
+
+api_mode="$(python3 -c '
+import sys
+from urllib.parse import urlsplit
+
+url = sys.argv[1]
+if not url or any(ord(char) <= 32 for char in url) or "\\" in url or "?" in url or "#" in url:
+    sys.exit(1)
+try:
+    parsed = urlsplit(url)
+except ValueError:
+    sys.exit(1)
+if parsed.scheme == "https" and parsed.hostname and parsed.username is None and parsed.password is None:
+    print("https")
+elif parsed.scheme == "file" and not parsed.netloc and parsed.path.startswith("/"):
+    print("file")
+else:
+    sys.exit(1)
+' "${API_URL}")" || die "TINK_RELEASES_API is not an allowed release URL"
+
+curl_fetch() {
+  fetch_url="$1"
+  fetch_dest="$2"
+  fetch_protocol="$3"
+  fetch_max_time="$4"
+  run_bounded "$((fetch_max_time + 5))" curl -fsSL \
+    --proto "=${fetch_protocol}" \
+    --proto-redir "=${fetch_protocol}" \
+    --connect-timeout 5 \
+    --max-time "${fetch_max_time}" \
+    --retry 2 \
+    --retry-delay 1 \
+    "${fetch_url}" -o "${fetch_dest}"
+}
+
+run_bounded() {
+  process_timeout="$1"
+  shift
+  python3 - "${process_timeout}" "$@" <<'PY'
+import os, signal, subprocess, sys
+
+def terminate_group(process):
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except OSError:
+        pass
+
+def reap_after_kill(process):
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
+
+try:
+    process = subprocess.Popen(sys.argv[2:], start_new_session=True)
+except OSError:
+    sys.exit(126)
+def interrupt(_signum, _frame):
+    raise KeyboardInterrupt
+for watched in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(watched, interrupt)
+try:
+    returncode = process.wait(timeout=float(sys.argv[1]))
+except subprocess.TimeoutExpired:
+    terminate_group(process)
+    reap_after_kill(process)
+    sys.exit(124)
+except BaseException:
+    terminate_group(process)
+    reap_after_kill(process)
+    sys.exit(130)
+terminate_group(process)
+sys.exit(returncode)
+PY
+}
+
+probe_exact() {
+  probe_path="$1"
+  probe_version="$2"
+  python3 - "${probe_path}" "${probe_version}" <<'PY'
+import os, signal, subprocess, sys
+
+def terminate_group(process):
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except OSError:
+        pass
+
+def reap_after_kill(process):
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
+
+def close_pipes(process):
+    try:
+        if process.stdout is not None:
+            process.stdout.close()
+        if process.stderr is not None:
+            process.stderr.close()
+    except OSError:
+        pass
+
+try:
+    process = subprocess.Popen(
+        [sys.argv[1], "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+except OSError:
+    sys.exit(1)
+def interrupt(_signum, _frame):
+    raise KeyboardInterrupt
+for watched in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(watched, interrupt)
+try:
+    stdout, _ = process.communicate(timeout=5)
+except (OSError, subprocess.TimeoutExpired):
+    terminate_group(process)
+    close_pipes(process)
+    reap_after_kill(process)
+    sys.exit(1)
+except BaseException:
+    terminate_group(process)
+    close_pipes(process)
+    reap_after_kill(process)
+    sys.exit(130)
+terminate_group(process)
+expected = f"tink {sys.argv[2]}\n".encode()
+sys.exit(0 if process.returncode == 0 and stdout == expected else 1)
+PY
+}
 
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -30,54 +178,189 @@ case "${os}/${arch}" in
 esac
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "${tmp}"' EXIT
+stage=""
+backup=""
+cleanup() {
+  rm -rf "${tmp}"
+  [ -z "${stage}" ] || rm -f "${stage}"
+  [ -z "${backup}" ] || rm -f "${backup}"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
-curl -fsSL "${API_URL}" -o "${tmp}/release.json" \
-  || die "could not fetch release metadata from ${API_URL}"
+curl_fetch "${API_URL}" "${tmp}/release.json" "${api_mode}" 30 \
+  2>"${tmp}/metadata-curl-error.txt" || die "could not fetch release metadata"
 
-if command -v python3 >/dev/null 2>&1; then
-  asset_url="$(python3 -c '
-import json, sys
-target = sys.argv[1]
-data = json.load(open(sys.argv[2]))
-tag = data.get("tag_name") or ""
-version = tag[1:] if tag.startswith("v") else tag
+python3 -c '
+import json, re, sys
+from urllib.parse import urlsplit
+
+def valid_semver(value):
+    pieces = value.split("+")
+    if len(pieces) > 2:
+        return False
+    version_and_pre = pieces[0]
+    build = pieces[1] if len(pieces) == 2 else None
+    pieces = version_and_pre.split("-")
+    core = pieces[0]
+    pre = "-".join(pieces[1:]) if len(pieces) > 1 else None
+    core_parts = core.split(".")
+    if len(core_parts) != 3:
+        return False
+    if any(not part or not all("0" <= char <= "9" for char in part) or (len(part) > 1 and part.startswith("0")) for part in core_parts):
+        return False
+    for identifiers, reject_numeric_zero in ((pre, True), (build, False)):
+        if identifiers is None:
+            continue
+        parts = identifiers.split(".")
+        if any(not part or not re.fullmatch(r"[0-9A-Za-z-]+", part) for part in parts):
+            return False
+        if reject_numeric_zero and any(part.isdigit() and len(part) > 1 and part.startswith("0") for part in parts):
+            return False
+    return True
+
+def url_mode(url, file_allowed):
+    if not isinstance(url, str) or not url or any(ord(char) <= 32 for char in url):
+        return None
+    if "\\" in url or "?" in url or "#" in url:
+        return None
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return None
+    if parsed.scheme == "https" and parsed.hostname and parsed.username is None and parsed.password is None:
+        return "https"
+    if file_allowed and parsed.scheme == "file" and not parsed.netloc and parsed.path.startswith("/"):
+        return "file"
+    return None
+
+try:
+    target, metadata_path, api_mode = sys.argv[1:]
+    with open(metadata_path, encoding="utf-8") as source:
+        data = json.load(source)
+except (OSError, ValueError, TypeError):
+    sys.exit("could not parse release metadata")
+
+tag = data.get("tag_name") if isinstance(data, dict) else None
+version = tag[1:] if isinstance(tag, str) and tag.startswith("v") else tag
+if not isinstance(version, str) or not valid_semver(version):
+    sys.exit("release metadata has invalid semantic version")
 want = f"tink-{version}-{target}.tar.gz"
-for asset in data.get("assets") or []:
-    if asset.get("name") == want:
-        print(asset.get("browser_download_url") or "")
-        print(tag, file=sys.stderr)
-        sys.exit(0)
-names = ", ".join(a.get("name", "") for a in (data.get("assets") or []))
-sys.stderr.write(f"no asset named {want} (have: {names})\n")
-sys.exit(1)
-' "${target}" "${tmp}/release.json" 2>"${tmp}/tag.txt")" \
-    || die "$(cat "${tmp}/tag.txt" 2>/dev/null || echo could not parse release metadata)"
-  tag_name="$(cat "${tmp}/tag.txt")"
-else
-  tag_name="$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' "${tmp}/release.json" | head -n1)"
-  version="${tag_name#v}"
-  want="tink-${version}-${target}.tar.gz"
-  asset_url="$(tr ',' '\n' < "${tmp}/release.json" | sed -n "s/.*\"browser_download_url\": *\"\\([^\"]*${want}\\)\".*/\\1/p" | head -n1)"
-  [ -n "${asset_url}" ] || die "no asset named ${want}"
-fi
+assets = data.get("assets")
+if not isinstance(assets, list):
+    sys.exit("release metadata has invalid assets")
+matches = [asset for asset in assets if isinstance(asset, dict) and asset.get("name") == want]
+if len(matches) != 1:
+    sys.exit(f"expected exactly one asset named {want}")
+asset = matches[0]
+url = asset.get("browser_download_url")
+asset_mode = url_mode(url, api_mode == "file")
+if asset_mode is None:
+    sys.exit(f"asset {want} has invalid download URL")
+digest = asset.get("digest")
+if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+    sys.exit(f"asset {want} has invalid SHA-256 digest")
+print(tag)
+print(version)
+print(url)
+print(digest[7:])
+print(asset_mode)
+' "${target}" "${tmp}/release.json" "${api_mode}" >"${tmp}/asset.txt" 2>"${tmp}/metadata-error.txt" \
+  || die "$(cat "${tmp}/metadata-error.txt" 2>/dev/null || echo could not parse release metadata)"
 
-[ -n "${asset_url}" ] || die "empty download URL"
+[ "$(wc -l < "${tmp}/asset.txt" | tr -d ' ')" = "5" ] \
+  || die "release metadata parser returned invalid asset fields"
+tag_name="$(sed -n '1p' "${tmp}/asset.txt")"
+version="$(sed -n '2p' "${tmp}/asset.txt")"
+asset_url="$(sed -n '3p' "${tmp}/asset.txt")"
+expected_digest="$(sed -n '4p' "${tmp}/asset.txt")"
+asset_mode="$(sed -n '5p' "${tmp}/asset.txt")"
 
-curl -fsSL "${asset_url}" -o "${tmp}/tink.tgz" || die "download failed: ${asset_url}"
-tar -C "${tmp}" -xzf "${tmp}/tink.tgz"
-[ -f "${tmp}/tink" ] || die "archive did not contain a tink binary"
+curl_fetch "${asset_url}" "${tmp}/tink.tgz" "${asset_mode}" 300 \
+  2>"${tmp}/asset-curl-error.txt" || die "could not download release asset"
+actual_digest="$(python3 -c '
+import hashlib, sys
+digest = hashlib.sha256()
+with open(sys.argv[1], "rb") as source:
+    for chunk in iter(lambda: source.read(65536), b""):
+        digest.update(chunk)
+print(digest.hexdigest())
+' "${tmp}/tink.tgz")" || die "could not hash downloaded release archive"
+[ "${actual_digest}" = "${expected_digest}" ] || die "release archive SHA-256 digest mismatch"
+
+run_bounded 30 tar -tzf "${tmp}/tink.tgz" >"${tmp}/archive-entries.txt" \
+  2>"${tmp}/tar-list-error.txt" || die "failed to inspect release archive"
+python3 -c '
+import sys
+sys.exit(0 if open(sys.argv[1], "rb").read() == b"tink\n" else 1)
+' "${tmp}/archive-entries.txt" \
+  || die "release archive must contain exactly one top-level tink file"
+run_bounded 30 tar -tvzf "${tmp}/tink.tgz" >"${tmp}/archive-details.txt" \
+  2>"${tmp}/tar-details-error.txt" || die "failed to inspect release archive entry type"
+python3 -c '
+import sys
+rows = open(sys.argv[1], "rb").read().splitlines()
+sys.exit(0 if len(rows) == 1 and rows[0].lstrip().startswith(b"-") else 1)
+' "${tmp}/archive-details.txt" \
+  || die "release archive tink entry must be a regular file"
+
+mkdir "${tmp}/extract"
+run_bounded 30 tar -C "${tmp}/extract" -xzf "${tmp}/tink.tgz" \
+  >"${tmp}/tar-extract-output.txt" 2>"${tmp}/tar-extract-error.txt" \
+  || die "failed to extract release archive"
+candidate="${tmp}/extract/tink"
+[ -f "${candidate}" ] && [ ! -L "${candidate}" ] \
+  || die "archive did not contain a regular tink binary"
+[ -x "${candidate}" ] || die "release candidate is not executable"
+probe_exact "${candidate}" "${version}" \
+  || die "release candidate failed version probe"
 
 mkdir -p "${INSTALL_DIR}"
-install -m 755 "${tmp}/tink" "${INSTALL_DIR}/tink"
+destination="${INSTALL_DIR}/tink"
+[ ! -L "${destination}" ] || die "refusing to replace symlink: ${destination}"
+[ ! -e "${destination}" ] || [ -f "${destination}" ] \
+  || die "refusing to replace non-file: ${destination}"
+stage="$(mktemp "${INSTALL_DIR}/.tink-install.XXXXXX")" \
+  || die "could not create install staging file in ${INSTALL_DIR}"
+cp "${candidate}" "${stage}" || die "could not stage tink in ${INSTALL_DIR}"
+chmod 755 "${stage}" || die "could not make staged tink executable"
+probe_exact "${stage}" "${version}" || die "staged release candidate failed version probe"
 
-printf 'Installed tink %s -> %s/tink\n' "${tag_name:-unknown}" "${INSTALL_DIR}"
+if [ -f "${destination}" ]; then
+  backup="$(mktemp "${INSTALL_DIR}/.tink-backup.XXXXXX")" \
+    || die "could not create install backup in ${INSTALL_DIR}"
+  cp -p "${destination}" "${backup}" || die "could not preserve existing tink binary"
+fi
+python3 -c 'import os, sys; os.replace(sys.argv[1], sys.argv[2])' "${stage}" "${destination}" \
+  || die "could not publish tink to install destination"
+stage=""
+
+if ! probe_exact "${destination}" "${version}"; then
+  if [ -n "${backup}" ]; then
+    if ! python3 -c 'import os, sys; os.replace(sys.argv[1], sys.argv[2])' \
+      "${backup}" "${destination}"
+    then
+      recovery_backup="${backup}"
+      backup=""
+      die "published tink failed verification; rollback backup remains at ${recovery_backup}"
+    fi
+    backup=""
+  else
+    rm -f "${destination}"
+  fi
+  die "published tink failed exact version verification"
+fi
+[ -z "${backup}" ] || rm -f "${backup}"
+backup=""
+
+trap '' PIPE
+printf 'Installed tink %s -> %s/tink\n' "${tag_name:-unknown}" "${INSTALL_DIR}" || :
 
 case ":${PATH}:" in
   *":${INSTALL_DIR}:"*) ;;
   *)
-    printf 'Add %s to your PATH, then run: tink --version\n' "${INSTALL_DIR}"
+    printf 'Add %s to your PATH, then run: tink --version\n' "${INSTALL_DIR}" || :
     ;;
 esac
 
-"${INSTALL_DIR}/tink" --version || true
+printf 'tink %s\n' "${version}" || :

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -75,14 +75,20 @@ by hand.
 After adding or changing project skills, check for `.tink/skills.toml` and
 `.tink/skills.lock`. If absent, ask whether the user wants a reproducible
 manifest. Only after approval, run `tink skill lock`, supplying
-`--source NAME=PATH` for each local skill. If both files already exist, use
-`tink skill sync` only when the user requested restoration.
+`--source NAME=PATH` for each local skill. If `skill verify` reports a legacy
+version-1 lock digest, ask before rerunning `skill lock`; that explicit relock
+rewrites version 2 and includes raw Unix path bytes and portable executable modes. If
+both files already exist, use `tink skill sync` only when the user requested
+restoration.
 
 **Expected:** Manifest files are created or synchronized only with explicit
 approval; divergent content remains untouched.
 
 **On failure:** Report missing local source mappings or divergence and stop.
-Do not guess a source or overwrite a project tree.
+Do not guess a source or overwrite a project tree. If an unexpected operational
+error interrupted sequential sync publication, report the potentially partial
+state and explain that rerunning the same idempotent `tink skill sync` is the
+recovery path; ask before retrying.
 
 ### Step 5: Configure Shell Completion When Requested
 
@@ -118,8 +124,9 @@ was removed. Do not conceal a partially completed replacement.
 - After `skillset remove`, run `tink skillset list`; its definition and library
   copy should remain.
 - After `skill lock`, run `tink skill verify`.
-- After `destroy`, confirm `.agents/`, `ZEN.md`, and `AGENTS.md` are gone and
-  the project has no catalog rows; do not run `skill check`.
+- After `destroy`, confirm `.agents/skills/` is gone, `.agents/` is gone only if
+  it became empty, `ZEN.md` and `AGENTS.md` are preserved, unrelated `.agents/`
+  siblings remain, and the project has no catalog rows; do not run `skill check`.
 
 **Expected:** The proof matching the mutation is reported to the user.
 
@@ -138,6 +145,8 @@ from the mutation command alone.
 
 - Treating the home library as an agent discovery root.
 - Treating a receipt-backed library skillset as a standalone skill.
+- Treating a source with a regular or dangling `.tink-skillset.json` entry as a
+  standalone skill; use `tink skillset add NAME-skillset` instead.
 - Inferring a skillset suffix or definition from inspection output.
 - Combining a binary update with project-skill replacement without approval.
 - Hand-editing receipts, catalog metadata, or divergent managed trees.
@@ -165,7 +174,7 @@ from the mutation command alone.
 | Re-embed manage-tink | `tink skill remove manage-tink`, then `tink init --no-zen --no-tink-skills` |
 | Remove one project skill | `tink skill remove NAME` |
 | Update the Tink binary | `tink update` only; re-embedding requires separate authority |
-| Remove scaffolding / destroy Tink setup | `tink destroy` (TTY) or `tink destroy --yes` (scripts) |
+| Remove managed project skills / destroy Tink setup | `tink destroy` (TTY) or `tink destroy --yes` (scripts); guidance and unrelated `.agents/` siblings are preserved |
 
 "Set up Tink" does **not** authorize ZEN, tink-skills, re-embedding, or destroy.
 
@@ -180,8 +189,9 @@ from the mutation command alone.
     from the by-project catalog
   - `tink skillset remove NAME-skillset` → only the receipt-backed project
     skillset tree; preserves its catalog definition and library copy
-  - `tink destroy` → `.agents/`, `ZEN.md`, and `AGENTS.md`, and drops this
-    project's by-project catalog entry
+  - `tink destroy` → `.agents/skills/`, then `.agents/` only if empty, and
+    drops this project's by-project catalog entry; preserves `ZEN.md`,
+    `AGENTS.md`, and unrelated `.agents/` siblings
 - Treat local skills as non-refreshable unless they carry a valid receipt.
 - Never execute code from a skill while Tink manages it.
 - Library (`~/.tink/skills/`) is **not** an agent discovery root; use
@@ -190,3 +200,5 @@ from the mutation command alone.
   `.agents/skills/NAME-skillset/<member>/SKILL.md`; each member remains a valid
   named skill. Never flatten, merge, or manually copy members.
 - Do not prune the library by hand. Project removals preserve library trees.
+- Do not run concurrent Tink mutations against one project or shared Tink home;
+  Tink has no inter-process lock.

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -21,7 +21,7 @@ form for add, list, check, refresh, and remove.
 | Check | `tink skill check` |
 | Generate project manifest and lockfile | `tink skill lock --source NAME=PATH` for each local skill |
 | Verify manifest, lockfile, and installed trees | `tink skill verify` |
-| Sync missing/pinned skills from manifest | `tink skill sync` |
+| Sync the exact pinned manifest set | `tink skill sync` (preflights expected project/library/catalog refusals, then publishes sequentially; rerun after an operational interruption) |
 | Refresh all clean imports | `tink skill refresh` |
 | Refresh one | `tink skill refresh NAME` |
 | Remove one project skill | `tink skill remove NAME` |
@@ -30,9 +30,9 @@ form for add, list, check, refresh, and remove.
 | List library skillsets | `tink skillset list --library` |
 | Refresh a clean pinned skillset | `tink skillset refresh NAME-skillset` |
 | Remove one project skillset | `tink skillset remove NAME-skillset` |
-| Update the tink CLI binary | `tink update` |
+| Update the tink CLI binary | `tink update` (newer host asset only; verifies release digest, archive shape, and exact candidate version before replacement) |
 | Re-embed manage-tink after separate approval | `tink skill remove manage-tink`, then `tink init --no-zen --no-tink-skills` |
-| Destroy scaffolding | `tink destroy --yes` (non-TTY/scripts) or `tink destroy` (TTY, confirm `y`) |
+| Destroy managed project skills | `tink destroy --yes` (non-TTY/scripts) or `tink destroy` (TTY, confirm `y`); preserves guidance and unrelated `.agents/` siblings |
 
 ## Layout facts
 
@@ -45,7 +45,8 @@ form for add, list, check, refresh, and remove.
   library trees at `skills/<name>/`. List the library with
   `tink skill list --library`; promote into a project with
   `tink skill add NAME` (bare standalone library skill name). Receipt-backed
-  roots are excluded from both standalone operations. `tink skill harvest` copies complete trees
+  roots and receipt-bearing sources (including dangling receipt links) are excluded
+  from standalone operations. `tink skill harvest` copies complete trees
   from known harness roots into the library create-only (never overwrites a
   divergent library entry). Global roots include `~/.agents/skills`,
   `~/.claude/skills`, `~/.codex/skills`, `~/.cursor/skills`,
@@ -62,14 +63,23 @@ form for add, list, check, refresh, and remove.
   and `.sourcegraph/skills`. Matching GitHub tips install into the project
   from that library; divergent library trees are repaired with a warning on
   `skill add`. Names are recorded in
-  `catalog/by-project/<project>/meta.json`. List the catalog with
-  `tink skill list --catalog` (TSV with header `project`, `root`, `skill`).
+  `catalog/by-project/<bounded-name>-<sha256-identity>/meta.json`. List the catalog with
+  `tink skill list --catalog` (always headered three-column TSV; backslash, tab, CR,
+  and LF inside fields are escaped as `\\\\`, `\\t`, `\\r`, and `\\n`).
   Do not hand-parse `meta.json` when the CLI is available. `skill remove`
   deletes the project skill directory and drops that name from the by-project
-  catalog; it does not prune the library. `destroy` removes project
-  scaffolding and this project's catalog entry; it does not delete library
-  trees or other projects' catalog rows.
+  catalog; it does not prune the library. `destroy` removes
+  `.agents/skills/`, removes `.agents/` only when it is then empty, and drops
+  this project's catalog entry. It preserves `AGENTS.md`, `ZEN.md`, unrelated
+  `.agents/` siblings, library trees, and other projects' catalog rows.
   Project skill overwrites are still refused.
+- Project lockfiles use version 2 tree digests with unambiguous entry framing,
+  raw Unix path bytes, canonical executable modes, and file contents. A version-1 lock
+  is refused until `tink skill lock` explicitly rewrites it. Manifest sync
+  prepares every exact source and preflights expected project, library, and
+  catalog failures before sequential publication; it does not promise
+  cross-skill atomicity. Retry the same sync after an unexpected operational
+  interruption.
 - `tink inspect GITHUB_URL` is read-only. It recursively discovers valid
   `SKILL.md` folders and reports inferred source skillsets, standalone skills,
   diagnostics, and the immutable inspected revision. It does not install
@@ -83,3 +93,7 @@ form for add, list, check, refresh, and remove.
   `SKILL.md`; standalone skill commands never expose, promote, or replace it.
   `skillset remove` deletes only the project tree and keeps
   both the definition and library copy.
+  New receipts use `digestVersion: 2`; a clean legacy receipt migrates only via
+  `tink skillset refresh NAME-skillset`.
+- Tink has no inter-process lock. Do not run concurrent mutations against the
+  same project or shared Tink home.

--- a/src/add.rs
+++ b/src/add.rs
@@ -7,6 +7,7 @@ use crate::error::Error;
 use crate::git;
 use crate::init;
 use crate::library::{self, LibraryWrite};
+use crate::output;
 use crate::provenance::Provenance;
 use crate::skills::{self, Skill};
 use crate::sources::{self, AddSource, LockedSource, RemoteSource};
@@ -28,27 +29,85 @@ pub(crate) struct AddOutcome {
     origin: AddOrigin,
 }
 
+/// A locked source resolved exactly once. Checkout/staging guards keep the
+/// selected bytes alive through cross-skill validation and quiet publication.
+pub(crate) struct PreparedLockedSkill {
+    _guards: Vec<tempfile::TempDir>,
+    skill: Skill,
+    provenance: Option<Provenance>,
+}
+
+impl PreparedLockedSkill {
+    pub(crate) fn skill(&self) -> &Skill {
+        &self.skill
+    }
+
+    pub(crate) fn provenance(&self) -> Option<&Provenance> {
+        self.provenance.as_ref()
+    }
+
+    pub(crate) fn publish(self, project_root: &Path) -> Result<AddOutcome, Error> {
+        self.publish_at(project_root, None)
+    }
+
+    pub(crate) fn publish_at(
+        self,
+        project_root: &Path,
+        home: Option<&Path>,
+    ) -> Result<AddOutcome, Error> {
+        let destination_root = crate::home::project_skills_path(project_root);
+        place_skill_inner(
+            project_root,
+            home,
+            &self.skill,
+            &destination_root,
+            self.provenance.as_ref(),
+            false,
+        )
+    }
+}
+
 fn place_skill(
     project_root: &Path,
     skill: &Skill,
     destination_root: &Path,
     provenance: Option<&Provenance>,
 ) -> Result<AddOutcome, Error> {
+    place_skill_inner(
+        project_root,
+        None,
+        skill,
+        destination_root,
+        provenance,
+        true,
+    )
+}
+
+fn place_skill_inner(
+    project_root: &Path,
+    home: Option<&Path>,
+    skill: &Skill,
+    destination_root: &Path,
+    provenance: Option<&Provenance>,
+    report_library_repair: bool,
+) -> Result<AddOutcome, Error> {
+    crate::skillsets::ensure_standalone_source(&skill.path, &skill.name)?;
+    init::ensure_project_layout(project_root)?;
     // Protect the project tree first. Library is a rebuildable collection: repair on
     // diverge, then install project (re-add recovers if that fails).
     skills::preflight_install(skill, destination_root, provenance)?
         .require_compatible(&skill.name, destination_root)?;
-    let (_, write) = library::deposit(skill, provenance)?;
-    if write == LibraryWrite::Repaired {
-        let err = CliStyle::auto_stderr();
-        eprintln!(
-            "{}",
-            err.warn(format!("Updated home copy of {}", skill.name))
-        );
-    }
+    let (_, write) = library::deposit_at(home, skill, provenance)?;
     let (installed, created) = skills::install_local(skill, destination_root, provenance)?;
     // Catalog even on identical noop so the name index can catch up.
-    catalog::deposit_skill(project_root, &skill.name)?;
+    catalog::deposit_skill_at(home, project_root, &skill.name)?;
+    if write == LibraryWrite::Repaired && report_library_repair {
+        let err = CliStyle::auto_stderr();
+        output::warning_line(format_args!(
+            "{}",
+            err.warn(format!("Updated home copy of {}", skill.name))
+        ));
+    }
     Ok(AddOutcome {
         name: skill.name.clone(),
         created,
@@ -57,12 +116,110 @@ fn place_skill(
     })
 }
 
+fn select_locked_skill(
+    source_root: &Path,
+    name: &str,
+    source_path: Option<&str>,
+) -> Result<Skill, Error> {
+    let skill = if let Some(source_path) = source_path {
+        if source_path.is_empty()
+            || source_path.contains("..")
+            || source_path.contains('\\')
+            || source_path.starts_with('/')
+        {
+            return Err(Error::msg(format!(
+                "Invalid locked skill path: {source_path}"
+            )));
+        }
+        let path = crate::paths::canonicalize_beneath(source_root, Path::new(source_path))?;
+        let skill = skills::read_skill(&path, source_path != ".")?;
+        if skill.name != name {
+            return Err(Error::msg(format!(
+                "Locked skill path does not contain {name:?}"
+            )));
+        }
+        skill
+    } else {
+        select_one_skill(source_root, &output::display_path(source_root), Some(name))?
+    };
+    crate::skillsets::ensure_standalone_source(&skill.path, &skill.name)?;
+    Ok(skill)
+}
+
+pub(crate) fn prepare_locked_skill(
+    name: &str,
+    source: LockedSource,
+) -> Result<PreparedLockedSkill, Error> {
+    match source {
+        LockedSource::LocalPath {
+            declared,
+            project_root,
+        } => {
+            let source_root =
+                crate::paths::canonicalize_beneath(&project_root, Path::new(&declared))?;
+            let selected = select_locked_skill(&source_root, name, None)?;
+            let guard = tempfile::Builder::new()
+                .prefix(".tink-locked-local-")
+                .tempdir()
+                .map_err(|e| Error::msg(format!("local skill snapshot: {e}")))?;
+            let snapshot = guard.path().join(name);
+            skills::copy_skill_tree(&selected.path, &snapshot, &[".git"])?;
+            let skill = skills::read_skill(&snapshot, true)?;
+            Ok(PreparedLockedSkill {
+                _guards: vec![guard],
+                skill,
+                provenance: None,
+            })
+        }
+        LockedSource::Github {
+            remote,
+            revision,
+            path,
+        } => {
+            let (clone_guard, repository, tip) = git::checkout(&remote)?;
+            let mut guards = vec![clone_guard];
+            let source_root = if tip == revision {
+                repository
+            } else {
+                let (worktree_guard, worktree) = git::checkout_revision(&repository, &revision)?;
+                guards.push(worktree_guard);
+                worktree
+            };
+            let skill = select_locked_skill(&source_root, name, Some(&path))?;
+            let mut provenance = Provenance::new();
+            provenance.insert("source".into(), remote.url);
+            provenance.insert("revision".into(), revision);
+            provenance.insert("path".into(), path);
+            Ok(PreparedLockedSkill {
+                _guards: guards,
+                skill,
+                provenance: Some(provenance),
+            })
+        }
+        LockedSource::EmbeddedManageTink => {
+            let (guard, skill) = crate::manage_tink::prepare_manage_tink()?;
+            if skill.name != name {
+                return Err(Error::msg(format!(
+                    "Embedded source does not provide skill: {name}"
+                )));
+            }
+            Ok(PreparedLockedSkill {
+                _guards: vec![guard],
+                skill,
+                provenance: None,
+            })
+        }
+    }
+}
+
 /// Install into the project from an already-complete library tree (receipt included).
 fn place_from_library(
     project_root: &Path,
     skill: &Skill,
     destination_root: &Path,
 ) -> Result<AddOutcome, Error> {
+    crate::skillsets::ensure_standalone_source(&skill.path, &skill.name)?;
+    init::ensure_project_layout(project_root)?;
     skills::preflight_install(skill, destination_root, None)?
         .require_compatible(&skill.name, destination_root)?;
     let (installed, created) = skills::install_local(skill, destination_root, None)?;
@@ -107,8 +264,8 @@ fn repository_relative_path(repository: &Path, skill: &Skill) -> Result<String, 
         .map_err(|_| {
             Error::msg(format!(
                 "skill path {} is outside source {}",
-                skill.path.display(),
-                repository.display()
+                output::display_path(&skill.path),
+                output::display_path(repository)
             ))
         })?
         .to_string_lossy()
@@ -161,20 +318,24 @@ fn select_remote_skill_path(
     Ok(candidates.remove(0).1)
 }
 
+struct CheckoutInstallOptions<'a> {
+    source_display: &'a str,
+    selected_name: Option<&'a str>,
+    source_url: Option<&'a str>,
+    revision: Option<&'a str>,
+    source_path: Option<&'a str>,
+}
+
 fn install_from_checkout(
     project_root: &Path,
     source_root: &Path,
-    source_display: &str,
     destination_root: &Path,
-    selected_name: Option<&str>,
-    source_url: Option<&str>,
-    revision: Option<&str>,
-    source_path: Option<&str>,
+    options: CheckoutInstallOptions<'_>,
 ) -> Result<AddOutcome, Error> {
     let source_root = source_root
         .canonicalize()
         .map_err(|e| crate::paths::map_io(source_root, e))?;
-    let skill = if let Some(source_path) = source_path {
+    let skill = if let Some(source_path) = options.source_path {
         if source_path.is_empty()
             || source_path.contains("..")
             || source_path.contains('\\')
@@ -184,18 +345,22 @@ fn install_from_checkout(
                 "Invalid locked skill path: {source_path}"
             )));
         }
-        let path = source_root.join(source_path);
+        let path = crate::paths::canonicalize_beneath(&source_root, Path::new(source_path))?;
         let skill = skills::read_skill(&path, source_path != ".")?;
-        if selected_name != Some(skill.name.as_str()) && selected_name != Some(source_path) {
+        if options.selected_name != Some(skill.name.as_str())
+            && options.selected_name != Some(source_path)
+        {
             return Err(Error::msg(format!(
-                "Locked skill path does not contain {selected_name:?}"
+                "Locked skill path does not contain {:?}",
+                options.selected_name
             )));
         }
         skill
     } else {
-        select_one_skill(&source_root, source_display, selected_name)?
+        select_one_skill(&source_root, options.source_display, options.selected_name)?
     };
-    let provenance = match (source_url, revision) {
+    crate::skillsets::ensure_standalone_source(&skill.path, &skill.name)?;
+    let provenance = match (options.source_url, options.revision) {
         (Some(url), Some(rev)) => {
             let rel = skill
                 .path
@@ -203,8 +368,8 @@ fn install_from_checkout(
                 .map_err(|_| {
                     Error::msg(format!(
                         "skill path {} is outside source {}",
-                        skill.path.display(),
-                        source_root.display()
+                        output::display_path(&skill.path),
+                        output::display_path(&source_root)
                     ))
                 })?
                 .to_string_lossy()
@@ -223,69 +388,6 @@ fn install_from_checkout(
         return place_from_library(project_root, &cached, destination_root);
     }
     place_skill(project_root, &skill, destination_root, provenance.as_ref())
-}
-
-pub(crate) fn add_locked_skill(
-    project_root: &Path,
-    name: &str,
-    source: LockedSource,
-) -> Result<AddOutcome, Error> {
-    match source {
-        LockedSource::LocalPath { path, .. } => {
-            init::ensure_project_layout(project_root)?;
-            crate::paths::refuse_symlink(&path)?;
-            if !path.exists() {
-                return Err(Error::msg(format!(
-                    "Path does not exist: {}",
-                    path.display()
-                )));
-            }
-            let source_root = path
-                .canonicalize()
-                .map_err(|e| crate::paths::map_io(&path, e))?;
-            let outcome = install_from_checkout(
-                project_root,
-                &source_root,
-                &source_root.display().to_string(),
-                &crate::home::project_skills_path(project_root),
-                Some(name),
-                None,
-                None,
-                None,
-            )?;
-            report_add(&outcome);
-            Ok(outcome)
-        }
-        LockedSource::Github {
-            remote,
-            revision,
-            path,
-        } => {
-            let (_clone, repository, tip) = git::checkout(&remote)?;
-            let (_old_checkout, source_root) = if tip == revision {
-                (None, repository)
-            } else {
-                let (temp, checkout) = git::checkout_revision(&repository, &revision)?;
-                (Some(temp), checkout)
-            };
-            install_from_checkout(
-                project_root,
-                &source_root,
-                &remote.display,
-                &crate::home::project_skills_path(project_root),
-                Some(name),
-                Some(&remote.url),
-                Some(&revision),
-                Some(&path),
-            )
-        }
-        LockedSource::EmbeddedManageTink if name == "manage-tink" => {
-            crate::manage_tink::install_manage_tink(project_root)
-        }
-        LockedSource::EmbeddedManageTink => Err(Error::msg(format!(
-            "Embedded source does not provide skill: {name}"
-        ))),
-    }
 }
 
 pub fn add_skill(
@@ -311,7 +413,6 @@ fn add_skill_inner(
     selected_name: Option<&str>,
     report: bool,
 ) -> Result<AddOutcome, Error> {
-    init::ensure_project_layout(project_root)?;
     let destination_root = crate::home::project_skills_path(project_root);
     match sources::classify_add_input(source_value)? {
         AddSource::LocalPath(local_source) => {
@@ -322,22 +423,24 @@ fn add_skill_inner(
             let outcome = install_from_checkout(
                 project_root,
                 &source_root,
-                &source_root.display().to_string(),
                 &destination_root,
-                selected_name,
-                None,
-                None,
-                None,
+                CheckoutInstallOptions {
+                    source_display: &output::display_path(&source_root),
+                    selected_name,
+                    source_url: None,
+                    revision: None,
+                    source_path: None,
+                },
             )?;
             if report {
-                report_add(&outcome);
+                report_add(&outcome)?;
             }
             Ok(outcome)
         }
         AddSource::Github(remote) => {
             let outcome = add_from_remote(project_root, &destination_root, &remote, selected_name)?;
             if report {
-                report_add(&outcome);
+                report_add(&outcome)?;
             }
             Ok(outcome)
         }
@@ -350,34 +453,34 @@ fn add_skill_inner(
             let skill = library::load(&name)?;
             let outcome = place_from_library(project_root, &skill, &destination_root)?;
             if report {
-                report_add(&outcome);
+                report_add(&outcome)?;
             }
             Ok(outcome)
         }
     }
 }
 
-fn report_add(outcome: &AddOutcome) {
+fn report_add(outcome: &AddOutcome) -> Result<(), Error> {
     let style = CliStyle::auto_stdout();
     match (outcome.created, outcome.origin) {
-        (true, AddOrigin::Library) => println!(
+        (true, AddOrigin::Library) => output::stdout_line(format_args!(
             "{} {} → {} {}",
             style.success("Installed"),
             style.skill(&outcome.name),
-            style.accent(outcome.project_path.display()),
+            style.accent(output::display_path(&outcome.project_path)),
             style.muted("(from library)")
-        ),
-        (true, AddOrigin::Source) => println!(
+        )),
+        (true, AddOrigin::Source) => output::stdout_line(format_args!(
             "{} {} → {}",
             style.success("Installed"),
             style.skill(&outcome.name),
-            style.accent(outcome.project_path.display())
-        ),
-        (false, _) => println!(
+            style.accent(output::display_path(&outcome.project_path))
+        )),
+        (false, _) => output::stdout_line(format_args!(
             "{} {}",
             style.muted("Unchanged"),
             style.skill(&outcome.name)
-        ),
+        )),
     }
 }
 
@@ -402,11 +505,129 @@ fn add_from_remote(
     install_from_checkout(
         project_root,
         &source_root,
-        &remote.display,
         destination_root,
-        selected_name,
-        Some(&remote.url),
-        Some(&revision),
-        selected_path.as_deref(),
+        CheckoutInstallOptions {
+            source_display: &remote.display,
+            selected_name,
+            source_url: Some(&remote.url),
+            revision: Some(&revision),
+            source_path: selected_path.as_deref(),
+        },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn prepared_local_skill_owns_snapshot_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("alpha");
+        fs::create_dir_all(&source).unwrap();
+        let original = "---\nname: alpha\ndescription: Original fixture.\n---\n\n# Alpha\n";
+        fs::write(source.join("SKILL.md"), original).unwrap();
+        let prepared = prepare_locked_skill(
+            "alpha",
+            LockedSource::LocalPath {
+                declared: "alpha".into(),
+                project_root: temp.path().to_path_buf(),
+            },
+        )
+        .unwrap();
+
+        fs::write(
+            source.join("SKILL.md"),
+            "---\nname: alpha\ndescription: Mutated fixture.\n---\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(prepared.skill().path.join("SKILL.md")).unwrap(),
+            original
+        );
+    }
+
+    #[test]
+    fn prepared_local_skill_refuses_receipt_owned_source() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("common-skillset");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join("SKILL.md"),
+            "---\nname: common-skillset\ndescription: Receipt fixture.\n---\n",
+        )
+        .unwrap();
+        fs::write(source.join(".tink-skillset.json"), "{}\n").unwrap();
+
+        let error = prepare_locked_skill(
+            "common-skillset",
+            LockedSource::LocalPath {
+                declared: "common-skillset".into(),
+                project_root: temp.path().to_path_buf(),
+            },
+        )
+        .err()
+        .expect("receipt-owned source must be refused");
+
+        assert!(
+            error
+                .to_string()
+                .contains("tink skillset add common-skillset"),
+            "{error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepared_local_skill_refuses_symlinked_ancestor() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let outside = temp.path().join("outside");
+        let source = outside.join("alpha");
+        fs::create_dir_all(&project).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join("SKILL.md"),
+            "---\nname: alpha\ndescription: Outside fixture.\n---\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&outside, project.join("jump")).unwrap();
+
+        let error = prepare_locked_skill(
+            "alpha",
+            LockedSource::LocalPath {
+                declared: "jump/alpha".into(),
+                project_root: project,
+            },
+        )
+        .err()
+        .expect("ancestor symlink must be refused");
+
+        assert!(error.to_string().contains("symlink"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn locked_remote_skill_refuses_symlinked_ancestor() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkout = temp.path().join("checkout");
+        let outside = temp.path().join("outside");
+        let source = outside.join("alpha");
+        fs::create_dir_all(&checkout).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join("SKILL.md"),
+            "---\nname: alpha\ndescription: Outside fixture.\n---\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&outside, checkout.join("jump")).unwrap();
+
+        let error = select_locked_skill(&checkout, "alpha", Some("jump/alpha"))
+            .expect_err("ancestor symlink must be refused");
+
+        assert!(error.to_string().contains("symlink"), "{error}");
+    }
 }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -5,9 +5,11 @@
 
 use std::collections::BTreeSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use crate::error::Error;
 use crate::home::{
@@ -17,11 +19,7 @@ use crate::home::{
 use crate::paths::{map_io, mkdir_p, refuse_symlink, require_directory, require_file};
 
 fn safe_project_dirname(name: &str) -> String {
-    let cleaned = name
-        .trim()
-        .replace('/', "-")
-        .replace('\\', "-")
-        .replace('\0', "");
+    let cleaned = name.trim().replace(['/', '\\'], "-").replace('\0', "");
     let cleaned = cleaned.trim_end_matches(['.', ' ']);
     if cleaned.is_empty() || cleaned == "." || cleaned == ".." {
         "project".into()
@@ -31,13 +29,40 @@ fn safe_project_dirname(name: &str) -> String {
 }
 
 fn project_catalog_dir(home: &Path, project_root: &Path) -> Result<PathBuf, Error> {
-    Ok(by_project_path(home).join(safe_project_root_name(project_root)))
+    // Leave ample room below the portable 255-byte component limit for the
+    // separator and fixed-width identity, without splitting a UTF-8 scalar.
+    let mut basename = safe_project_root_name(project_root);
+    while basename.len() > 120 {
+        basename.pop();
+    }
+    if basename.is_empty() {
+        basename.push_str("project");
+    }
+    let identity = project_identity(project_root);
+    Ok(by_project_path(home).join(format!("{basename}-{identity}")))
+}
+
+fn project_identity(project_root: &Path) -> String {
+    #[cfg(unix)]
+    let root_bytes = {
+        use std::os::unix::ffi::OsStrExt;
+
+        project_root.as_os_str().as_bytes().to_vec()
+    };
+    #[cfg(not(unix))]
+    let root_bytes = project_root.to_string_lossy().into_owned().into_bytes();
+    format!("{:x}", Sha256::digest(root_bytes))
+}
+
+fn legacy_project_catalog_dir(home: &Path, project_root: &Path) -> PathBuf {
+    by_project_path(home).join(safe_project_root_name(project_root))
 }
 
 #[derive(Debug, Clone)]
 struct CatalogMeta {
     name: String,
     root: String,
+    identity: Option<String>,
     skills: BTreeSet<String>,
 }
 
@@ -46,6 +71,7 @@ impl CatalogMeta {
         Self {
             name: safe_project_root_name(project_root),
             root: project_root.to_string_lossy().into_owned(),
+            identity: Some(project_identity(project_root)),
             skills: BTreeSet::new(),
         }
     }
@@ -62,6 +88,10 @@ impl CatalogMeta {
                 .and_then(|v| v.as_str())
                 .map(str::to_string)
                 .unwrap_or_default(),
+            identity: value
+                .get("identity")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
             skills: value
                 .get("skills")
                 .and_then(|v| v.as_array())
@@ -88,37 +118,44 @@ impl CatalogMeta {
         let body = json!({
             "name": self.name,
             "root": self.root,
+            "identity": self.identity,
             "skills": self.skills.iter().cloned().collect::<Vec<_>>()
         });
         let text = format!(
             "{}\n",
             serde_json::to_string_pretty(&body).map_err(|e| Error::msg(e.to_string()))?
         );
-        fs::write(meta_path, text).map_err(|e| map_io(meta_path, e))?;
+        let parent = meta_path
+            .parent()
+            .ok_or_else(|| Error::msg("Catalog metadata path has no parent"))?;
+        let mut staged = tempfile::Builder::new()
+            .prefix(".meta-")
+            .tempfile_in(parent)
+            .map_err(|e| map_io(parent, e))?;
+        staged
+            .write_all(text.as_bytes())
+            .map_err(|e| map_io(staged.path(), e))?;
+        staged.flush().map_err(|e| map_io(staged.path(), e))?;
+        staged
+            .persist(meta_path)
+            .map_err(|e| map_io(meta_path, e.error))?;
         Ok(())
     }
 
     /// Whether withdraw/forget may mutate this entry for `project_root`.
     ///
-    /// Non-empty `meta.root` must canonicalize to `project_root` (already
-    /// canonical). Missing/empty `root` keeps basename-keyed behavior for
-    /// legacy metas. Unresolvable stored roots soft-refuse so a sibling basename
-    /// cannot wipe another project's catalog.
+    /// `meta.root` must canonicalize to `project_root` (already canonical).
+    /// Missing, empty, or unresolvable roots are not ownership proof.
     fn catalog_owned_by(&self, project_root: &Path) -> bool {
+        if let Some(identity) = &self.identity {
+            return identity == &project_identity(project_root);
+        }
         if self.root.is_empty() {
-            return true;
+            return false;
         }
         match Path::new(&self.root).canonicalize() {
             Ok(canon) => canon == project_root,
             Err(_) => false,
-        }
-    }
-
-    /// Seal empty/missing root to the withdrawing project when siblings remain,
-    /// matching pre-`CatalogMeta` write behavior (`root` defaulted to project).
-    fn seal_root_if_empty(&mut self, project_root: &Path) {
-        if self.root.is_empty() {
-            self.root = project_root.to_string_lossy().into_owned();
         }
     }
 
@@ -155,6 +192,55 @@ fn remove_catalog_dir(catalog: &Path) -> Result<(), Error> {
     Ok(())
 }
 
+fn validate_catalog_dir(catalog: &Path) -> Result<Option<PathBuf>, Error> {
+    if !catalog.exists() && !catalog.is_symlink() {
+        return Ok(None);
+    }
+    refuse_symlink(catalog)?;
+    if !catalog.is_dir() {
+        return Err(Error::msg(format!(
+            "Refusing non-directory catalog: {}",
+            catalog.display()
+        )));
+    }
+    let meta = catalog.join("meta.json");
+    require_file(&meta)?;
+    if !meta.is_file() {
+        return Ok(None);
+    }
+    Ok(Some(catalog.to_path_buf()))
+}
+
+/// Move a basename-keyed entry only when its stored canonical root proves it
+/// belongs to this project. Ambiguous and foreign entries remain untouched.
+fn migrate_owned_legacy_catalog(
+    home: &Path,
+    project_root: &Path,
+    destination: &Path,
+) -> Result<(), Error> {
+    if destination.exists() || destination.is_symlink() {
+        return Ok(());
+    }
+    let legacy = legacy_project_catalog_dir(home, project_root);
+    let Some(legacy) = validate_catalog_dir(&legacy)? else {
+        return Ok(());
+    };
+    let meta_path = legacy.join("meta.json");
+    let meta = CatalogMeta::read(&meta_path, project_root)?;
+    if !meta.catalog_owned_by(project_root) {
+        if meta.identity.is_none()
+            && (meta.root.is_empty() || Path::new(&meta.root).canonicalize().is_err())
+        {
+            return Err(Error::msg(format!(
+                "Cannot migrate ambiguous legacy catalog {}; restore its canonical root field or remove the stale entry",
+                legacy.display()
+            )));
+        }
+        return Ok(());
+    }
+    fs::rename(&legacy, destination).map_err(|e| map_io(destination, e))
+}
+
 /// Find an existing project catalog only after validating the owned home and
 /// every directory boundary that a destructive operation would traverse.
 fn existing_project_catalog(
@@ -186,26 +272,67 @@ fn existing_project_catalog(
     }
 
     let catalog = project_catalog_dir(&home, project_root)?;
-    if !catalog.exists() && !catalog.is_symlink() {
+    if let Some(catalog) = validate_catalog_dir(&catalog)? {
+        return Ok(Some(catalog));
+    }
+
+    let legacy = legacy_project_catalog_dir(&home, project_root);
+    let Some(legacy) = validate_catalog_dir(&legacy)? else {
         return Ok(None);
-    }
-    refuse_symlink(&catalog)?;
-    if !catalog.is_dir() {
-        return Err(Error::msg(format!(
-            "Refusing to remove non-directory catalog: {}",
-            catalog.display()
-        )));
-    }
-    require_file(&catalog.join("meta.json"))?;
-    Ok(Some(catalog))
+    };
+    let meta = CatalogMeta::read(&legacy.join("meta.json"), project_root)?;
+    Ok(meta.catalog_owned_by(project_root).then_some(legacy))
 }
 
 /// Record that `skill_name` is installed in `project_root`.
 ///
-/// Last writer wins on `meta.json` `root` when two projects share a basename.
 /// Failure fails the caller.
 pub fn deposit_skill(project_root: &Path, skill_name: &str) -> Result<PathBuf, Error> {
     deposit_skill_at(None, project_root, skill_name)
+}
+
+/// Validate every catalog boundary that a later deposit will traverse.
+/// Inventory creation may occur, but no project entry or skill name is written.
+pub(crate) fn preflight_deposit_skill(project_root: &Path) -> Result<(), Error> {
+    preflight_deposit_skill_at(None, project_root)
+}
+
+pub(crate) fn preflight_deposit_skill_at(
+    home: Option<&Path>,
+    project_root: &Path,
+) -> Result<(), Error> {
+    let project_root = project_root
+        .canonicalize()
+        .map_err(|e| map_io(project_root, e))?;
+    let (home, _) = ensure_inventory_root(home)?;
+    let catalog = project_catalog_dir(&home, &project_root)?;
+    require_directory(&catalog)?;
+    if let Some(existing) = validate_catalog_dir(&catalog)? {
+        let meta = CatalogMeta::read(&existing.join("meta.json"), &project_root)?;
+        if !meta.catalog_owned_by(&project_root) {
+            return Err(Error::msg(format!(
+                "Catalog identity belongs to another project: {}",
+                catalog.display()
+            )));
+        }
+        return Ok(());
+    }
+
+    let legacy = legacy_project_catalog_dir(&home, &project_root);
+    let Some(legacy) = validate_catalog_dir(&legacy)? else {
+        return Ok(());
+    };
+    let meta = CatalogMeta::read(&legacy.join("meta.json"), &project_root)?;
+    if !meta.catalog_owned_by(&project_root)
+        && meta.identity.is_none()
+        && (meta.root.is_empty() || Path::new(&meta.root).canonicalize().is_err())
+    {
+        return Err(Error::msg(format!(
+            "Cannot migrate ambiguous legacy catalog {}; restore its canonical root field or remove the stale entry",
+            legacy.display()
+        )));
+    }
+    Ok(())
 }
 
 /// Like [`deposit_skill`], with an optional home root (tests).
@@ -219,6 +346,7 @@ pub(crate) fn deposit_skill_at(
         .map_err(|e| map_io(project_root, e))?;
     let (home, _) = ensure_inventory_root(home)?;
     let catalog = project_catalog_dir(&home, &project_root)?;
+    migrate_owned_legacy_catalog(&home, &project_root, &catalog)?;
     require_directory(&catalog)?;
     mkdir_p(&catalog)?;
 
@@ -226,12 +354,20 @@ pub(crate) fn deposit_skill_at(
     require_file(&meta_path)?;
 
     let mut meta = if meta_path.is_file() {
-        CatalogMeta::read(&meta_path, &project_root)?
+        let meta = CatalogMeta::read(&meta_path, &project_root)?;
+        if !meta.catalog_owned_by(&project_root) {
+            return Err(Error::msg(format!(
+                "Catalog identity belongs to another project: {}",
+                catalog.display()
+            )));
+        }
+        meta
     } else {
         CatalogMeta::by_project(&project_root)
     };
     meta.name = safe_project_root_name(&project_root);
     meta.root = project_root.to_string_lossy().into_owned();
+    meta.identity = Some(project_identity(&project_root));
     meta.add_skill(skill_name);
     meta.write(&meta_path)?;
     Ok(catalog)
@@ -240,9 +376,9 @@ pub(crate) fn deposit_skill_at(
 /// Drop `skill_name` from the by-project catalog for `project_root`.
 ///
 /// Soft success when home, project entry, or name is already absent, or when
-/// `meta.root` belongs to a different project sharing this basename. Never
-/// creates inventory. Preserves existing meta `name`/`root` when siblings
-/// remain. Removes the project catalog directory when no names remain.
+/// stored ownership cannot be proven. Never creates inventory. Preserves
+/// existing meta `name`/`root` when siblings remain. Removes the project
+/// catalog directory when no names remain.
 pub fn withdraw_skill(project_root: &Path, skill_name: &str) -> Result<(), Error> {
     withdraw_skill_at(None, project_root, skill_name)
 }
@@ -276,9 +412,6 @@ pub(crate) fn withdraw_skill_at(
     if meta.skills.is_empty() {
         return remove_catalog_dir(&catalog);
     }
-    // Legacy metas omit `root`; after partial withdraw, seal ownership so a
-    // foreign basename checkout cannot soft-own remaining skill names.
-    meta.seal_root_if_empty(&project_root);
     meta.write(&meta_path)
 }
 
@@ -288,6 +421,30 @@ pub(crate) fn withdraw_skill_at(
 /// project sharing this basename. Does not create inventory or touch library.
 pub fn forget_project(project_root: &Path) -> Result<(), Error> {
     forget_project_at(None, project_root)
+}
+
+/// Validate catalog cleanup before destructive project filesystem changes.
+pub(crate) fn preflight_forget_project(project_root: &Path) -> Result<(), Error> {
+    preflight_forget_project_at(None, project_root)
+}
+
+pub(crate) fn preflight_forget_project_at(
+    home: Option<&Path>,
+    project_root: &Path,
+) -> Result<(), Error> {
+    let project_root = match project_root.canonicalize() {
+        Ok(path) => path,
+        Err(_) => return Ok(()),
+    };
+    let Some(catalog) = existing_project_catalog(home, &project_root)? else {
+        return Ok(());
+    };
+    let meta_path = catalog.join("meta.json");
+    if meta_path.is_file() {
+        refuse_symlink(&meta_path)?;
+        let _ = CatalogMeta::read(&meta_path, &project_root)?;
+    }
+    Ok(())
 }
 
 /// Like [`forget_project`], with an optional home root (tests).
@@ -356,9 +513,12 @@ pub fn list_catalog(home: Option<&Path>) -> Result<Vec<CatalogEntry>, Error> {
     let mut entries = Vec::new();
     let mut dirs: Vec<_> = fs::read_dir(&by_project)
         .map_err(|e| map_io(&by_project, e))?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .collect();
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|e| map_io(&by_project, e))
+        })
+        .collect::<Result<_, _>>()?;
     dirs.sort();
 
     for dir in dirs {
@@ -367,7 +527,7 @@ pub fn list_catalog(home: Option<&Path>) -> Result<Vec<CatalogEntry>, Error> {
             .and_then(|s| s.to_str())
             .unwrap_or("")
             .to_string();
-        if name.is_empty() || name.starts_with('.') {
+        if name.is_empty() {
             continue;
         }
         if dir.is_symlink() || !dir.is_dir() {
@@ -447,9 +607,10 @@ mod tests {
         assert_eq!(meta.skills.iter().collect::<Vec<_>>().len(), 1);
         assert!(!meta.withdraw_skill("missing"));
 
-        // Empty root: legacy basename soft-own.
+        // Empty root is ambiguous and never proves ownership.
+        meta.identity = None;
         meta.root.clear();
-        assert!(meta.catalog_owned_by(&project));
+        assert!(!meta.catalog_owned_by(&project));
         // Unresolvable path: soft-refuse.
         meta.root = project
             .join("does-not-exist-ownership-probe")
@@ -472,58 +633,30 @@ mod tests {
     }
 
     #[test]
-    fn withdraw_seals_empty_root_and_blocks_foreign_forget() {
+    fn destructive_operations_do_not_claim_empty_root_metadata() {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
-        let clone_a = temp.path().join("clone-a").join("app");
-        let clone_b = temp.path().join("clone-b").join("app");
-        fs::create_dir_all(&clone_a).unwrap();
-        fs::create_dir_all(&clone_b).unwrap();
-        let catalog = deposit_skill_at(Some(&home), &clone_a, "alpha").unwrap();
-        deposit_skill_at(Some(&home), &clone_a, "beta").unwrap();
+        let project = temp.path().join("app");
+        fs::create_dir_all(&project).unwrap();
+        let catalog = deposit_skill_at(Some(&home), &project, "alpha").unwrap();
+        deposit_skill_at(Some(&home), &project, "beta").unwrap();
 
-        // Legacy: missing/empty root still soft-owns for the first withdraws.
         let meta_path = catalog.join("meta.json");
         let mut value: Value =
             serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
         value["root"] = json!("");
+        value.as_object_mut().unwrap().remove("identity");
         fs::write(
             &meta_path,
             format!("{}\n", serde_json::to_string_pretty(&value).unwrap()),
         )
         .unwrap();
+        let before = fs::read(&meta_path).unwrap();
 
-        withdraw_skill_at(Some(&home), &clone_a, "alpha").unwrap();
-        let after: Value = serde_json::from_str(&fs::read_to_string(&meta_path).unwrap()).unwrap();
-        let sealed = after["root"].as_str().unwrap_or("");
-        assert!(
-            !sealed.is_empty(),
-            "empty root should seal after partial withdraw"
-        );
-        assert_eq!(
-            Path::new(sealed).canonicalize().unwrap(),
-            clone_a.canonicalize().unwrap()
-        );
-        assert_eq!(
-            after["skills"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .filter_map(|s| s.as_str())
-                .collect::<Vec<_>>(),
-            vec!["beta"]
-        );
+        withdraw_skill_at(Some(&home), &project, "alpha").unwrap();
+        forget_project_at(Some(&home), &project).unwrap();
 
-        // Foreign basename must not forget remaining names after seal.
-        forget_project_at(Some(&home), &clone_b).unwrap();
-        assert_eq!(
-            list_catalog(Some(&home))
-                .unwrap()
-                .iter()
-                .map(|e| e.skill.as_str())
-                .collect::<Vec<_>>(),
-            vec!["beta"]
-        );
+        assert_eq!(fs::read(&meta_path).unwrap(), before);
     }
 
     #[test]
@@ -562,6 +695,198 @@ mod tests {
                 .any(|s| s == "grill-me")
         );
         assert!(!catalog.join("grill-me").exists());
+    }
+
+    #[test]
+    fn projects_with_the_same_basename_have_distinct_catalog_identities() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let first = temp.path().join("first").join("app");
+        let second = temp.path().join("second").join("app");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+
+        let first_catalog = deposit_skill_at(Some(&home), &first, "alpha").unwrap();
+        let second_catalog = deposit_skill_at(Some(&home), &second, "beta").unwrap();
+
+        assert_ne!(first_catalog, second_catalog);
+        let rows = list_catalog(Some(&home)).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().any(|row| {
+            row.root == first.canonicalize().unwrap().to_string_lossy() && row.skill == "alpha"
+        }));
+        assert!(rows.iter().any(|row| {
+            row.root == second.canonicalize().unwrap().to_string_lossy() && row.skill == "beta"
+        }));
+    }
+
+    #[test]
+    fn long_project_basename_stays_within_component_limit() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = temp.path().join("p".repeat(200));
+        fs::create_dir_all(&project).unwrap();
+
+        let catalog = deposit_skill_at(Some(&home), &project, "alpha").unwrap();
+
+        assert!(
+            catalog.file_name().unwrap().to_string_lossy().len() <= 255,
+            "catalog component exceeded common filesystem NAME_MAX: {}",
+            catalog.display()
+        );
+        deposit_skill_at(Some(&home), &project, "beta").unwrap();
+        assert_eq!(list_catalog(Some(&home)).unwrap().len(), 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_project_root_keeps_catalog_ownership() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = temp
+            .path()
+            .join(OsString::from_vec(b"project-\x80".to_vec()));
+        if let Err(error) = fs::create_dir_all(&project) {
+            assert_eq!(
+                error.raw_os_error(),
+                Some(92),
+                "unexpected fixture error: {error}"
+            );
+            return;
+        }
+
+        deposit_skill_at(Some(&home), &project, "alpha").unwrap();
+        deposit_skill_at(Some(&home), &project, "beta").unwrap();
+        withdraw_skill_at(Some(&home), &project, "alpha").unwrap();
+        assert_eq!(
+            list_catalog(Some(&home))
+                .unwrap()
+                .iter()
+                .map(|entry| entry.skill.as_str())
+                .collect::<Vec<_>>(),
+            vec!["beta"]
+        );
+        forget_project_at(Some(&home), &project).unwrap();
+        assert!(list_catalog(Some(&home)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn deposit_refuses_ambiguous_legacy_catalog() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = temp.path().join("app");
+        fs::create_dir_all(&project).unwrap();
+        let project = project.canonicalize().unwrap();
+        ensure_inventory_root(Some(&home)).unwrap();
+        let legacy = legacy_project_catalog_dir(&home, &project);
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(
+            legacy.join("meta.json"),
+            "{\"name\":\"app\",\"skills\":[\"legacy\"]}\n",
+        )
+        .unwrap();
+
+        let error = deposit_skill_at(Some(&home), &project, "alpha").unwrap_err();
+
+        assert!(
+            error.to_string().contains("ambiguous legacy catalog"),
+            "{error}"
+        );
+        assert!(legacy.join("meta.json").is_file());
+        assert!(!project_catalog_dir(&home, &project).unwrap().exists());
+    }
+
+    #[test]
+    fn deposit_surfaces_malformed_legacy_catalog() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = temp.path().join("app");
+        fs::create_dir_all(&project).unwrap();
+        let project = project.canonicalize().unwrap();
+        ensure_inventory_root(Some(&home)).unwrap();
+        let legacy = legacy_project_catalog_dir(&home, &project);
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("meta.json"), "{not-json}\n").unwrap();
+
+        let error = deposit_skill_at(Some(&home), &project, "alpha").unwrap_err();
+
+        assert!(
+            error.to_string().contains("Invalid catalog meta"),
+            "{error}"
+        );
+        assert!(!project_catalog_dir(&home, &project).unwrap().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn catalog_identity_does_not_normalize_backslash_into_separator() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let backslash = temp.path().join("a\\b").join("app");
+        let separator = temp.path().join("a").join("b").join("app");
+        fs::create_dir_all(&backslash).unwrap();
+        fs::create_dir_all(&separator).unwrap();
+
+        let first = deposit_skill_at(Some(&home), &backslash, "alpha").unwrap();
+        let second = deposit_skill_at(Some(&home), &separator, "beta").unwrap();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn deposit_migrates_legacy_catalog_with_matching_root() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = temp.path().join("app");
+        fs::create_dir_all(&project).unwrap();
+        let project = project.canonicalize().unwrap();
+        ensure_inventory_root(Some(&home)).unwrap();
+        let legacy = legacy_project_catalog_dir(&home, &project);
+        fs::create_dir_all(&legacy).unwrap();
+        let mut meta = CatalogMeta::by_project(&project);
+        meta.add_skill("alpha");
+        meta.write(&legacy.join("meta.json")).unwrap();
+
+        let catalog = deposit_skill_at(Some(&home), &project, "beta").unwrap();
+
+        assert_ne!(catalog, legacy);
+        assert!(!legacy.exists());
+        assert_eq!(
+            list_catalog(Some(&home))
+                .unwrap()
+                .iter()
+                .map(|entry| entry.skill.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta"]
+        );
+    }
+
+    #[test]
+    fn deposit_leaves_foreign_legacy_catalog_untouched() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let first = temp.path().join("first").join("app");
+        let second = temp.path().join("second").join("app");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+        let first = first.canonicalize().unwrap();
+        ensure_inventory_root(Some(&home)).unwrap();
+        let legacy = legacy_project_catalog_dir(&home, &first);
+        fs::create_dir_all(&legacy).unwrap();
+        let mut meta = CatalogMeta::by_project(&first);
+        meta.add_skill("alpha");
+        let meta_path = legacy.join("meta.json");
+        meta.write(&meta_path).unwrap();
+        let before = fs::read(&meta_path).unwrap();
+
+        let second_catalog = deposit_skill_at(Some(&home), &second, "beta").unwrap();
+
+        assert_ne!(second_catalog, legacy);
+        assert_eq!(fs::read(&meta_path).unwrap(), before);
+        assert_eq!(list_catalog(Some(&home)).unwrap().len(), 2);
     }
 
     #[test]

--- a/src/check.rs
+++ b/src/check.rs
@@ -45,9 +45,12 @@ pub fn load_project_skills(root: &Path) -> Result<Vec<Skill>, Error> {
 
     let mut entries: Vec<_> = fs::read_dir(&skills_root)
         .map_err(|e| map_io(&skills_root, e))?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .collect();
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|e| map_io(&skills_root, e))
+        })
+        .collect::<Result<_, _>>()?;
     entries.sort();
 
     let mut skills = Vec::new();

--- a/src/destroy.rs
+++ b/src/destroy.rs
@@ -14,18 +14,30 @@ pub struct DestroyReport {
     pub removed: Vec<PathBuf>,
 }
 
-/// Drop this project's by-project catalog entry, then remove `.agents/`,
-/// `ZEN.md`, and `AGENTS.md` from the project root. Does not touch the home
-/// library. Catalog sync runs before disk deletes; sync errors leave project
-/// files intact. Refuses symlinks. Requires `--yes` or an interactive `y`
-/// confirmation (default no).
+/// Remove this project's `.agents/skills/`, then drop its by-project catalog
+/// entry. An empty `.agents/` directory is removed, but unrelated siblings are
+/// preserved.
+/// `ZEN.md` and `AGENTS.md` are preserved because the current
+/// project layout has no durable proof that Tink created either file. Does not
+/// touch the home library. Catalog cleanup is preflighted before disk deletes;
+/// expected catalog refusals leave project files intact. Refuses symlinks.
+/// Requires `--yes` or an
+/// interactive `y` confirmation (default no).
 pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, Error> {
+    destroy_project_at(project_root, yes, None)
+}
+
+fn destroy_project_at(
+    project_root: &Path,
+    yes: bool,
+    catalog_home: Option<&Path>,
+) -> Result<DestroyReport, Error> {
     if !yes {
         confirm_destroy()?;
     }
 
-    let mut to_remove = Vec::new();
     let agents = crate::home::project_agents_path(project_root);
+    let skills = crate::home::project_skills_path(project_root);
     if agents.exists() || agents.is_symlink() {
         refuse_symlink(&agents)?;
         if !agents.is_dir() {
@@ -34,35 +46,42 @@ pub fn destroy_project(project_root: &Path, yes: bool) -> Result<DestroyReport, 
                 agents.display()
             )));
         }
-        to_remove.push(agents);
     }
-
-    for name in ["ZEN.md", "AGENTS.md"] {
-        let path = project_root.join(name);
-        if !path.exists() && !path.is_symlink() {
-            continue;
-        }
-        refuse_symlink(&path)?;
-        if !path.is_file() {
+    if skills.exists() || skills.is_symlink() {
+        refuse_symlink(&skills)?;
+        if !skills.is_dir() {
             return Err(Error::msg(format!(
-                "Refusing to remove non-file: {}",
-                path.display()
+                "Refusing to remove non-directory: {}",
+                skills.display()
             )));
         }
-        to_remove.push(path);
     }
 
-    catalog::forget_project(project_root)?;
+    match catalog_home {
+        Some(home) => catalog::preflight_forget_project_at(Some(home), project_root)?,
+        None => catalog::preflight_forget_project(project_root)?,
+    }
 
     let mut removed = Vec::new();
-    for path in to_remove {
-        if path.is_dir() {
-            fs::remove_dir_all(&path).map_err(|e| map_io(&path, e))?;
-        } else {
-            fs::remove_file(&path).map_err(|e| map_io(&path, e))?;
-        }
-        removed.push(path);
+    if skills.is_dir() {
+        fs::remove_dir_all(&skills).map_err(|e| map_io(&skills, e))?;
+        removed.push(skills);
     }
+    if agents.is_dir()
+        && fs::read_dir(&agents)
+            .map_err(|e| map_io(&agents, e))?
+            .next()
+            .is_none()
+    {
+        fs::remove_dir(&agents).map_err(|e| map_io(&agents, e))?;
+        removed.push(agents);
+    }
+
+    match catalog_home {
+        Some(home) => catalog::forget_project_at(Some(home), project_root)?,
+        None => catalog::forget_project(project_root)?,
+    }
+
     Ok(DestroyReport { removed })
 }
 
@@ -77,7 +96,7 @@ fn confirm_destroy() -> Result<(), Error> {
     write!(
         stdout,
         "{} {}",
-        style.warn("Delete .agents/, ZEN.md, and AGENTS.md in this project?"),
+        style.warn("Delete .agents/skills/ in this project?"),
         style.accent("[y/N]")
     )
     .map_err(|e| Error::msg(format!("prompt: {e}")))?;
@@ -94,4 +113,70 @@ fn confirm_destroy() -> Result<(), Error> {
         return Ok(());
     }
     Err(Error::msg("Destroy cancelled"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn destroy_preserves_preexisting_project_guidance() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let home = temp.path().join("home");
+        fs::create_dir_all(crate::home::project_skills_path(&project)).unwrap();
+        let agents_body = "# Existing agent guidance\n";
+        let zen_body = "# Existing maintainability guidance\n";
+        fs::write(project.join("AGENTS.md"), agents_body).unwrap();
+        fs::write(project.join("ZEN.md"), zen_body).unwrap();
+        catalog::deposit_skill_at(Some(&home), &project, "alpha").unwrap();
+
+        let report = destroy_project_at(&project, true, Some(&home)).unwrap();
+        assert!(!crate::home::project_agents_path(&project).exists());
+        assert!(catalog::list_catalog(Some(&home)).unwrap().is_empty());
+        assert!(
+            project.join("AGENTS.md").is_file(),
+            "destroy removed pre-existing AGENTS.md"
+        );
+        assert!(
+            project.join("ZEN.md").is_file(),
+            "destroy removed pre-existing ZEN.md"
+        );
+        assert_eq!(
+            fs::read_to_string(project.join("AGENTS.md")).unwrap(),
+            agents_body
+        );
+        assert_eq!(
+            fs::read_to_string(project.join("ZEN.md")).unwrap(),
+            zen_body
+        );
+        assert_eq!(
+            report.removed,
+            vec![
+                crate::home::project_skills_path(&project),
+                crate::home::project_agents_path(&project)
+            ]
+        );
+    }
+
+    #[test]
+    fn destroy_preserves_unrelated_agents_siblings() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let home = temp.path().join("home");
+        let agents = crate::home::project_agents_path(&project);
+        fs::create_dir_all(crate::home::project_skills_path(&project)).unwrap();
+        fs::write(agents.join("foreign-config.json"), b"keep\n").unwrap();
+        catalog::deposit_skill_at(Some(&home), &project, "alpha").unwrap();
+
+        destroy_project_at(&project, true, Some(&home)).unwrap();
+
+        assert!(!crate::home::project_skills_path(&project).exists());
+        assert_eq!(
+            fs::read(agents.join("foreign-config.json")).unwrap(),
+            b"keep\n"
+        );
+        assert!(agents.is_dir());
+        assert!(catalog::list_catalog(Some(&home)).unwrap().is_empty());
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,47 @@
 //! User-facing refusals and failures.
 
 use std::fmt;
+use std::io;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorKind {
+    Message,
+    StdoutBrokenPipe,
+    StderrBrokenPipe,
+}
 
 #[derive(Debug)]
 pub struct Error {
     message: String,
+    kind: ErrorKind,
 }
 
 impl Error {
     pub fn msg(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            kind: ErrorKind::Message,
         }
+    }
+
+    pub(crate) fn output(stream: &str, error: io::Error) -> Self {
+        let kind = if error.kind() == io::ErrorKind::BrokenPipe {
+            if stream == "stdout" {
+                ErrorKind::StdoutBrokenPipe
+            } else {
+                ErrorKind::StderrBrokenPipe
+            }
+        } else {
+            ErrorKind::Message
+        };
+        Self {
+            message: format!("{stream}: {error}"),
+            kind,
+        }
+    }
+
+    pub(crate) fn is_stdout_broken_pipe(&self) -> bool {
+        self.kind == ErrorKind::StdoutBrokenPipe
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use tempfile::TempDir;
 
@@ -11,6 +12,7 @@ use crate::sources::RemoteSource;
 
 const GIT_LOW_SPEED_LIMIT_SETTING: &str = "http.lowSpeedLimit=1024";
 const GIT_LOW_SPEED_TIME_SETTING: &str = "http.lowSpeedTime=30";
+const GIT_TIMEOUT: Duration = Duration::from_secs(300);
 
 fn git_transport_args() -> [&'static str; 4] {
     [
@@ -45,17 +47,7 @@ fn run_git(
         command.current_dir(cwd);
     }
 
-    command.output().map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            if let Some(missing_message) = missing_message {
-                Error::msg(missing_message)
-            } else {
-                Error::msg(format!("{io_context}: {e}"))
-            }
-        } else {
-            Error::msg(format!("{io_context}: {e}"))
-        }
-    })
+    crate::process::run_bounded(&mut command, GIT_TIMEOUT, io_context, missing_message)
 }
 
 fn git_detail(stderr: &[u8], fallback: &str) -> String {

--- a/src/home.rs
+++ b/src/home.rs
@@ -43,7 +43,7 @@ skills only from a project's `.agents/skills/`.
 Successful installs:
 - copy skill and validated project skillset trees into the library under `skills/<name>/`
 - skillsets use canonical `<name>-skillset` roots; their project tree is primary
-- record skill **names** under `catalog/by-project/<project>/meta.json`
+- record skill **names** under `catalog/by-project/<bounded-name>-<identity>/meta.json`
 - read pinned skillset definitions from `catalog/by-skillset/<name>/meta.json`
 
 `skill remove` and `destroy` update that name catalog; they do not delete
@@ -82,10 +82,10 @@ fn normalize_lexically(path: &Path) -> PathBuf {
 
 /// Resolve the offline inventory root.
 pub fn resolve_home() -> Result<PathBuf, Error> {
-    if let Ok(custom) = env::var(TINK_HOME_ENV) {
-        if !custom.is_empty() {
-            return absolutize(PathBuf::from(custom));
-        }
+    if let Ok(custom) = env::var(TINK_HOME_ENV)
+        && !custom.is_empty()
+    {
+        return absolutize(PathBuf::from(custom));
     }
     let home = env::var_os("HOME").ok_or_else(|| Error::msg("HOME is not set"))?;
     absolutize(PathBuf::from(home).join(TINK_HOME_NAME))

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,12 +1,13 @@
 //! Minimal project skill home: `.agents/skills/` (+ optional ZEN / tink-skills / manage-tink).
 
-use std::io::{self, BufRead, IsTerminal, Write};
+use std::io::{self, BufRead, IsTerminal};
 use std::path::{Path, PathBuf};
 
 use crate::add;
 use crate::error::Error;
 use crate::home;
 use crate::manage_tink;
+use crate::output;
 use crate::paths::{map_io, mkdir_p, require_directory, require_file};
 use crate::style::CliStyle;
 use crate::templates::{
@@ -60,12 +61,10 @@ pub fn opt_in(explicit: Option<bool>, question: &str, hint: Option<&str>) -> Res
     }
     let style = CliStyle::auto_stdout();
     if let Some(hint) = hint {
-        println!("{}", style.muted(hint));
+        output::stdout_line(format_args!("{}", style.muted(hint)))?;
     }
-    print!("{} {}", question, style.accent("[y/N] "));
-    io::stdout()
-        .flush()
-        .map_err(|e| Error::msg(format!("prompt: {e}")))?;
+    output::stdout(format_args!("{} {}", question, style.accent("[y/N] ")))?;
+    output::flush_stdout()?;
     let mut line = String::new();
     io::stdin()
         .lock()
@@ -94,11 +93,9 @@ fn opt_in_zen(explicit: Option<bool>) -> Result<bool, Error> {
     let hint = format!("{r} = print {zen} without adding it");
     let choices = format!("[{}/{}/{}] ", style.accent("y"), style.accent("N"), r);
     loop {
-        println!("{hint}");
-        print!("{question} {choices}");
-        io::stdout()
-            .flush()
-            .map_err(|e| Error::msg(format!("prompt: {e}")))?;
+        output::stdout_line(format_args!("{hint}"))?;
+        output::stdout(format_args!("{question} {choices}"))?;
+        output::flush_stdout()?;
         let mut line = String::new();
         io::stdin()
             .lock()
@@ -108,9 +105,9 @@ fn opt_in_zen(explicit: Option<bool>) -> Result<bool, Error> {
         match answer.as_str() {
             "y" | "yes" => return Ok(true),
             "r" | "read" => {
-                println!();
-                println!("{}", style.muted(ZEN.trim_end()));
-                println!();
+                output::stdout_line(format_args!(""))?;
+                output::stdout_line(format_args!("{}", style.muted(ZEN.trim_end())))?;
+                output::stdout_line(format_args!(""))?;
             }
             _ => return Ok(false),
         }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::Error;
 use crate::git;
+use crate::output;
 use crate::skills;
 use crate::sources::RemoteSource;
 
@@ -40,24 +41,34 @@ pub struct InspectionReport {
     pub diagnostics: Vec<String>,
 }
 
+fn inspection_boundary(checkout: &Path, relative: &Path) -> Result<PathBuf, Error> {
+    let boundary = if relative.as_os_str().is_empty() {
+        checkout
+            .canonicalize()
+            .map_err(|error| crate::paths::map_io(checkout, error))?
+    } else {
+        crate::paths::canonicalize_beneath(checkout, relative).map_err(|error| {
+            Error::msg(format!(
+                "Inspection boundary {} is invalid: {error}",
+                output::display_path(relative)
+            ))
+        })?
+    };
+    if !boundary.is_dir() {
+        return Err(Error::msg(format!(
+            "Inspection boundary is not a directory: {}",
+            output::display_path(relative)
+        )));
+    }
+    Ok(boundary)
+}
+
 pub fn inspect(url: &str) -> Result<InspectionReport, Error> {
     let parsed = parse_url(url)?;
     reject_ambiguous_ref(&parsed)?;
     let (_temp, checkout, revision) =
         git::checkout_ref(&parsed.remote, parsed.requested_ref.as_deref())?;
-    let boundary = checkout.join(&parsed.boundary);
-    let metadata = fs::symlink_metadata(&boundary).map_err(|_| {
-        Error::msg(format!(
-            "Inspection boundary does not exist: {}",
-            parsed.boundary_display
-        ))
-    })?;
-    if !metadata.is_dir() {
-        return Err(Error::msg(format!(
-            "Inspection boundary is not a directory: {}",
-            parsed.boundary_display
-        )));
-    }
+    let boundary = inspection_boundary(&checkout, &parsed.boundary)?;
 
     let mut diagnostics = Vec::new();
     let mut discovered = Vec::new();
@@ -81,6 +92,7 @@ pub fn inspect(url: &str) -> Result<InspectionReport, Error> {
             .and_then(|value| value.to_str())
             .unwrap_or("");
         if skill.name != directory_name {
+            let directory_name = output::escape_untrusted(directory_name);
             diagnostics.push(format!(
                 "skill name {} does not match directory {directory_name} at {path}",
                 skill.name
@@ -94,13 +106,7 @@ pub fn inspect(url: &str) -> Result<InspectionReport, Error> {
     discovered.sort_by(|left, right| left.path.cmp(&right.path));
     diagnostics.extend(duplicate_diagnostics(&discovered));
     diagnostics.extend(overlap_diagnostics(&discovered));
-    let skillsets = infer_skillsets(
-        &checkout,
-        &parsed.boundary,
-        &boundary,
-        &discovered,
-        &mut diagnostics,
-    )?;
+    let skillsets = infer_skillsets(&checkout, &boundary, &discovered, &mut diagnostics)?;
     for skillset in &skillsets {
         if skillset.name.is_none() && skillset.path != "." {
             diagnostics.push(format!(
@@ -236,10 +242,12 @@ fn valid_part(part: &str) -> bool {
 }
 
 fn relative_posix(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .replace('\\', "/")
+    let relative = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
+    #[cfg(windows)]
+    let relative = relative.replace('\\', "/");
+    #[cfg(not(windows))]
+    let relative = relative.into_owned();
+    output::escape_untrusted(&relative)
 }
 
 fn duplicate_diagnostics(skills: &[DiscoveredSkill]) -> Vec<String> {
@@ -271,12 +279,11 @@ fn overlap_diagnostics(skills: &[DiscoveredSkill]) -> Vec<String> {
 
 fn infer_skillsets(
     checkout: &Path,
-    boundary_path: &Path,
     boundary: &Path,
     skills: &[DiscoveredSkill],
     diagnostics: &mut Vec<String>,
 ) -> Result<Vec<InferredSkillset>, Error> {
-    let boundary_prefix = relative_posix(checkout, &checkout.join(boundary_path));
+    let boundary_prefix = relative_posix(checkout, boundary);
     if skills.iter().any(|skill| skill.path == boundary_prefix) {
         return Ok(Vec::new());
     }
@@ -338,7 +345,7 @@ fn infer_skillsets(
             .iter()
             .next()
             .expect("descendants length checked");
-        return infer_skillsets(checkout, child, child, skills, diagnostics);
+        return infer_skillsets(checkout, child, skills, diagnostics);
     }
     diagnostics.push("skillsets could not be inferred from this boundary".to_string());
     Ok(Vec::new())
@@ -406,6 +413,27 @@ fn regular_children(directory: &Path) -> Result<Vec<PathBuf>, Error> {
         }
     }
     Ok(children)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn inspection_boundary_refuses_symlinked_ancestor() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkout = temp.path().join("checkout");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&checkout).unwrap();
+        fs::create_dir_all(outside.join("skills")).unwrap();
+        std::os::unix::fs::symlink(&outside, checkout.join("jump")).unwrap();
+
+        let error = inspection_boundary(&checkout, Path::new("jump/skills"))
+            .expect_err("ancestor symlink must be refused");
+
+        assert!(error.to_string().contains("symlink"), "{error}");
+    }
 }
 
 mod url_lite {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@ mod inspect;
 mod library;
 mod manage_tink;
 mod manifest;
+mod output;
 mod paths;
+mod process;
 mod provenance;
 mod refresh;
 mod remove;
@@ -39,6 +41,23 @@ use std::process::ExitCode;
 use crate::error::Error;
 use crate::init::InitOptions;
 use crate::style::CliStyle;
+
+// This dispatch module is intentionally output-heavy. Shadow the infallible
+// standard macros here so every write is propagated through the CLI error path.
+macro_rules! println {
+    () => {
+        crate::output::stdout_line(format_args!(""))?
+    };
+    ($($arg:tt)*) => {
+        crate::output::stdout_line(format_args!($($arg)*))?
+    };
+}
+
+macro_rules! eprintln {
+    ($($arg:tt)*) => {
+        crate::output::warning_line(format_args!($($arg)*))
+    };
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -87,13 +106,13 @@ pub enum Command {
     },
     /// Inspect skills and source-defined skillsets in a public GitHub URL
     Inspect { url: String },
-    /// Remove `.agents/`, `ZEN.md`, `AGENTS.md`, and this project's catalog entry (not library)
+    /// Remove `.agents/skills/`, an empty `.agents/`, and this project's catalog entry (not guidance or library)
     Destroy {
         /// Skip the confirmation prompt
         #[arg(long)]
         yes: bool,
     },
-    /// Replace this binary with the latest GitHub Release
+    /// Replace this binary with a newer verified GitHub Release
     Update,
 }
 
@@ -188,10 +207,15 @@ fn flag_tri(yes: bool, no: bool) -> Option<bool> {
 pub fn run(cli: Cli, cwd: PathBuf) -> ExitCode {
     match dispatch(cli, cwd) {
         Ok(()) => ExitCode::SUCCESS,
+        Err(err) if err.is_stdout_broken_pipe() => ExitCode::SUCCESS,
         Err(err) => {
             let style = CliStyle::auto_stderr();
-            eprintln!("{}", style.error(&err));
-            ExitCode::from(1)
+            match output::stderr_line(format_args!("{}", style.error(&err))) {
+                Ok(()) => ExitCode::from(1),
+                // Downstream closure is expected for CLI pipelines. Never convert
+                // it into Rust's default printing panic / exit status 101.
+                Err(_) => ExitCode::from(1),
+            }
         }
     }
 }
@@ -232,7 +256,7 @@ fn dispatch(cli: Cli, cwd: PathBuf) -> Result<(), Error> {
         }
         Command::Update => {
             let report = update::update_binary()?;
-            update::print_report(&report);
+            update::print_report(&report)?;
             Ok(())
         }
     }
@@ -470,10 +494,10 @@ fn dispatch_init(
         );
     }
     if let Some(skill) = &report.manage_tink_added {
-        print_init_skill(&style, skill);
+        print_init_skill(&style, skill)?;
     }
     for skill in &report.tink_skills_added {
-        print_init_skill(&style, skill);
+        print_init_skill(&style, skill)?;
     }
     if report.inventory_created {
         println!(
@@ -491,7 +515,7 @@ fn dispatch_init(
     Ok(())
 }
 
-fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) {
+fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) -> Result<(), Error> {
     if skill.created {
         println!("{} {}", style.success("Added"), style.skill(&skill.name));
     } else {
@@ -501,6 +525,7 @@ fn print_init_skill(style: &CliStyle, skill: &init::InstalledSkill) {
             style.skill(&skill.name)
         );
     }
+    Ok(())
 }
 
 fn dispatch_skill_add(cwd: &Path, source: &str, skill: Option<&str>) -> Result<(), Error> {
@@ -590,26 +615,26 @@ fn dispatch_skill_list(cwd: &Path) -> Result<(), Error> {
 fn dispatch_skill_list_catalog() -> Result<(), Error> {
     let style = CliStyle::auto_stdout();
     let entries = catalog::list_catalog(None)?;
-    if entries.is_empty() {
-        println!("{}", style.muted("(no catalog entries)"));
-    } else {
-        // Header + TSV rows: plain when piped; lightly role-colored on a TTY.
+    // Header + TSV rows: plain when piped; lightly role-colored on a TTY.
+    println!(
+        "{}\t{}\t{}",
+        style.muted("project"),
+        style.muted("root"),
+        style.muted("skill")
+    );
+    for entry in &entries {
         println!(
             "{}\t{}\t{}",
-            style.muted("project"),
-            style.muted("root"),
-            style.muted("skill")
+            style.muted(tsv_field(&entry.project)),
+            style.muted(tsv_field(&entry.root)),
+            style.skill(tsv_field(&entry.skill))
         );
-        for entry in &entries {
-            println!(
-                "{}\t{}\t{}",
-                style.muted(&entry.project),
-                style.muted(&entry.root),
-                style.skill(&entry.skill)
-            );
-        }
     }
     Ok(())
+}
+
+fn tsv_field(value: &str) -> String {
+    output::escape_untrusted(value)
 }
 
 fn dispatch_skill_list_library() -> Result<(), Error> {

--- a/src/library.rs
+++ b/src/library.rs
@@ -100,7 +100,16 @@ pub fn deposit(
     skill: &Skill,
     provenance: Option<&Provenance>,
 ) -> Result<(PathBuf, LibraryWrite), Error> {
-    let library = library_root(None)?;
+    deposit_at(None, skill, provenance)
+}
+
+pub(crate) fn deposit_at(
+    home: Option<&Path>,
+    skill: &Skill,
+    provenance: Option<&Provenance>,
+) -> Result<(PathBuf, LibraryWrite), Error> {
+    crate::skillsets::ensure_standalone_source(&skill.path, &skill.name)?;
+    let library = library_root(home)?;
     let target = library.join(&skill.name);
     if crate::skillsets::has_receipt_entry(&target) {
         return Err(Error::msg(format!(
@@ -126,13 +135,56 @@ pub fn deposit(
     }
 }
 
+/// Validate every existing library boundary a later [`deposit`] will touch.
+/// Divergent ordinary standalone entries are acceptable because deposit repairs
+/// them; symlinks, unsafe trees, and skillset ownership collisions are not.
+pub(crate) fn preflight_deposit(
+    skill: &Skill,
+    provenance: Option<&Provenance>,
+) -> Result<(), Error> {
+    preflight_deposit_at(None, skill, provenance)
+}
+
+pub(crate) fn preflight_deposit_at(
+    home: Option<&Path>,
+    skill: &Skill,
+    provenance: Option<&Provenance>,
+) -> Result<(), Error> {
+    crate::skillsets::ensure_standalone_source(&skill.path, &skill.name)?;
+    let library = library_root(home)?;
+    let target = library.join(&skill.name);
+    if crate::skillsets::has_receipt_entry(&target) {
+        return Err(Error::msg(format!(
+            "Library entry is a skillset; refusing standalone skill collision: {}",
+            skill.name
+        )));
+    }
+    let _ = skills::preflight_install(skill, &library, provenance)?;
+    Ok(())
+}
+
 /// Copy skill tree into the library only when missing or identical.
 ///
 /// Divergent trees are skipped (no repair). Unreadable/unsafe trees surface as
 /// [`CreateOnlyWrite::Skipped`] with the error detail — same create-only
 /// contract harvest used before this lived in `library`.
 pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), Error> {
-    let library = library_root(None)?;
+    deposit_create_only_at(None, skill)
+}
+
+fn deposit_create_only_at(
+    home: Option<&Path>,
+    skill: &Skill,
+) -> Result<(PathBuf, CreateOnlyWrite), Error> {
+    if let Err(error) = crate::skillsets::ensure_standalone_source(&skill.path, &skill.name) {
+        let home = match home {
+            Some(home) => home.to_path_buf(),
+            None => crate::home::resolve_home()?,
+        };
+        let target = skills_library_path(&home).join(&skill.name);
+        return Ok((target, CreateOnlyWrite::Skipped(Some(error.to_string()))));
+    }
+    let library = library_root(home)?;
     let target = library.join(&skill.name);
     match skills::preflight_install(skill, &library, None) {
         Err(err) => Ok((target, CreateOnlyWrite::Skipped(Some(err.to_string())))),
@@ -154,6 +206,7 @@ pub fn deposit_create_only(skill: &Skill) -> Result<(PathBuf, CreateOnlyWrite), 
 /// When the library already holds the exact standalone tree we would install, return it.
 /// Receipt-backed roots remain owned by the skillset lifecycle and are never cache hits.
 pub fn matching(skill: &Skill, provenance: Option<&Provenance>) -> Result<Option<Skill>, Error> {
+    crate::skillsets::ensure_standalone_source(&skill.path, &skill.name)?;
     let library = library_root(None)?;
     let target = library.join(&skill.name);
     if !target.is_dir() || crate::skillsets::has_receipt_entry(&target) {
@@ -218,10 +271,10 @@ pub fn for_remote_tip(
 
     let mut hits = Vec::new();
     for skill in iter_library_skills(&library)? {
-        if let Some(want) = selected_name {
-            if skill.name != want {
-                continue;
-            }
+        if let Some(want) = selected_name
+            && skill.name != want
+        {
+            continue;
         }
         let Ok(Some(provenance)) = provenance::read(&skill) else {
             continue;
@@ -263,6 +316,7 @@ pub fn preflight_refresh(
     new_skill: &Skill,
     new_provenance: &Provenance,
 ) -> Result<(), Error> {
+    crate::skillsets::ensure_standalone_source(&new_skill.path, &new_skill.name)?;
     let library = library_root(None)?;
     match skills::preflight_install(new_skill, &library, Some(new_provenance))? {
         PreflightOutcome::Ready
@@ -296,56 +350,28 @@ pub fn deposit_refresh(new_skill: &Skill, new_provenance: &Provenance) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::home::TINK_HOME_ENV;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::TempDir;
 
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    /// Isolates `TINK_HOME` for in-process library writes (serialized).
     struct TempHome {
         home: PathBuf,
         root: PathBuf,
         _temp: TempDir,
-        prev: Option<std::ffi::OsString>,
-        _guard: MutexGuard<'static, ()>,
     }
 
     impl TempHome {
         fn new() -> Self {
-            let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
             let temp = TempDir::new().unwrap();
             let root = temp.path().to_path_buf();
             let home = root.join("tink-home");
-            let prev = std::env::var_os(TINK_HOME_ENV);
-            // SAFETY: exclusive via env_lock for all tests in this module.
-            unsafe { std::env::set_var(TINK_HOME_ENV, &home) };
             Self {
                 home,
                 root,
                 _temp: temp,
-                prev,
-                _guard: guard,
             }
         }
 
         fn library_skill(&self, name: &str) -> PathBuf {
             skills_library_path(&self.home).join(name)
-        }
-    }
-
-    impl Drop for TempHome {
-        fn drop(&mut self) {
-            // SAFETY: still holding env_lock via `_guard`.
-            unsafe {
-                match &self.prev {
-                    Some(value) => std::env::set_var(TINK_HOME_ENV, value),
-                    None => std::env::remove_var(TINK_HOME_ENV),
-                }
-            }
         }
     }
 
@@ -382,7 +408,7 @@ mod tests {
         let src = home.root.join("src").join("demo-skill");
         let skill = write_skill(&src, "demo-skill", "fresh body");
 
-        let (path, write) = deposit_create_only(&skill).unwrap();
+        let (path, write) = deposit_create_only_at(Some(&home.home), &skill).unwrap();
         assert_eq!(write, CreateOnlyWrite::Created);
         assert_eq!(path, home.library_skill("demo-skill"));
         assert!(skill_md(&path).contains("fresh body"));
@@ -432,12 +458,12 @@ mod tests {
         let skill = write_skill(&src, "demo-skill", "same body");
 
         assert_eq!(
-            deposit_create_only(&skill).unwrap().1,
+            deposit_create_only_at(Some(&home.home), &skill).unwrap().1,
             CreateOnlyWrite::Created
         );
         let before = skill_md(&home.library_skill("demo-skill"));
 
-        let (path, write) = deposit_create_only(&skill).unwrap();
+        let (path, write) = deposit_create_only_at(Some(&home.home), &skill).unwrap();
         assert_eq!(write, CreateOnlyWrite::Unchanged);
         assert_eq!(skill_md(&path), before);
     }
@@ -451,12 +477,14 @@ mod tests {
         let incoming = write_skill(&second, "demo-skill", "incoming body");
 
         assert_eq!(
-            deposit_create_only(&original).unwrap().1,
+            deposit_create_only_at(Some(&home.home), &original)
+                .unwrap()
+                .1,
             CreateOnlyWrite::Created
         );
         let before = skill_md(&home.library_skill("demo-skill"));
 
-        let (path, write) = deposit_create_only(&incoming).unwrap();
+        let (path, write) = deposit_create_only_at(Some(&home.home), &incoming).unwrap();
         assert!(
             matches!(write, CreateOnlyWrite::Skipped(Some(ref detail)) if detail.contains("create-only")),
             "{write:?}"
@@ -473,9 +501,12 @@ mod tests {
         let original = write_skill(&first, "demo-skill", "original body");
         let incoming = write_skill(&second, "demo-skill", "incoming body");
 
-        assert_eq!(deposit(&original, None).unwrap().1, LibraryWrite::Created);
+        assert_eq!(
+            deposit_at(Some(&home.home), &original, None).unwrap().1,
+            LibraryWrite::Created
+        );
 
-        let (path, write) = deposit(&incoming, None).unwrap();
+        let (path, write) = deposit_at(Some(&home.home), &incoming, None).unwrap();
         assert_eq!(write, LibraryWrite::Repaired);
         assert!(skill_md(&path).contains("incoming body"));
         assert!(!skill_md(&path).contains("original body"));
@@ -489,7 +520,9 @@ mod tests {
         let provenance = sample_provenance();
 
         assert_eq!(
-            deposit(&skill, Some(&provenance)).unwrap().1,
+            deposit_at(Some(&home.home), &skill, Some(&provenance))
+                .unwrap()
+                .1,
             LibraryWrite::Created
         );
         let library = home.library_skill("demo-skill");
@@ -497,7 +530,7 @@ mod tests {
         let before = skill_md(&library);
 
         // Incoming tree matches body but has no receipt — create-only must not rewrite.
-        let (path, write) = deposit_create_only(&skill).unwrap();
+        let (path, write) = deposit_create_only_at(Some(&home.home), &skill).unwrap();
         assert_eq!(write, CreateOnlyWrite::Unchanged);
         assert_eq!(skill_md(&path), before);
         assert!(path.join(".tink-source.json").is_file());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use std::process::ExitCode;
 
 use clap::{CommandFactory, Parser};
@@ -14,8 +15,15 @@ fn main() -> ExitCode {
     let cwd = match std::env::current_dir() {
         Ok(cwd) => cwd,
         Err(err) => {
-            eprintln!("Failed to resolve current directory: {err}");
-            return ExitCode::from(1);
+            let result = writeln!(
+                io::stderr().lock(),
+                "Failed to resolve current directory: {err}"
+            );
+            // A closed diagnostic pipe is deliberate process control, not a panic.
+            return match result {
+                Ok(()) => ExitCode::from(1),
+                Err(_) => ExitCode::from(1),
+            };
         }
     };
     run(cli, cwd)

--- a/src/manage_tink.rs
+++ b/src/manage_tink.rs
@@ -5,16 +5,15 @@ use std::path::Path;
 use crate::add;
 use crate::error::Error;
 use crate::paths::map_io;
+use crate::skills::{self, Skill};
 
 const SKILL_MD: &str = include_str!("../skills/manage-tink/SKILL.md");
 const OPENAI_YAML: &str = include_str!("../skills/manage-tink/agents/openai.yaml");
 const COMMANDS_MD: &str = include_str!("../skills/manage-tink/references/commands.md");
 
-/// Stage the embedded skill and install it into the project via `add`.
-///
-/// Uses the quiet add path so init can own the closing narrative.
-/// Returns the install outcome (name + whether the project tree was created).
-pub fn install_manage_tink(project_root: &Path) -> Result<add::AddOutcome, Error> {
+/// Materialize the embedded tree for read-only validation or later publication.
+/// The returned guard owns the bytes referenced by `Skill`.
+pub(crate) fn prepare_manage_tink() -> Result<(tempfile::TempDir, Skill), Error> {
     let staging = tempfile::Builder::new()
         .prefix(".tink-manage-tink-")
         .tempdir()
@@ -30,9 +29,20 @@ pub fn install_manage_tink(project_root: &Path) -> Result<add::AddOutcome, Error
         .map_err(|e| map_io(&agents.join("openai.yaml"), e))?;
     std::fs::write(references.join("commands.md"), COMMANDS_MD)
         .map_err(|e| map_io(&references.join("commands.md"), e))?;
+    let skill = skills::read_skill(&skill_root, true)?;
+    Ok((staging, skill))
+}
+
+/// Stage the embedded skill and install it into the project via `add`.
+///
+/// Uses the quiet add path so init can own the closing narrative.
+/// Returns the install outcome (name + whether the project tree was created).
+pub fn install_manage_tink(project_root: &Path) -> Result<add::AddOutcome, Error> {
+    let (_staging, skill) = prepare_manage_tink()?;
     add::add_skill_quiet(
         project_root,
-        skill_root
+        skill
+            .path
             .to_str()
             .ok_or_else(|| Error::msg("manage-tink path is not UTF-8"))?,
         None,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -6,18 +6,18 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
-use sha2::{Digest, Sha256};
-
 use crate::error::Error;
 use crate::paths::{map_io, refuse_symlink};
 use crate::provenance;
 use crate::skills;
 use crate::sources;
+use serde::Deserialize;
 
 pub const DIRECTORY: &str = ".tink";
 pub const MANIFEST_FILE: &str = "skills.toml";
 pub const LOCK_FILE: &str = "skills.lock";
+const MANIFEST_VERSION: u32 = 1;
+const LOCK_VERSION: u32 = 2;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -51,10 +51,12 @@ pub struct LockedSkill {
     pub sha256: String,
 }
 
+#[derive(Debug)]
 struct ResolvedLockfile {
     skills: Vec<ResolvedLockedSkill>,
 }
 
+#[derive(Debug)]
 struct ResolvedLockedSkill {
     name: String,
     source: sources::LockedSource,
@@ -96,8 +98,8 @@ fn read_toml<T: for<'de> Deserialize<'de>>(
     toml::from_str(&text).map_err(|e| Error::msg(format!("Invalid {label}: {e}")))
 }
 
-fn validate_version(version: u32) -> Result<(), Error> {
-    if version != 1 {
+fn validate_manifest_version(version: u32) -> Result<(), Error> {
+    if version != MANIFEST_VERSION {
         return Err(Error::msg(format!(
             "Unsupported project manifest version: {version}"
         )));
@@ -116,7 +118,7 @@ fn validate_name(name: &str, kind: &str, names: &mut BTreeMap<String, ()>) -> Re
 }
 
 fn validate_manifest(manifest: &Manifest) -> Result<(), Error> {
-    validate_version(manifest.version)?;
+    validate_manifest_version(manifest.version)?;
     let mut names = BTreeMap::new();
     for skill in &manifest.skills {
         validate_name(&skill.name, "project manifest", &mut names)?;
@@ -126,7 +128,17 @@ fn validate_manifest(manifest: &Manifest) -> Result<(), Error> {
 }
 
 fn resolve_lock(root: &Path, lock: Lockfile) -> Result<ResolvedLockfile, Error> {
-    validate_version(lock.version)?;
+    if lock.version == 1 {
+        return Err(Error::msg(
+            "Project lockfile version 1 uses a legacy digest; run `tink skill lock` to rewrite version 2",
+        ));
+    }
+    if lock.version != LOCK_VERSION {
+        return Err(Error::msg(format!(
+            "Unsupported project lockfile version: {}",
+            lock.version
+        )));
+    }
     let mut names = BTreeMap::new();
     let mut skills = Vec::with_capacity(lock.skills.len());
     for skill in lock.skills {
@@ -223,20 +235,28 @@ pub fn lock(root: &Path, source_args: &[String]) -> Result<usize, Error> {
         )));
     }
     entries.sort_by(|a, b| a.name.cmp(&b.name));
-    let manifest = entries
-        .iter()
-        .map(|entry| format_manifest_entry(entry))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let lock = entries
-        .iter()
-        .map(|entry| format_lock_entry(entry))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let manifest = if entries.is_empty() {
+        "skills = []\n".to_string()
+    } else {
+        entries
+            .iter()
+            .map(format_manifest_entry)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let lock = if entries.is_empty() {
+        "skills = []\n".to_string()
+    } else {
+        entries
+            .iter()
+            .map(format_lock_entry)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
     write_atomic(
         root,
-        &format!("version = 1\n\n{manifest}"),
-        &format!("version = 1\n\n{lock}"),
+        &format!("version = {MANIFEST_VERSION}\n\n{manifest}"),
+        &format!("version = {LOCK_VERSION}\n\n{lock}"),
     )?;
     Ok(entries.len())
 }
@@ -294,6 +314,18 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
     } else {
         None
     };
+    let mut previous_backup = if let Some(previous) = &previous_manifest {
+        let mut backup = tempfile::Builder::new()
+            .prefix(".skills-manifest-backup-")
+            .tempfile_in(&directory)
+            .map_err(|e| map_io(&directory, e))?;
+        backup
+            .write_all(previous)
+            .map_err(|e| map_io(backup.path(), e))?;
+        Some(backup)
+    } else {
+        None
+    };
     let mut manifest_temp = tempfile::Builder::new()
         .prefix(".skills-toml-")
         .tempfile_in(&directory)
@@ -313,13 +345,23 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
     fs::rename(&manifest_temp_path, &manifest_path).map_err(|e| map_io(&manifest_path, e))?;
     if let Err(error) = fs::rename(&lock_temp_path, &lock_path) {
         // Roll the first rename back so the pair remains consistent.
-        match previous_manifest {
-            Some(previous) => {
-                let _ = fs::write(&manifest_path, previous);
-            }
-            None => {
-                let _ = fs::remove_file(&manifest_path);
-            }
+        let rollback = match previous_backup.as_ref() {
+            Some(backup) => fs::rename(backup.path(), &manifest_path),
+            None => fs::remove_file(&manifest_path),
+        };
+        if let Err(rollback_error) = rollback {
+            let recovery = match previous_backup.take() {
+                Some(backup) => backup
+                    .keep()
+                    .map(|(_, path)| path)
+                    .unwrap_or_else(|_| manifest_path.clone()),
+                None => manifest_path.clone(),
+            };
+            return Err(Error::msg(format!(
+                "could not publish {} ({error}); manifest rollback failed ({rollback_error}); recovery state: {}",
+                lock_path.display(),
+                recovery.display()
+            )));
         }
         return Err(map_io(&lock_path, error));
     }
@@ -327,6 +369,10 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
 }
 
 pub fn sync(root: &Path) -> Result<usize, Error> {
+    sync_at(root, None)
+}
+
+fn sync_at(root: &Path, home: Option<&Path>) -> Result<usize, Error> {
     let manifest = load(root)?;
     let lock = load_lock(root)?;
     let declarations: BTreeMap<_, _> = manifest.skills.iter().map(|s| (&s.name, s)).collect();
@@ -337,6 +383,15 @@ pub fn sync(root: &Path) -> Result<usize, Error> {
             "Project manifest and lockfile skill sets differ",
         ));
     }
+
+    // Resolve exact source bytes, validate pins, and protect every existing
+    // project destination before the first project/library/catalog write.
+    let agents_root = crate::home::project_agents_path(root);
+    let destination_root = crate::home::project_skills_path(root);
+    crate::paths::require_directory(&agents_root)?;
+    crate::paths::require_directory(&destination_root)?;
+    crate::paths::require_file(&destination_root.join("README.md"))?;
+    let mut prepared = Vec::with_capacity(declarations.len());
     for (name, declaration) in &declarations {
         let pin = pins[name];
         if pin.source.declared() != declaration.source
@@ -346,7 +401,50 @@ pub fn sync(root: &Path) -> Result<usize, Error> {
                 "Project lockfile does not match manifest: {name}"
             )));
         }
-        crate::add::add_locked_skill(root, name, pin.source.clone())?;
+        let candidate = crate::add::prepare_locked_skill(name, pin.source.clone())?;
+        if tree_sha256(&candidate.skill().path)? != pin.sha256.to_ascii_lowercase() {
+            return Err(Error::msg(format!("Skill content hash mismatch: {name}")));
+        }
+        skills::preflight_install(candidate.skill(), &destination_root, candidate.provenance())?
+            .require_compatible(name, &destination_root)?;
+        prepared.push(candidate);
+    }
+
+    if destination_root.is_dir() {
+        for installed in crate::check::load_project_skills(root)? {
+            if !declarations.contains_key(&installed.name) {
+                return Err(Error::msg(format!(
+                    "Installed skill is not declared in manifest: {}",
+                    installed.name
+                )));
+            }
+        }
+    }
+
+    // Library and catalog refusals are predictable and must be discovered
+    // before publishing the first prepared project skill. Operational failures
+    // such as ENOSPC can still interrupt sequential publication and are
+    // recoverable by rerunning sync.
+    for candidate in &prepared {
+        match home {
+            Some(home) => crate::library::preflight_deposit_at(
+                Some(home),
+                candidate.skill(),
+                candidate.provenance(),
+            )?,
+            None => crate::library::preflight_deposit(candidate.skill(), candidate.provenance())?,
+        }
+    }
+    match home {
+        Some(home) => crate::catalog::preflight_deposit_skill_at(Some(home), root)?,
+        None => crate::catalog::preflight_deposit_skill(root)?,
+    }
+
+    for candidate in prepared {
+        match home {
+            Some(home) => candidate.publish_at(root, Some(home))?,
+            None => candidate.publish(root)?,
+        };
     }
     verify(root)
 }
@@ -411,50 +509,23 @@ pub fn verify(root: &Path) -> Result<usize, Error> {
 }
 
 fn tree_sha256(root: &Path) -> Result<String, Error> {
-    fn walk(root: &Path, dir: &Path, digest: &mut Sha256) -> Result<(), Error> {
-        let mut entries = fs::read_dir(dir)
-            .map_err(|e| map_io(dir, e))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| map_io(dir, e))?;
-        entries.sort_by_key(|entry| entry.file_name());
-        for entry in entries {
-            let path = entry.path();
-            let relative = path
-                .strip_prefix(root)
-                .map_err(|_| Error::msg("Manifest tree path escaped root"))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            if relative == ".tink-source.json" {
-                continue;
-            }
-            refuse_symlink(&path)?;
-            let file_type = entry.file_type().map_err(|e| map_io(&path, e))?;
-            digest.update(relative.as_bytes());
-            digest.update([0]);
-            if file_type.is_dir() {
-                digest.update([b'd']);
-                walk(root, &path, digest)?;
-            } else if file_type.is_file() {
-                digest.update([b'f']);
-                digest.update(fs::read(&path).map_err(|e| map_io(&path, e))?);
-            } else {
-                return Err(Error::msg(format!(
-                    "Refusing special file in manifest skill: {}",
-                    path.display()
-                )));
-            }
-            digest.update([0]);
-        }
-        Ok(())
-    }
-    let mut digest = Sha256::new();
-    walk(root, root, &mut digest)?;
-    Ok(format!("{:x}", digest.finalize()))
+    skills::tree_digest(root, &[provenance::SIDECAR_FILE])
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::home::skills_library_path;
+
+    fn write_skill(path: &Path, name: &str) {
+        fs::create_dir_all(path).unwrap();
+        fs::write(
+            path.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: Manifest sync fixture.\n---\n\n# {name}\n"),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn receipt_is_excluded_from_hash() {
         let temp = tempfile::tempdir().unwrap();
@@ -464,5 +535,222 @@ mod tests {
         let before = tree_sha256(&skill).unwrap();
         fs::write(skill.join(".tink-source.json"), "receipt").unwrap();
         assert_eq!(before, tree_sha256(&skill).unwrap());
+    }
+
+    #[test]
+    fn tree_hash_uses_unambiguous_entry_framing() {
+        let temp = tempfile::tempdir().unwrap();
+        let one_file = temp.path().join("one-file");
+        let two_files = temp.path().join("two-files");
+        fs::create_dir_all(&one_file).unwrap();
+        fs::create_dir_all(&two_files).unwrap();
+        fs::write(one_file.join("SKILL.md"), b"BASE\0z\0fPAYLOAD").unwrap();
+        fs::write(two_files.join("SKILL.md"), b"BASE").unwrap();
+        fs::write(two_files.join("z"), b"PAYLOAD").unwrap();
+
+        assert_ne!(
+            tree_sha256(&one_file).unwrap(),
+            tree_sha256(&two_files).unwrap(),
+            "distinct entry framing must not collide"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tree_hash_pins_regular_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let skill = temp.path().join("skill");
+        fs::create_dir_all(&skill).unwrap();
+        let script = skill.join("run.sh");
+        fs::write(&script, b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        let executable = tree_sha256(&skill).unwrap();
+
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert_ne!(tree_sha256(&skill).unwrap(), executable);
+    }
+
+    #[test]
+    fn legacy_lock_digest_requires_explicit_relock() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path();
+        fs::create_dir_all(project.join(DIRECTORY)).unwrap();
+        fs::write(
+            lock_path(project),
+            "version = 1\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\nsha256 = \"0000000000000000000000000000000000000000000000000000000000000000\"\n",
+        )
+        .unwrap();
+
+        let error = load_lock(project).unwrap_err();
+        assert!(
+            error.to_string().contains("run `tink skill lock`"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn sync_validates_every_locked_hash_before_any_mutation() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let home = temp.path().join("home");
+        let alpha = project.join("sources/alpha");
+        let beta = project.join("sources/beta");
+        fs::create_dir_all(&project).unwrap();
+        write_skill(&alpha, "alpha");
+        write_skill(&beta, "beta");
+        let alpha_hash = tree_sha256(&alpha).unwrap();
+        fs::create_dir_all(project.join(DIRECTORY)).unwrap();
+        fs::write(
+            path(&project),
+            "version = 1\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\n\n[[skills]]\nname = \"beta\"\nsource = \"sources/beta\"\n",
+        )
+        .unwrap();
+        fs::write(
+            lock_path(&project),
+            format!(
+                "version = 2\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\nsha256 = \"{alpha_hash}\"\n\n[[skills]]\nname = \"beta\"\nsource = \"sources/beta\"\nsha256 = \"{}\"\n",
+                "0".repeat(64)
+            ),
+        )
+        .unwrap();
+        let error = sync_at(&project, Some(&home)).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Skill content hash mismatch: beta"),
+            "unexpected error: {error}"
+        );
+        let project_mutated = crate::home::project_agents_path(&project).exists();
+        let library_mutated = skills_library_path(&home).exists();
+        assert!(
+            !project_mutated && !library_mutated,
+            "sync mutated before validating every lock entry: project_mutated={project_mutated}, library_mutated={library_mutated}"
+        );
+    }
+
+    #[test]
+    fn sync_preflights_every_project_destination_before_publishing() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let home = temp.path().join("home");
+        let alpha = project.join("sources/alpha");
+        let beta = project.join("sources/beta");
+        write_skill(&alpha, "alpha");
+        write_skill(&beta, "beta");
+        let alpha_hash = tree_sha256(&alpha).unwrap();
+        let beta_hash = tree_sha256(&beta).unwrap();
+        fs::create_dir_all(project.join(DIRECTORY)).unwrap();
+        fs::write(
+            path(&project),
+            "version = 1\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\n\n[[skills]]\nname = \"beta\"\nsource = \"sources/beta\"\n",
+        )
+        .unwrap();
+        fs::write(
+            lock_path(&project),
+            format!(
+                "version = 2\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\nsha256 = \"{alpha_hash}\"\n\n[[skills]]\nname = \"beta\"\nsource = \"sources/beta\"\nsha256 = \"{beta_hash}\"\n"
+            ),
+        )
+        .unwrap();
+        let installed_beta = crate::home::project_skills_path(&project).join("beta");
+        write_skill(&installed_beta, "beta");
+        fs::write(installed_beta.join("local-change.txt"), "keep me\n").unwrap();
+        let before = fs::read(installed_beta.join("SKILL.md")).unwrap();
+        let error = sync_at(&project, Some(&home)).unwrap_err();
+
+        assert!(
+            error.to_string().contains("Refusing to overwrite"),
+            "{error}"
+        );
+        assert!(
+            !crate::home::project_skills_path(&project)
+                .join("alpha")
+                .exists()
+        );
+        assert_eq!(fs::read(installed_beta.join("SKILL.md")).unwrap(), before);
+        assert!(!skills_library_path(&home).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_preflights_every_library_destination_before_publishing() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let home = temp.path().join("home");
+        let alpha = project.join("sources/alpha");
+        let beta = project.join("sources/beta");
+        write_skill(&alpha, "alpha");
+        write_skill(&beta, "beta");
+        let alpha_hash = tree_sha256(&alpha).unwrap();
+        let beta_hash = tree_sha256(&beta).unwrap();
+        fs::create_dir_all(project.join(DIRECTORY)).unwrap();
+        fs::write(
+            path(&project),
+            "version = 1\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\n\n[[skills]]\nname = \"beta\"\nsource = \"sources/beta\"\n",
+        )
+        .unwrap();
+        fs::write(
+            lock_path(&project),
+            format!(
+                "version = 2\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\nsha256 = \"{alpha_hash}\"\n\n[[skills]]\nname = \"beta\"\nsource = \"sources/beta\"\nsha256 = \"{beta_hash}\"\n"
+            ),
+        )
+        .unwrap();
+        crate::home::ensure_inventory_root(Some(&home)).unwrap();
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, skills_library_path(&home).join("beta")).unwrap();
+
+        let error = sync_at(&project, Some(&home)).unwrap_err();
+
+        assert!(error.to_string().contains("symlink"), "{error}");
+        assert!(
+            !crate::home::project_skills_path(&project)
+                .join("alpha")
+                .exists()
+        );
+        assert!(!skills_library_path(&home).join("alpha").exists());
+        assert!(
+            crate::catalog::list_catalog(Some(&home))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn sync_preflights_and_publishes_embedded_skill() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let home = temp.path().join("home");
+        fs::create_dir_all(project.join(DIRECTORY)).unwrap();
+        let (_guard, embedded) = crate::manage_tink::prepare_manage_tink().unwrap();
+        let hash = tree_sha256(&embedded.path).unwrap();
+        fs::write(
+            path(&project),
+            "version = 1\n\n[[skills]]\nname = \"manage-tink\"\nsource = \"tink:embedded/manage-tink\"\n",
+        )
+        .unwrap();
+        fs::write(
+            lock_path(&project),
+            format!(
+                "version = 2\n\n[[skills]]\nname = \"manage-tink\"\nsource = \"tink:embedded/manage-tink\"\nsha256 = \"{hash}\"\n"
+            ),
+        )
+        .unwrap();
+        assert_eq!(sync_at(&project, Some(&home)).unwrap(), 1);
+        assert!(
+            crate::home::project_skills_path(&project)
+                .join("manage-tink/SKILL.md")
+                .is_file()
+        );
+        assert!(
+            skills_library_path(&home)
+                .join("manage-tink/SKILL.md")
+                .is_file()
+        );
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,98 @@
+//! Fallible process output.
+//!
+//! Rust's `print!` macros panic when a downstream pipeline closes early. A closed
+//! pipe is normal CLI control flow, so all application output passes through this
+//! module and is returned to the command boundary as an ordinary I/O error.
+
+use std::fmt;
+use std::io::{self, Write};
+use std::path::Path;
+
+use crate::error::Error;
+
+/// Render untrusted text without allowing it to create terminal control flow.
+pub(crate) fn escape_untrusted(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\0' => escaped.push_str("\\0"),
+            '\u{1b}' => escaped.push_str("\\x1b"),
+            character if character.is_control() => escaped.extend(character.escape_default()),
+            character => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+/// Lossily render an operating-system path, then make control flow visible.
+///
+/// `Path::display` also substitutes invalid Unicode; this helper preserves that
+/// user-facing behavior while ensuring a repository-controlled filename cannot
+/// inject terminal control sequences into diagnostics.
+pub(crate) fn display_path(path: &Path) -> String {
+    escape_untrusted(path.to_string_lossy().as_ref())
+}
+
+fn write(
+    mut sink: impl Write,
+    stream: &str,
+    args: fmt::Arguments<'_>,
+    newline: bool,
+) -> Result<(), Error> {
+    sink.write_fmt(args)
+        .map_err(|error| Error::output(stream, error))?;
+    if newline {
+        sink.write_all(b"\n")
+            .map_err(|error| Error::output(stream, error))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn stdout(args: fmt::Arguments<'_>) -> Result<(), Error> {
+    write(io::stdout().lock(), "stdout", args, false)
+}
+
+pub(crate) fn stdout_line(args: fmt::Arguments<'_>) -> Result<(), Error> {
+    write(io::stdout().lock(), "stdout", args, true)
+}
+
+pub(crate) fn stderr_line(args: fmt::Arguments<'_>) -> Result<(), Error> {
+    write(io::stderr().lock(), "stderr", args, true)
+}
+
+/// Warnings are advisory and must never retroactively fail completed work.
+pub(crate) fn warning_line(args: fmt::Arguments<'_>) {
+    let _ = stderr_line(args);
+}
+
+pub(crate) fn flush_stdout() -> Result<(), Error> {
+    io::stdout()
+        .lock()
+        .flush()
+        .map_err(|error| Error::output("stdout", error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn untrusted_terminal_text_uses_visible_reversible_escapes() {
+        assert_eq!(
+            escape_untrusted("a\\b\nrow\r\t\0\u{1b}[31m"),
+            "a\\\\b\\nrow\\r\\t\\0\\x1b[31m"
+        );
+    }
+
+    #[test]
+    fn displayed_paths_escape_terminal_controls() {
+        assert_eq!(
+            display_path(Path::new("directory\u{1b}[31m/file\nname")),
+            "directory\\x1b[31m/file\\nname"
+        );
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,15 +1,16 @@
 //! Shared refusals for unsafe paths.
 
 use std::io;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::error::Error;
+use crate::output;
 
 pub fn refuse_symlink(path: &Path) -> Result<(), Error> {
     if path.is_symlink() {
         return Err(Error::msg(format!(
             "Refusing to follow symlink: {}",
-            path.display()
+            output::display_path(path)
         )));
     }
     Ok(())
@@ -20,7 +21,7 @@ pub fn require_directory(path: &Path) -> Result<(), Error> {
     if path.exists() && !path.is_dir() {
         return Err(Error::msg(format!(
             "Refusing to replace non-directory: {}",
-            path.display()
+            output::display_path(path)
         )));
     }
     Ok(())
@@ -31,7 +32,7 @@ pub fn require_file(path: &Path) -> Result<(), Error> {
     if path.exists() && !path.is_file() {
         return Err(Error::msg(format!(
             "Refusing to replace non-file: {}",
-            path.display()
+            output::display_path(path)
         )));
     }
     Ok(())
@@ -45,6 +46,53 @@ pub fn mkdir_p(path: &Path) -> Result<(), Error> {
     Ok(())
 }
 
+/// Resolve a caller-validated relative path beneath a trusted base without
+/// following symlinks in any relative component.
+pub fn canonicalize_beneath(base: &Path, relative: &Path) -> Result<PathBuf, Error> {
+    if relative.as_os_str().is_empty() || relative.is_absolute() {
+        return Err(Error::msg(format!(
+            "Path must be non-empty and relative: {}",
+            output::display_path(relative)
+        )));
+    }
+
+    let mut candidate = base.to_path_buf();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => {
+                candidate.push(part);
+                refuse_symlink(&candidate)?;
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(Error::msg(format!(
+                    "Refusing path outside trusted root: {}",
+                    output::display_path(&base.join(relative))
+                )));
+            }
+        }
+    }
+
+    let canonical_base = base.canonicalize().map_err(|error| map_io(base, error))?;
+    let canonical_candidate = candidate.canonicalize().map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            Error::msg(format!(
+                "Path does not exist: {}",
+                output::display_path(&candidate)
+            ))
+        } else {
+            map_io(&candidate, error)
+        }
+    })?;
+    if !canonical_candidate.starts_with(&canonical_base) {
+        return Err(Error::msg(format!(
+            "Refusing path outside trusted root: {}",
+            output::display_path(&candidate)
+        )));
+    }
+    Ok(canonical_candidate)
+}
+
 pub fn map_io(path: &Path, err: io::Error) -> Error {
-    Error::msg(format!("{}: {err}", path.display()))
+    Error::msg(format!("{}: {err}", output::display_path(path)))
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,371 @@
+//! Bounded subprocess execution with captured output and group-level cleanup.
+
+use std::io::Read;
+use std::process::{Child, Command, Output, Stdio};
+#[cfg(unix)]
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering as AtomicOrdering},
+};
+use std::sync::{
+    Mutex, MutexGuard,
+    mpsc::{self, TryRecvError},
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::error::Error;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+// Each stream is retained only up to this limit; readers keep draining after it
+// so a verbose child cannot block on a full pipe.
+const MAX_CAPTURE_BYTES: usize = 16 * 1024 * 1024;
+
+#[cfg(unix)]
+static INTERRUPTED: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+#[cfg(unix)]
+static DEFAULT_ENABLED: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+#[cfg(unix)]
+static SIGNAL_HANDLERS: OnceLock<Result<(), String>> = OnceLock::new();
+static SUPERVISION_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(unix)]
+fn install_interrupt_handlers() -> Result<(), Error> {
+    use signal_hook::consts::signal::{SIGHUP, SIGINT, SIGTERM};
+
+    let interrupted = INTERRUPTED.get_or_init(|| Arc::new(AtomicBool::new(false)));
+    let default_enabled = DEFAULT_ENABLED.get_or_init(|| Arc::new(AtomicBool::new(true)));
+    let installed = SIGNAL_HANDLERS.get_or_init(|| {
+        for signal in [SIGHUP, SIGINT, SIGTERM] {
+            signal_hook::flag::register_conditional_default(signal, Arc::clone(default_enabled))
+                .map_err(|error| format!("could not install default signal handler: {error}"))?;
+            signal_hook::flag::register(signal, Arc::clone(interrupted))
+                .map_err(|error| format!("could not install subprocess signal handler: {error}"))?;
+        }
+        Ok(())
+    });
+    installed.clone().map_err(Error::msg)
+}
+
+#[cfg(not(unix))]
+fn install_interrupt_handlers() -> Result<(), Error> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn interrupted() -> bool {
+    INTERRUPTED
+        .get()
+        .is_some_and(|flag| flag.load(AtomicOrdering::SeqCst))
+}
+
+#[cfg(not(unix))]
+fn interrupted() -> bool {
+    false
+}
+
+struct SupervisionGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl Drop for SupervisionGuard {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(default_enabled) = DEFAULT_ENABLED.get() {
+            default_enabled.store(true, AtomicOrdering::SeqCst);
+        }
+    }
+}
+
+fn begin_supervision() -> Result<SupervisionGuard, Error> {
+    let lock = SUPERVISION_LOCK
+        .lock()
+        .map_err(|_| Error::msg("subprocess supervision lock is poisoned"))?;
+    install_interrupt_handlers()?;
+    if interrupted() {
+        return Err(Error::msg("subprocess execution interrupted"));
+    }
+    #[cfg(unix)]
+    {
+        let Some(default_enabled) = DEFAULT_ENABLED.get() else {
+            return Err(Error::msg(
+                "subprocess signal handlers were not initialized",
+            ));
+        };
+        default_enabled.store(false, AtomicOrdering::SeqCst);
+    }
+    Ok(SupervisionGuard { _lock: lock })
+}
+
+pub(crate) fn run_bounded(
+    command: &mut Command,
+    timeout: Duration,
+    context: &str,
+    missing_message: Option<&str>,
+) -> Result<Output, Error> {
+    let _supervision = begin_supervision()?;
+    if interrupted() {
+        return Err(Error::msg(format!("{context} interrupted")));
+    }
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let mut child = command.spawn().map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            Error::msg(
+                missing_message
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| format!("could not start {context}: {error}")),
+            )
+        } else {
+            Error::msg(format!("could not start {context}: {error}"))
+        }
+    })?;
+    let Some(stdout) = child.stdout.take() else {
+        return abort(
+            &mut child,
+            Error::msg(format!("could not capture {context} stdout")),
+        );
+    };
+    let Some(stderr) = child.stderr.take() else {
+        return abort(
+            &mut child,
+            Error::msg(format!("could not capture {context} stderr")),
+        );
+    };
+    let (stdout_tx, stdout_rx) = mpsc::channel();
+    let (stderr_tx, stderr_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = stdout_tx.send(drain_capped(stdout));
+    });
+    thread::spawn(move || {
+        let _ = stderr_tx.send(drain_capped(stderr));
+    });
+
+    let started = Instant::now();
+    let mut status = None;
+    let mut stdout = None;
+    let mut stderr = None;
+    loop {
+        if interrupted() {
+            return abort(&mut child, Error::msg(format!("{context} interrupted")));
+        }
+        if status.is_none() {
+            status = match child.try_wait() {
+                Ok(status) => status,
+                Err(error) => {
+                    return abort(
+                        &mut child,
+                        Error::msg(format!("could not wait for {context}: {error}")),
+                    );
+                }
+            };
+        }
+        if stdout.is_none() {
+            stdout = match receive_pipe(&stdout_rx, context, "stdout") {
+                Ok(output) => output,
+                Err(error) => return abort(&mut child, error),
+            };
+        }
+        if stderr.is_none() {
+            stderr = match receive_pipe(&stderr_rx, context, "stderr") {
+                Ok(output) => output,
+                Err(error) => return abort(&mut child, error),
+            };
+        }
+        if status.is_some() && stdout.is_some() && stderr.is_some() {
+            match (status.take(), stdout.take(), stderr.take()) {
+                (Some(status), Some(stdout), Some(stderr)) => {
+                    if interrupted() {
+                        return abort(&mut child, Error::msg(format!("{context} interrupted")));
+                    }
+                    if stdout.exceeded {
+                        return abort(&mut child, capture_limit_error(context, "stdout"));
+                    }
+                    if stderr.exceeded {
+                        return abort(&mut child, capture_limit_error(context, "stderr"));
+                    }
+                    // A direct child can exit while descendants with redirected pipes remain.
+                    terminate_process_tree(&mut child);
+                    return Ok(Output {
+                        status,
+                        stdout: stdout.bytes,
+                        stderr: stderr.bytes,
+                    });
+                }
+                _ => unreachable!("all subprocess output fields were checked above"),
+            }
+        }
+        if started.elapsed() >= timeout {
+            return abort(&mut child, Error::msg(format!("{context} timed out")));
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+struct CapturedStream {
+    bytes: Vec<u8>,
+    exceeded: bool,
+}
+
+fn drain_capped(mut reader: impl Read) -> std::io::Result<CapturedStream> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0; 8192];
+    let mut exceeded = false;
+    loop {
+        let count = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(count) => count,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        let retained = count.min(MAX_CAPTURE_BYTES.saturating_sub(bytes.len()));
+        bytes.extend_from_slice(&buffer[..retained]);
+        exceeded |= retained < count;
+    }
+    Ok(CapturedStream { bytes, exceeded })
+}
+
+fn capture_limit_error(context: &str, stream: &str) -> Error {
+    Error::msg(format!(
+        "{context} {stream} exceeded the {} MiB capture limit",
+        MAX_CAPTURE_BYTES / (1024 * 1024)
+    ))
+}
+
+fn abort(child: &mut Child, error: Error) -> Result<Output, Error> {
+    terminate_process_tree(child);
+    let _ = child.wait();
+    Err(error)
+}
+
+fn receive_pipe(
+    receiver: &mpsc::Receiver<std::io::Result<CapturedStream>>,
+    context: &str,
+    stream: &str,
+) -> Result<Option<CapturedStream>, Error> {
+    match receiver.try_recv() {
+        Ok(Ok(bytes)) => Ok(Some(bytes)),
+        Ok(Err(error)) => Err(Error::msg(format!(
+            "could not read {context} {stream}: {error}"
+        ))),
+        Err(TryRecvError::Empty) => Ok(None),
+        Err(TryRecvError::Disconnected) => Err(Error::msg(format!(
+            "could not read {context} {stream}: reader stopped"
+        ))),
+    }
+}
+
+fn terminate_process_tree(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        unsafe extern "C" {
+            fn kill(pid: i32, signal: i32) -> i32;
+        }
+
+        if let Ok(process_group) = i32::try_from(child.id()) {
+            // SAFETY: `kill` has the POSIX signature on supported macOS/Linux
+            // targets. `process_group(0)` made the child's PID its group ID;
+            // a negative PID targets that group without dereferencing memory.
+            let _ = unsafe { kill(-process_group, 9) };
+        }
+    }
+    let _ = child.kill();
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const HELPER_ENV: &str = "TINK_PROCESS_SIGNAL_HELPER";
+
+    #[test]
+    fn signal_helper() {
+        let Some(root) = std::env::var_os(HELPER_ENV) else {
+            return;
+        };
+        let root = std::path::PathBuf::from(root);
+        let output = run_bounded(
+            Command::new("sh").args(["-c", "exit 0"]),
+            Duration::from_secs(5),
+            "signal helper",
+            None,
+        )
+        .expect("complete supervised helper");
+        assert!(output.status.success());
+        fs::write(root.join("ready"), b"ready").unwrap();
+        thread::sleep(Duration::from_secs(3));
+        fs::write(root.join("survived"), b"survived").unwrap();
+    }
+
+    #[test]
+    fn termination_after_supervision_uses_the_default_signal_action() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "process::tests::signal_helper"])
+            .env(HELPER_ENV, temp.path())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let started = Instant::now();
+        while !temp.path().join("ready").exists() {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "signal helper exited before synchronization"
+            );
+            assert!(started.elapsed() < Duration::from_secs(10));
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        unsafe extern "C" {
+            fn kill(pid: i32, signal: i32) -> i32;
+        }
+        let pid = i32::try_from(child.id()).unwrap();
+        // SAFETY: POSIX kill takes an integer PID and signal; the spawned child
+        // is live and PID conversion was checked.
+        assert_eq!(unsafe { kill(pid, 15) }, 0);
+        let status = child.wait().unwrap();
+        assert!(!status.success());
+        thread::sleep(Duration::from_millis(3200));
+        assert!(!temp.path().join("survived").exists());
+    }
+
+    #[test]
+    fn output_over_limit_is_drained_and_refused() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("drained");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "dd if=/dev/zero bs=1024 count=\"$1\" 2>/dev/null; printf drained > \"$2\"",
+            "sh",
+            &(MAX_CAPTURE_BYTES / 1024 + 1).to_string(),
+            marker.to_str().unwrap(),
+        ]);
+
+        let error = run_bounded(
+            &mut command,
+            Duration::from_secs(10),
+            "output-limit helper",
+            None,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "output-limit helper stdout exceeded the {} MiB capture limit",
+                MAX_CAPTURE_BYTES / (1024 * 1024)
+            )
+        );
+        assert!(marker.exists(), "the overflowing stream must be drained");
+    }
+}

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::Path;
 
 use crate::error::Error;
+use crate::output;
 use crate::paths::{map_io, refuse_symlink};
 use crate::skills::Skill;
 use crate::sources;
@@ -49,7 +50,7 @@ pub fn read(skill: &Skill) -> Result<Option<Provenance>, Error> {
     if !sidecar.is_file() {
         return Err(Error::msg(format!(
             "Provenance must be a regular file: {}",
-            sidecar.display()
+            output::display_path(&sidecar)
         )));
     }
     let text = fs::read_to_string(&sidecar).map_err(|e| map_io(&sidecar, e))?;
@@ -71,13 +72,13 @@ pub fn read(skill: &Skill) -> Result<Option<Provenance>, Error> {
         let Some(serde_json::Value::String(s)) = obj.get(key) else {
             return Err(Error::msg(format!(
                 "Provenance fields must be non-empty strings: {}",
-                sidecar.display()
+                output::display_path(&sidecar)
             )));
         };
         if s.is_empty() {
             return Err(Error::msg(format!(
                 "Provenance fields must be non-empty strings: {}",
-                sidecar.display()
+                output::display_path(&sidecar)
             )));
         }
         provenance.insert(key.into(), s.clone());
@@ -86,7 +87,7 @@ pub fn read(skill: &Skill) -> Result<Option<Provenance>, Error> {
     if source.url != provenance["source"] {
         return Err(Error::msg(format!(
             "Provenance source must be a canonical GitHub HTTPS URL: {}",
-            sidecar.display()
+            output::display_path(&sidecar)
         )));
     }
     let revision = &provenance["revision"];
@@ -95,14 +96,14 @@ pub fn read(skill: &Skill) -> Result<Option<Provenance>, Error> {
     {
         return Err(Error::msg(format!(
             "Provenance revision must be a full Git object ID: {}",
-            sidecar.display()
+            output::display_path(&sidecar)
         )));
     }
     let path = &provenance["path"];
     if path.starts_with('/') || path.contains("..") || path.contains('\\') {
         return Err(Error::msg(format!(
             "Provenance path must be normalized and relative: {}",
-            sidecar.display()
+            output::display_path(&sidecar)
         )));
     }
     Ok(Some(provenance))

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -15,17 +15,19 @@ use crate::sources;
 use tempfile::TempDir;
 
 fn skill_at(repository: &Path, source_path: &str) -> Result<PathBuf, Error> {
-    let mut path = repository.to_path_buf();
+    let mut relative = PathBuf::from(".");
     if source_path != "." {
+        relative.clear();
         for part in source_path.split('/') {
             if part.is_empty() || part == "." || part == ".." {
                 return Err(Error::msg(format!(
                     "Upstream skill path is missing: {source_path}"
                 )));
             }
-            path.push(part);
+            relative.push(part);
         }
     }
+    let path = crate::paths::canonicalize_beneath(repository, &relative)?;
     if !path.is_dir() {
         return Err(Error::msg(format!(
             "Upstream skill path is missing: {source_path}"
@@ -212,4 +214,27 @@ pub fn refresh_all(root: &Path) -> Result<Vec<String>, Error> {
         }
     }
     Ok(refreshed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_at_refuses_symlinked_ancestor() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repository");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&repository).unwrap();
+        fs::create_dir_all(outside.join("skills/alpha")).unwrap();
+        std::os::unix::fs::symlink(&outside, repository.join("jump")).unwrap();
+
+        let error = skill_at(&repository, "jump/skills/alpha")
+            .expect_err("ancestor symlink must be refused");
+
+        assert!(error.to_string().contains("symlink"), "{error}");
+    }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 use crate::error::Error;
+use crate::output;
 use crate::paths::{map_io, refuse_symlink};
 use crate::provenance::{self, Provenance};
 
@@ -86,7 +87,7 @@ pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Er
     if !skill_file.is_file() {
         return Err(Error::msg(format!(
             "Missing regular SKILL.md: {}",
-            skill_file.display()
+            output::display_path(&skill_file)
         )));
     }
     let text = fs::read_to_string(&skill_file).map_err(|e| map_io(&skill_file, e))?;
@@ -94,7 +95,7 @@ pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Er
     if lines.first().copied() != Some("---") {
         return Err(Error::msg(format!(
             "SKILL.md must start with YAML frontmatter: {}",
-            skill_file.display()
+            output::display_path(&skill_file)
         )));
     }
     let closing = lines
@@ -105,7 +106,7 @@ pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Er
         .ok_or_else(|| {
             Error::msg(format!(
                 "SKILL.md frontmatter is not closed: {}",
-                skill_file.display()
+                output::display_path(&skill_file)
             ))
         })?;
     let frontmatter = &lines[1..closing];
@@ -114,7 +115,7 @@ pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Er
     if !valid_skill_name(&name) {
         return Err(Error::msg(format!(
             "Invalid skill name in {}",
-            skill_file.display()
+            output::display_path(&skill_file)
         )));
     }
     if require_directory_name {
@@ -128,7 +129,7 @@ pub fn read_skill(path: &Path, require_directory_name: bool) -> Result<Skill, Er
     if description.is_empty() || description.len() > 1024 {
         return Err(Error::msg(format!(
             "Invalid skill description in {}",
-            skill_file.display()
+            output::display_path(&skill_file)
         )));
     }
     Ok(Skill {
@@ -147,15 +148,18 @@ pub fn discover(source: &Path) -> Result<Vec<Skill>, Error> {
     if !skills_root.is_dir() {
         return Err(Error::msg(format!(
             "No skill found at {}",
-            source.display()
+            output::display_path(&source)
         )));
     }
     let mut entries: Vec<_> = fs::read_dir(&skills_root)
         .map_err(|e| map_io(&skills_root, e))?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.join("SKILL.md").exists())
-        .collect();
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|e| map_io(&skills_root, e))
+        })
+        .collect::<Result<_, _>>()?;
+    entries.retain(|path| path.join("SKILL.md").exists());
     entries.sort();
     let mut skills = Vec::new();
     for path in entries {
@@ -164,7 +168,7 @@ pub fn discover(source: &Path) -> Result<Vec<Skill>, Error> {
     if skills.is_empty() {
         return Err(Error::msg(format!(
             "No skill found at {}",
-            source.display()
+            output::display_path(&source)
         )));
     }
     Ok(skills)
@@ -233,13 +237,72 @@ pub fn discover_recursive(source: &Path) -> Result<RecursiveDiscovery, Error> {
 #[derive(Debug, PartialEq, Eq)]
 enum EntryKind {
     Dir,
-    File(Vec<u8>),
+    File { bytes: Vec<u8>, mode: u32 },
 }
 
 /// One skill-tree walk: skip `.git`, refuse symlinks/specials, optionally load bytes.
 enum Collected {
-    Tree(BTreeMap<String, EntryKind>),
+    Tree(BTreeMap<PathBuf, EntryKind>),
     Unsupported { path: PathBuf, what: &'static str },
+}
+
+#[cfg(unix)]
+fn regular_file_mode(metadata: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+
+    if metadata.permissions().mode() & 0o111 == 0 {
+        0o644
+    } else {
+        0o755
+    }
+}
+
+#[cfg(not(unix))]
+fn regular_file_mode(_metadata: &fs::Metadata) -> u32 {
+    0
+}
+
+#[cfg(unix)]
+fn default_file_mode() -> u32 {
+    0o644
+}
+
+#[cfg(not(unix))]
+fn default_file_mode() -> u32 {
+    0
+}
+
+/// Encode version-2 paths without collapsing legal Unix filename bytes.
+/// Windows is not a claimed platform, but normalizing its separator keeps the
+/// encoding well-defined for callers that compile there.
+pub(crate) fn digest_path_bytes(relative: &Path) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        relative.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        relative.to_string_lossy().replace('\\', "/").into_bytes()
+    }
+}
+
+/// Preserve the pre-version-2 encoding exactly for receipt migration.
+fn legacy_digest_path_bytes(relative: &Path) -> Vec<u8> {
+    if let Some(relative) = relative.to_str() {
+        return relative.replace('\\', "/").into_bytes();
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        relative.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        relative.to_string_lossy().replace('\\', "/").into_bytes()
+    }
 }
 
 fn collect_tree(root: &Path) -> Result<Collected, Error> {
@@ -248,17 +311,16 @@ fn collect_tree(root: &Path) -> Result<Collected, Error> {
     fn walk(
         root: &Path,
         dir: &Path,
-        contents: &mut BTreeMap<String, EntryKind>,
+        contents: &mut BTreeMap<PathBuf, EntryKind>,
     ) -> Result<Option<(PathBuf, &'static str)>, Error> {
         for entry in fs::read_dir(dir).map_err(|e| map_io(dir, e))? {
             let entry = entry.map_err(|e| map_io(dir, e))?;
             let path = entry.path();
             let relative = path
                 .strip_prefix(root)
-                .map_err(|_| Error::msg(format!("path escape: {}", path.display())))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            if relative == ".git" || relative.starts_with(".git/") {
+                .map_err(|_| Error::msg(format!("path escape: {}", output::display_path(&path))))?
+                .to_path_buf();
+            if relative == Path::new(".git") || relative.starts_with(Path::new(".git")) {
                 continue;
             }
             if path.is_symlink() {
@@ -272,7 +334,14 @@ fn collect_tree(root: &Path) -> Result<Collected, Error> {
                 }
             } else if ft.is_file() {
                 let bytes = fs::read(&path).map_err(|e| map_io(&path, e))?;
-                contents.insert(relative, EntryKind::File(bytes));
+                let metadata = entry.metadata().map_err(|e| map_io(&path, e))?;
+                contents.insert(
+                    relative,
+                    EntryKind::File {
+                        bytes,
+                        mode: regular_file_mode(&metadata),
+                    },
+                );
             } else {
                 return Ok(Some((path, "special file")));
             }
@@ -285,12 +354,12 @@ fn collect_tree(root: &Path) -> Result<Collected, Error> {
     }
 }
 
-fn require_safe_tree(root: &Path) -> Result<BTreeMap<String, EntryKind>, Error> {
+fn require_safe_tree(root: &Path) -> Result<BTreeMap<PathBuf, EntryKind>, Error> {
     match collect_tree(root)? {
         Collected::Tree(tree) => Ok(tree),
         Collected::Unsupported { path, what } => Err(Error::msg(format!(
             "Refusing to copy {what}: {}",
-            path.display()
+            output::display_path(&path)
         ))),
     }
 }
@@ -303,7 +372,7 @@ fn validate_tree_structure(root: &Path) -> Result<Option<(PathBuf, &'static str)
             let path = entry.path();
             let relative = path
                 .strip_prefix(root)
-                .map_err(|_| Error::msg(format!("path escape: {}", path.display())))?;
+                .map_err(|_| Error::msg(format!("path escape: {}", output::display_path(&path))))?;
             if relative == Path::new(".git") || relative.starts_with(".git") {
                 continue;
             }
@@ -330,19 +399,19 @@ pub fn validate_skill_tree(root: &Path) -> Result<(), Error> {
         None => Ok(()),
         Some((path, what)) => Err(Error::msg(format!(
             "Refusing to copy {what}: {}",
-            path.display()
+            output::display_path(&path)
         ))),
     }
 }
 
-fn tree_contents(root: &Path) -> Result<Option<BTreeMap<String, EntryKind>>, Error> {
+fn tree_contents(root: &Path) -> Result<Option<BTreeMap<PathBuf, EntryKind>>, Error> {
     match collect_tree(root)? {
         Collected::Tree(tree) => Ok(Some(tree)),
         Collected::Unsupported { .. } => Ok(None),
     }
 }
 
-fn materialize_tree(tree: &BTreeMap<String, EntryKind>, destination: &Path) -> Result<(), Error> {
+fn materialize_tree(tree: &BTreeMap<PathBuf, EntryKind>, destination: &Path) -> Result<(), Error> {
     fs::create_dir_all(destination).map_err(|e| map_io(destination, e))?;
     for (relative, kind) in tree {
         let to = destination.join(relative);
@@ -350,11 +419,18 @@ fn materialize_tree(tree: &BTreeMap<String, EntryKind>, destination: &Path) -> R
             EntryKind::Dir => {
                 fs::create_dir_all(&to).map_err(|e| map_io(&to, e))?;
             }
-            EntryKind::File(bytes) => {
+            EntryKind::File { bytes, mode } => {
                 if let Some(parent) = to.parent() {
                     fs::create_dir_all(parent).map_err(|e| map_io(parent, e))?;
                 }
                 fs::write(&to, bytes).map_err(|e| map_io(&to, e))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+
+                    fs::set_permissions(&to, fs::Permissions::from_mode(*mode & 0o777))
+                        .map_err(|e| map_io(&to, e))?;
+                }
             }
         }
     }
@@ -382,8 +458,8 @@ pub fn skill_contents_equal_except(
         return Ok(false);
     };
     for key in ignore {
-        a.remove(*key);
-        b.remove(*key);
+        a.remove(Path::new(key));
+        b.remove(Path::new(key));
     }
     Ok(a == b)
 }
@@ -395,37 +471,57 @@ pub fn copy_skill_tree(
 ) -> Result<(), Error> {
     let mut tree = require_safe_tree(source)?;
     for name in root_ignore {
-        tree.remove(*name);
-        let prefix = format!("{name}/");
-        tree.retain(|key, _| !key.starts_with(&prefix));
+        let ignored = Path::new(name);
+        tree.retain(|key, _| key != ignored && !key.starts_with(ignored));
     }
     materialize_tree(&tree, destination)
 }
 
-/// Compute the canonical digest used by opaque managed skillset trees.
-pub fn tree_digest(root: &Path, root_ignore: &[&str]) -> Result<String, Error> {
+fn digest_tree(root: &Path, root_ignore: &[&str], include_mode: bool) -> Result<String, Error> {
     let mut tree = require_safe_tree(root)?;
     for name in root_ignore {
-        tree.remove(*name);
-        let prefix = format!("{name}/");
-        tree.retain(|key, _| !key.starts_with(&prefix));
+        let ignored = Path::new(name);
+        tree.retain(|key, _| key != ignored && !key.starts_with(ignored));
     }
 
     let mut hasher = Sha256::new();
+    if include_mode {
+        hasher.update(b"tink-tree-digest-v2\0");
+    }
     for (relative, kind) in tree {
-        let path = relative.as_bytes();
+        let path = if include_mode {
+            digest_path_bytes(&relative)
+        } else {
+            legacy_digest_path_bytes(&relative)
+        };
         hasher.update((path.len() as u64).to_be_bytes());
-        hasher.update(path);
+        hasher.update(&path);
         match kind {
             EntryKind::Dir => hasher.update([b'd']),
-            EntryKind::File(bytes) => {
+            EntryKind::File { bytes, mode } => {
                 hasher.update([b'f']);
+                if include_mode {
+                    hasher.update(mode.to_be_bytes());
+                }
                 hasher.update((bytes.len() as u64).to_be_bytes());
                 hasher.update(bytes);
             }
         }
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Version-2 digest for opaque managed trees. Fields are unambiguously framed,
+/// and each regular file's canonical executable/non-executable mode is part of
+/// the integrity contract.
+pub fn tree_digest(root: &Path, root_ignore: &[&str]) -> Result<String, Error> {
+    digest_tree(root, root_ignore, true)
+}
+
+/// Pre-version-2 digest retained only to validate and migrate old receipts.
+/// New persisted state must use [`tree_digest`].
+pub(crate) fn tree_digest_legacy(root: &Path, root_ignore: &[&str]) -> Result<String, Error> {
+    digest_tree(root, root_ignore, false)
 }
 
 /// Result of comparing a candidate skill tree to an install target.
@@ -451,7 +547,7 @@ impl PreflightOutcome {
         match self {
             Self::Divergent => Err(Error::msg(format!(
                 "Refusing to overwrite existing skill: {}",
-                destination_root.join(skill_name).display()
+                output::display_path(&destination_root.join(skill_name))
             ))),
             other => Ok(other),
         }
@@ -461,47 +557,57 @@ impl PreflightOutcome {
 fn expected_install_tree(
     skill: &Skill,
     provenance: Option<&Provenance>,
-) -> Result<BTreeMap<String, EntryKind>, Error> {
+) -> Result<BTreeMap<PathBuf, EntryKind>, Error> {
     let mut expected = require_safe_tree(&skill.path)?;
     if let Some(provenance) = provenance {
-        if expected.contains_key(provenance::SIDECAR_FILE) {
+        if expected.contains_key(Path::new(provenance::SIDECAR_FILE)) {
             return Err(Error::msg(format!(
                 "Remote skill already contains reserved .tink-source.json: {}",
-                skill.path.display()
+                output::display_path(&skill.path)
             )));
         }
         expected.insert(
-            provenance::SIDECAR_FILE.into(),
-            EntryKind::File(provenance::to_bytes(provenance)?),
+            PathBuf::from(provenance::SIDECAR_FILE),
+            EntryKind::File {
+                bytes: provenance::to_bytes(provenance)?,
+                mode: default_file_mode(),
+            },
         );
     }
     Ok(expected)
 }
 
 fn equal_except_receipt(
-    left: &BTreeMap<String, EntryKind>,
-    right: &BTreeMap<String, EntryKind>,
+    left: &BTreeMap<PathBuf, EntryKind>,
+    right: &BTreeMap<PathBuf, EntryKind>,
 ) -> bool {
     left.iter()
-        .filter(|(key, _)| key.as_str() != provenance::SIDECAR_FILE)
+        .filter(|(key, _)| key.as_path() != Path::new(provenance::SIDECAR_FILE))
         .eq(right
             .iter()
-            .filter(|(key, _)| key.as_str() != provenance::SIDECAR_FILE))
+            .filter(|(key, _)| key.as_path() != Path::new(provenance::SIDECAR_FILE)))
 }
 
 /// Align destination receipt to `expected` without rewriting skill body files.
-fn repair_receipt(target: &Path, expected: &BTreeMap<String, EntryKind>) -> Result<(), Error> {
+fn repair_receipt(target: &Path, expected: &BTreeMap<PathBuf, EntryKind>) -> Result<(), Error> {
     refuse_symlink(target)?;
     let sidecar = target.join(provenance::SIDECAR_FILE);
-    match expected.get(provenance::SIDECAR_FILE) {
-        Some(EntryKind::File(bytes)) => {
+    match expected.get(Path::new(provenance::SIDECAR_FILE)) {
+        Some(EntryKind::File { bytes, mode }) => {
             refuse_symlink(&sidecar)?;
             fs::write(&sidecar, bytes).map_err(|e| map_io(&sidecar, e))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+
+                fs::set_permissions(&sidecar, fs::Permissions::from_mode(*mode & 0o777))
+                    .map_err(|e| map_io(&sidecar, e))?;
+            }
         }
         Some(EntryKind::Dir) => {
             return Err(Error::msg(format!(
                 "Invalid receipt entry (directory): {}",
-                sidecar.display()
+                output::display_path(&sidecar)
             )));
         }
         None => {
@@ -526,14 +632,14 @@ pub fn preflight_install(
     if !target.exists() && !target.is_symlink() {
         return Ok(PreflightOutcome::Ready);
     }
-    if target.is_dir() {
-        if let Some(existing) = tree_contents(&target)? {
-            if existing == expected {
-                return Ok(PreflightOutcome::Identical);
-            }
-            if equal_except_receipt(&existing, &expected) {
-                return Ok(PreflightOutcome::ReceiptMismatch);
-            }
+    if target.is_dir()
+        && let Some(existing) = tree_contents(&target)?
+    {
+        if existing == expected {
+            return Ok(PreflightOutcome::Identical);
+        }
+        if equal_except_receipt(&existing, &expected) {
+            return Ok(PreflightOutcome::ReceiptMismatch);
         }
     }
     Ok(PreflightOutcome::Divergent)
@@ -572,6 +678,45 @@ pub fn install_local(
     }
 }
 
+fn rollback_or_retain_backup(
+    staging: tempfile::TempDir,
+    backup: &Path,
+    target: &Path,
+    publish_error: std::io::Error,
+) -> Error {
+    match fs::rename(backup, target) {
+        Ok(()) => map_io(target, publish_error),
+        Err(rollback_error) => {
+            let recovery_root = staging.keep();
+            let recovery = recovery_root.join(
+                backup
+                    .file_name()
+                    .unwrap_or_else(|| std::ffi::OsStr::new("old")),
+            );
+            Error::msg(format!(
+                "could not publish {} ({publish_error}); rollback failed ({rollback_error}); recovery backup: {}",
+                output::display_path(target),
+                output::display_path(&recovery)
+            ))
+        }
+    }
+}
+
+/// Rename a fully staged replacement over an existing tree. If publication and
+/// rollback both fail, retain the only original at an explicit recovery path.
+pub(crate) fn publish_staged_tree(
+    staging: tempfile::TempDir,
+    staged: PathBuf,
+    target: &Path,
+) -> Result<PathBuf, Error> {
+    let backup = staging.path().join("old");
+    fs::rename(target, &backup).map_err(|e| map_io(target, e))?;
+    if let Err(error) = fs::rename(&staged, target) {
+        return Err(rollback_or_retain_backup(staging, &backup, target, error));
+    }
+    Ok(target.to_path_buf())
+}
+
 /// Replace an existing imported skill after dirty-tree preflight elsewhere.
 pub fn replace_verified(
     skill: &Skill,
@@ -584,7 +729,7 @@ pub fn replace_verified(
     if !target.is_dir() {
         return Err(Error::msg(format!(
             "Refusing to replace missing or unsafe skill: {}",
-            target.display()
+            output::display_path(&target)
         )));
     }
     let staging = tempfile::Builder::new()
@@ -592,28 +737,223 @@ pub fn replace_verified(
         .tempdir_in(destination_root)
         .map_err(|e| Error::msg(format!("update staging: {e}")))?;
     let staged = staging.path().join("new");
-    let backup = staging.path().join("old");
     copy_skill_tree(&skill.path, &staged, &[".git"])?;
     if staged.join(provenance::SIDECAR_FILE).exists() {
         return Err(Error::msg(format!(
             "Remote skill contains reserved .tink-source.json: {}",
-            skill.path.display()
+            output::display_path(&skill.path)
         )));
     }
     provenance::write_file(&staged.join(provenance::SIDECAR_FILE), provenance)?;
-    fs::rename(&target, &backup).map_err(|e| map_io(&target, e))?;
-    if let Err(err) = fs::rename(&staged, &target) {
-        let _ = fs::rename(&backup, &target);
-        return Err(map_io(&target, err));
-    }
-    let _ = fs::remove_dir_all(&backup);
-    Ok(target)
+    publish_staged_tree(staging, staged, &target)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_errors_escape_terminal_controls_in_paths() {
+        let temp = TempDir::new().unwrap();
+        let skill = temp.path().join("unsafe\u{1b}[31m");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "missing frontmatter\n").unwrap();
+
+        let error = read_skill(&skill, false).unwrap_err().to_string();
+
+        assert!(
+            !error.contains('\u{1b}'),
+            "raw escape reached diagnostic: {error:?}"
+        );
+        assert!(error.contains("unsafe\\x1b[31m"), "{error:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_skill_tree_canonicalizes_executable_mode_and_strips_special_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir_all(&source).unwrap();
+        let script = source.join("run.sh");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o6741)).unwrap();
+
+        copy_skill_tree(&source, &destination, &[]).unwrap();
+
+        let copied_mode = fs::metadata(destination.join("run.sh"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(copied_mode, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tree_identity_is_stable_across_non_executable_umask_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir_all(&source).unwrap();
+        let file = source.join("notes.txt");
+        fs::write(&file, "same bytes").unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o600)).unwrap();
+        let restrictive_digest = tree_digest(&source, &[]).unwrap();
+
+        copy_skill_tree(&source, &destination, &[]).unwrap();
+        assert_eq!(
+            fs::metadata(destination.join("notes.txt"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert_eq!(tree_digest(&source, &[]).unwrap(), restrictive_digest);
+        assert!(skill_contents_equal(&source, &destination).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_skill_tree_preserves_distinct_non_utf8_names() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir_all(&source).unwrap();
+        let first = source.join(OsString::from_vec(vec![0x80]));
+        let second = source.join(OsString::from_vec(vec![0x81]));
+        for (path, body) in [
+            (&first, b"first".as_slice()),
+            (&second, b"second".as_slice()),
+        ] {
+            if let Err(error) = fs::write(path, body) {
+                assert_eq!(
+                    error.raw_os_error(),
+                    Some(92),
+                    "unexpected fixture error: {error}"
+                );
+                assert!(
+                    !destination.exists(),
+                    "OS rejection must happen before destination writes"
+                );
+                return;
+            }
+        }
+
+        copy_skill_tree(&source, &destination, &[]).unwrap();
+
+        assert_eq!(
+            fs::read(destination.join(OsString::from_vec(vec![0x80]))).unwrap(),
+            b"first"
+        );
+        assert_eq!(
+            fs::read(destination.join(OsString::from_vec(vec![0x81]))).unwrap(),
+            b"second"
+        );
+    }
+
+    #[test]
+    fn tree_digest_v2_is_domain_separated_from_legacy_encoding() {
+        let temp = TempDir::new().unwrap();
+        let tree = temp.path().join("skill");
+        fs::create_dir_all(tree.join("resources")).unwrap();
+        fs::write(tree.join("SKILL.md"), b"body").unwrap();
+        fs::write(tree.join("resources/run.sh"), b"run").unwrap();
+
+        assert_ne!(
+            tree_digest(&tree, &[]).unwrap(),
+            tree_digest_legacy(&tree, &[]).unwrap()
+        );
+        assert_eq!(
+            tree_digest_legacy(&tree, &[]).unwrap(),
+            "f612169400ea83a502473a69fac44e95b4dff9aa49319aebc0a073b61dd57a03"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tree_digest_v2_includes_regular_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let tree = temp.path().join("skill");
+        fs::create_dir_all(&tree).unwrap();
+        let script = tree.join("run.sh");
+        fs::write(&script, b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        let executable = tree_digest(&tree, &[]).unwrap();
+        let legacy_executable = tree_digest_legacy(&tree, &[]).unwrap();
+
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert_ne!(tree_digest(&tree, &[]).unwrap(), executable);
+        assert_eq!(tree_digest_legacy(&tree, &[]).unwrap(), legacy_executable);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tree_digest_v2_distinguishes_literal_backslash_from_path_separator() {
+        let temp = tempfile::tempdir().unwrap();
+        let flat = temp.path().join("flat");
+        let nested = temp.path().join("nested");
+        fs::create_dir_all(flat.join("a")).unwrap();
+        fs::create_dir_all(nested.join("a")).unwrap();
+        fs::write(flat.join("SKILL.md"), "same").unwrap();
+        fs::write(nested.join("SKILL.md"), "same").unwrap();
+        fs::write(flat.join("a\\b"), "payload").unwrap();
+        fs::write(nested.join("a").join("b"), "payload").unwrap();
+
+        assert_eq!(
+            tree_digest_legacy(&flat, &[]).unwrap(),
+            tree_digest_legacy(&nested, &[]).unwrap(),
+            "fixture must reproduce the historical normalization collision"
+        );
+        assert_ne!(
+            tree_digest(&flat, &[]).unwrap(),
+            tree_digest(&nested, &[]).unwrap()
+        );
+    }
+
+    #[test]
+    fn rollback_failure_retains_recovery_backup() {
+        let temp = TempDir::new().unwrap();
+        let staging = tempfile::Builder::new()
+            .prefix(".rollback-fixture-")
+            .tempdir_in(temp.path())
+            .unwrap();
+        let staging_path = staging.path().to_path_buf();
+        let backup = staging.path().join("old");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("original"), "preserve me").unwrap();
+        let target = temp.path().join("target");
+        fs::write(&target, "rollback blocker").unwrap();
+
+        let error = rollback_or_retain_backup(
+            staging,
+            &backup,
+            &target,
+            std::io::Error::other("publish fixture"),
+        );
+
+        assert!(error.to_string().contains("recovery backup"), "{error}");
+        assert!(error.to_string().contains(&backup.display().to_string()));
+        assert_eq!(
+            fs::read(staging_path.join("old/original")).unwrap(),
+            b"preserve me"
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/skillsets.rs
+++ b/src/skillsets.rs
@@ -14,12 +14,18 @@ use crate::error::Error;
 use crate::git;
 use crate::home;
 use crate::init;
-use crate::paths::{map_io, refuse_symlink};
+use crate::output;
+use crate::paths::{canonicalize_beneath, map_io, refuse_symlink};
 use crate::skills;
 use crate::sources;
 
 const RECEIPT_FILE: &str = ".tink-skillset.json";
 const NAME_SUFFIX: &str = "-skillset";
+const DIGEST_VERSION: u32 = 2;
+
+fn legacy_digest_version() -> u32 {
+    1
+}
 
 /// Whether `path` contains a skillset receipt entry.
 ///
@@ -29,6 +35,18 @@ const NAME_SUFFIX: &str = "-skillset";
 pub(crate) fn has_receipt_entry(path: &Path) -> bool {
     let receipt = path.join(RECEIPT_FILE);
     receipt.exists() || receipt.is_symlink()
+}
+
+/// Refuse a skillset-owned tree at a standalone-skill boundary.
+///
+/// Receipt entry presence establishes ownership before receipt contents are trusted.
+pub(crate) fn ensure_standalone_source(path: &Path, name: &str) -> Result<(), Error> {
+    if has_receipt_entry(path) {
+        return Err(Error::msg(format!(
+            "Source is owned by a skillset; use `tink skillset add {name}`"
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,6 +74,8 @@ struct SkillsetReceipt {
     #[serde(rename = "sourceRoot")]
     source_root: String,
     members: Vec<String>,
+    #[serde(rename = "digestVersion", default = "legacy_digest_version")]
+    digest_version: u32,
     digest: String,
 }
 
@@ -74,7 +94,10 @@ pub struct ListedSkillset {
 fn read_json<T: for<'de> Deserialize<'de>>(path: &Path, label: &str) -> Result<T, Error> {
     refuse_symlink(path)?;
     if !path.is_file() {
-        return Err(Error::msg(format!("Missing {label}: {}", path.display())));
+        return Err(Error::msg(format!(
+            "Missing {label}: {}",
+            output::display_path(path)
+        )));
     }
     let text = fs::read_to_string(path).map_err(|e| map_io(path, e))?;
     serde_json::from_str(&text).map_err(|e| Error::msg(format!("Invalid {label}: {e}")))
@@ -183,6 +206,7 @@ fn receipt_for(meta: &SkillsetMeta, digest: String) -> SkillsetReceipt {
         revision: meta.revision.clone(),
         source_root: meta.source_root.clone(),
         members: meta.members.clone(),
+        digest_version: DIGEST_VERSION,
         digest,
     }
 }
@@ -199,11 +223,17 @@ fn receipt_meta(receipt: &SkillsetReceipt) -> SkillsetMeta {
 fn read_owned_receipt(path: &Path, label: &str) -> Result<SkillsetReceipt, Error> {
     let receipt: SkillsetReceipt = read_json(&path.join(RECEIPT_FILE), label)?;
     validate_meta(&receipt_meta(&receipt))?;
+    if receipt.digest_version != 1 && receipt.digest_version != DIGEST_VERSION {
+        return Err(Error::msg(format!(
+            "Unsupported skillset digest version: {}",
+            receipt.digest_version
+        )));
+    }
     validate_digest(&receipt.digest)?;
     Ok(receipt)
 }
 
-fn validate_installed_tree(path: &Path, receipt: &SkillsetReceipt) -> Result<(), Error> {
+fn validate_member_trees(path: &Path, receipt: &SkillsetReceipt) -> Result<(), Error> {
     for member in &receipt.members {
         let member_path = path.join(member);
         refuse_symlink(&member_path)?;
@@ -212,11 +242,37 @@ fn validate_installed_tree(path: &Path, receipt: &SkillsetReceipt) -> Result<(),
         }
         skills::read_skill(&member_path, true)?;
     }
+    Ok(())
+}
+
+fn validate_installed_tree(path: &Path, receipt: &SkillsetReceipt) -> Result<(), Error> {
+    validate_member_trees(path, receipt)?;
+    if receipt.digest_version != DIGEST_VERSION {
+        return Err(Error::msg(format!(
+            "Skillset receipt uses legacy digest version {}; run `tink skillset refresh {}` to migrate it",
+            receipt.digest_version,
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("NAME-skillset")
+        )));
+    }
     let digest = skills::tree_digest(path, &[RECEIPT_FILE])?;
     if digest != receipt.digest {
         return Err(Error::msg(format!(
             "Skillset tree digest mismatch: {}",
-            path.display()
+            output::display_path(path)
+        )));
+    }
+    Ok(())
+}
+
+fn validate_legacy_tree_for_refresh(path: &Path, receipt: &SkillsetReceipt) -> Result<(), Error> {
+    validate_member_trees(path, receipt)?;
+    let digest = skills::tree_digest_legacy(path, &[RECEIPT_FILE])?;
+    if digest != receipt.digest {
+        return Err(Error::msg(format!(
+            "Skillset tree digest mismatch: {}",
+            output::display_path(path)
         )));
     }
     Ok(())
@@ -237,16 +293,14 @@ fn source_member_root(
     meta: &SkillsetMeta,
     member: &str,
 ) -> Result<PathBuf, Error> {
-    let source_root = checkout.join(normalized_source_root(&meta.source_root)?);
-    refuse_symlink(&source_root)?;
+    let source_root = canonicalize_beneath(checkout, &normalized_source_root(&meta.source_root)?)?;
     if !source_root.is_dir() {
         return Err(Error::msg(format!(
             "Skillset sourceRoot is not a directory: {}",
-            source_root.display()
+            output::display_path(&source_root)
         )));
     }
-    let member_root = source_root.join(member);
-    refuse_symlink(&member_root)?;
+    let member_root = canonicalize_beneath(&source_root, Path::new(member))?;
     if !member_root.is_dir() {
         return Err(Error::msg(format!("Skillset member not found: {member}")));
     }
@@ -265,7 +319,7 @@ fn install_from_checkout(
         refuse_symlink(&target)?;
         return Err(Error::msg(format!(
             "Refusing to overwrite existing skillset: {}",
-            target.display()
+            output::display_path(&target)
         )));
     }
 
@@ -309,13 +363,7 @@ fn replace_from_checkout(
     let target = destination_root.join(name);
     let (staging, staged) = stage_from_checkout(checkout, meta, destination_root, name)?;
 
-    let backup = staging.path().join("old");
-    fs::rename(&target, &backup).map_err(|e| map_io(&target, e))?;
-    if let Err(error) = fs::rename(&staged, &target) {
-        let _ = fs::rename(&backup, &target);
-        return Err(map_io(&target, error));
-    }
-    Ok(target)
+    skills::publish_staged_tree(staging, staged, &target)
 }
 
 pub fn add_skillset(
@@ -331,10 +379,15 @@ pub fn add_skillset(
         if !target.is_dir() {
             return Err(Error::msg(format!(
                 "Refusing to overwrite non-directory skillset: {}",
-                target.display()
+                output::display_path(&target)
             )));
         }
         let receipt = read_owned_receipt(&target, "installed skillset receipt")?;
+        if receipt.digest_version != DIGEST_VERSION {
+            return Err(Error::msg(format!(
+                "Skillset receipt uses a legacy digest; run `tink skillset refresh {name}` to migrate it"
+            )));
+        }
         if validate_installed_tree(&target, &receipt).is_err() {
             return Err(Error::msg(format!(
                 "Refusing to add {name}: local modifications are present; remove it first to discard them"
@@ -378,13 +431,19 @@ pub fn refresh_skillset(project_root: &Path, name: &str) -> Result<bool, Error> 
         return Err(Error::msg(format!("Skillset not found: {name}")));
     }
     let receipt = read_owned_receipt(&target, "installed skillset receipt")?;
-    if validate_installed_tree(&target, &receipt).is_err() {
+    let legacy_receipt = receipt.digest_version != DIGEST_VERSION;
+    let validation = if legacy_receipt {
+        validate_legacy_tree_for_refresh(&target, &receipt)
+    } else {
+        validate_installed_tree(&target, &receipt)
+    };
+    if validation.is_err() {
         return Err(Error::msg(format!(
             "Refusing to refresh {name}: local modifications are present"
         )));
     }
     preflight_library_target(name)?;
-    if receipt_meta(&receipt) == meta {
+    if !legacy_receipt && receipt_meta(&receipt) == meta {
         sync_library_from_project(&target)?;
         return Ok(false);
     }
@@ -452,9 +511,12 @@ pub fn list_installed(project_root: &Path) -> Result<Vec<ListedSkillset>, Error>
 
     let mut entries: Vec<_> = fs::read_dir(&skills_root)
         .map_err(|e| map_io(&skills_root, e))?
-        .filter_map(|entry| entry.ok())
-        .map(|entry| entry.path())
-        .collect();
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|e| map_io(&skills_root, e))
+        })
+        .collect::<Result<_, _>>()?;
     entries.sort();
 
     let mut skillsets = Vec::new();
@@ -517,13 +579,13 @@ fn preflight_library_target(name: &str) -> Result<(), Error> {
     if !target.is_dir() {
         return Err(Error::msg(format!(
             "Library name collision for skillset: {}",
-            target.display()
+            output::display_path(&target)
         )));
     }
     validate_library_receipt(&target).map_err(|_| {
         Error::msg(format!(
             "Library name collision for skillset: {}; existing entry is not an owned skillset",
-            target.display()
+            output::display_path(&target)
         ))
     })
 }
@@ -547,14 +609,7 @@ fn copy_project_tree(
         return Ok(());
     }
 
-    let backup = staging.path().join("old");
-    fs::rename(&target, &backup).map_err(|e| map_io(&target, e))?;
-    if let Err(error) = fs::rename(&staged, &target) {
-        let _ = fs::rename(&backup, &target);
-        return Err(map_io(&target, error));
-    }
-    let _ = fs::remove_dir_all(&backup);
-    Ok(())
+    skills::publish_staged_tree(staging, staged, &target).map(|_| ())
 }
 
 fn sync_library_from_project(project: &Path) -> Result<LibraryWrite, Error> {
@@ -591,15 +646,18 @@ pub fn list_library(home_root: Option<&Path>) -> Result<Vec<ListedSkillset>, Err
     if !library.is_dir() {
         return Err(Error::msg(format!(
             "Refusing to read non-directory library: {}",
-            library.display()
+            output::display_path(&library)
         )));
     }
 
     let mut entries: Vec<_> = fs::read_dir(&library)
         .map_err(|e| map_io(&library, e))?
-        .filter_map(|entry| entry.ok())
-        .map(|entry| entry.path())
-        .collect();
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|e| map_io(&library, e))
+        })
+        .collect::<Result<_, _>>()?;
     entries.sort();
     let mut skillsets = Vec::new();
     for path in entries {
@@ -622,6 +680,32 @@ mod tests {
     use super::*;
 
     #[test]
+    fn legacy_receipt_is_only_accepted_for_refresh_migration() {
+        let temp = tempfile::tempdir().unwrap();
+        let installed = temp.path().join("demo-skillset");
+        let member = installed.join("demo");
+        fs::create_dir_all(&member).unwrap();
+        fs::write(
+            member.join("SKILL.md"),
+            "---\nname: demo\ndescription: Legacy receipt fixture.\n---\n",
+        )
+        .unwrap();
+        let digest = skills::tree_digest_legacy(&installed, &[RECEIPT_FILE]).unwrap();
+        let receipt = SkillsetReceipt {
+            source: "https://github.com/example/skills.git".into(),
+            revision: "a".repeat(40),
+            source_root: "skills".into(),
+            members: vec!["demo".into()],
+            digest_version: 1,
+            digest,
+        };
+
+        assert!(validate_legacy_tree_for_refresh(&installed, &receipt).is_ok());
+        let error = validate_installed_tree(&installed, &receipt).unwrap_err();
+        assert!(error.to_string().contains("skillset refresh"), "{error}");
+    }
+
+    #[test]
     fn source_root_rejects_escape_and_empty_segments() {
         for value in [
             "",
@@ -637,6 +721,34 @@ mod tests {
             normalized_source_root("skills/common").unwrap(),
             PathBuf::from("skills/common")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_member_root_refuses_symlinked_source_root_ancestor() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkout = temp.path().join("checkout");
+        let outside = temp.path().join("outside");
+        let member = outside.join("skills/alpha");
+        fs::create_dir_all(&checkout).unwrap();
+        fs::create_dir_all(&member).unwrap();
+        fs::write(
+            member.join("SKILL.md"),
+            "---\nname: alpha\ndescription: Outside fixture.\n---\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&outside, checkout.join("jump")).unwrap();
+        let meta = SkillsetMeta {
+            source: "https://github.com/example/skills.git".into(),
+            revision: "a".repeat(40),
+            source_root: "jump/skills".into(),
+            members: vec!["alpha".into()],
+        };
+
+        let error = source_member_root(&checkout, &meta, "alpha")
+            .expect_err("ancestor symlink must be refused");
+
+        assert!(error.to_string().contains("symlink"), "{error}");
     }
 
     #[test]

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -17,7 +17,7 @@ pub enum AddSource {
 pub enum LockedSource {
     LocalPath {
         declared: String,
-        path: PathBuf,
+        project_root: PathBuf,
     },
     Github {
         remote: RemoteSource,
@@ -126,7 +126,7 @@ pub fn classify_locked(
     normalize_project_path(Path::new(source), name)?;
     Ok(LockedSource::LocalPath {
         declared: source.to_string(),
-        path: project_root.join(source),
+        project_root: project_root.to_path_buf(),
     })
 }
 
@@ -230,20 +230,19 @@ fn github_part_ok(part: &str) -> bool {
 
 /// Parse `owner/repo` or `https://github.com/owner/repo[.git]`.
 pub fn parse_remote(value: &str) -> Result<RemoteSource, Error> {
-    if let Some((owner, repo)) = value.split_once('/') {
-        if !value.contains("://")
-            && !value.contains('@')
-            && github_part_ok(owner)
-            && github_part_ok(repo.trim_end_matches(".git"))
-            && !owner.is_empty()
-            && value.matches('/').count() == 1
-        {
-            let repo = repo.trim_end_matches(".git");
-            return Ok(RemoteSource {
-                display: value.to_string(),
-                url: format!("https://github.com/{owner}/{repo}.git"),
-            });
-        }
+    if let Some((owner, repo)) = value.split_once('/')
+        && !value.contains("://")
+        && !value.contains('@')
+        && github_part_ok(owner)
+        && github_part_ok(repo.trim_end_matches(".git"))
+        && !owner.is_empty()
+        && value.matches('/').count() == 1
+    {
+        let repo = repo.trim_end_matches(".git");
+        return Ok(RemoteSource {
+            display: value.to_string(),
+            url: format!("https://github.com/{owner}/{repo}.git"),
+        });
     }
 
     let err = || Error::msg("Remote sources must be public GitHub HTTPS URLs or owner/repository");
@@ -373,7 +372,7 @@ mod tests {
         let root = Path::new("/project");
         assert!(matches!(
             classify_locked(root, "local-skill", "owner/repo-shape", None, None).unwrap(),
-            LockedSource::LocalPath { path, .. } if path == root.join("owner/repo-shape")
+            LockedSource::LocalPath { project_root, .. } if project_root == root
         ));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -686,7 +686,7 @@ pub fn print_report(report: &UpdateReport) -> Result<(), Error> {
                 "{} {} ({})",
                 style.muted("Up to date"),
                 style.accent(format!("v{version}")),
-                style.muted(path.display())
+                style.muted(output::display_path(path))
             ))?;
         }
         UpdateReport::Updated { from, to, path } => {
@@ -698,7 +698,7 @@ pub fn print_report(report: &UpdateReport) -> Result<(), Error> {
             ))?;
             output::stdout_line(format_args!(
                 "{}",
-                style.muted(format!("Installed to {}", path.display()))
+                style.muted(format!("Installed to {}", output::display_path(path)))
             ))?;
         }
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -532,15 +532,17 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
         fs::set_permissions(staging.path(), fs::Permissions::from_mode(0o755))
             .map_err(|e| Error::msg(format!("chmod {}: {e}", staging.path().display())))?;
     }
-    probe_candidate(staging.path(), expected_version)?;
-    let published = staging.persist(current).map_err(|error| {
+    // Linux refuses to execute a file while a writable handle remains open.
+    // TempPath retains cleanup/persist ownership after closing that handle.
+    let staging = staging.into_temp_path();
+    probe_candidate(&staging, expected_version)?;
+    staging.persist(current).map_err(|error| {
         Error::msg(format!(
             "cannot replace {} ({}). Re-run install.sh or fix permissions.",
             current.display(),
             error.error
         ))
     })?;
-    drop(published);
     if let Err(probe_error) = probe_candidate(current, expected_version) {
         return match backup.persist(current) {
             Ok(restored) => {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,13 +1,22 @@
-//! Replace the running tink binary from the latest GitHub Release.
+//! Replace the running tink binary from a newer verified GitHub Release.
 
+use std::cmp::Ordering;
 use std::env;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
+#[cfg(test)]
+use std::thread;
+use std::time::Duration;
+#[cfg(test)]
+use std::time::Instant;
 
-use tempfile::TempDir;
+use sha2::{Digest, Sha256};
+use tempfile::{Builder, TempDir};
 
 use crate::error::Error;
+use crate::output;
 use crate::style::CliStyle;
 
 pub const DEFAULT_RELEASES_API: &str =
@@ -20,6 +29,9 @@ const CURL_METADATA_MAX_TIME_SECONDS: &str = "30";
 const CURL_ASSET_MAX_TIME_SECONDS: &str = "300";
 const CURL_RETRY_COUNT: &str = "2";
 const CURL_RETRY_DELAY_SECONDS: &str = "1";
+const TOOL_TIMEOUT: Duration = Duration::from_secs(5);
+const TAR_TIMEOUT: Duration = Duration::from_secs(30);
+const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy)]
 enum CurlBudget {
@@ -38,8 +50,17 @@ impl CurlBudget {
 
 /// Full curl argv for a download (transport flags wired in one place).
 fn curl_command_args<'a>(budget: CurlBudget, url: &'a str, dest: &'a Path) -> Vec<&'a str> {
+    let protocol = if url.starts_with("file://") {
+        "=file"
+    } else {
+        "=https"
+    };
     vec![
         "-fsSL",
+        "--proto",
+        protocol,
+        "--proto-redir",
+        protocol,
         "--connect-timeout",
         CURL_CONNECT_TIMEOUT_SECONDS,
         "--max-time",
@@ -79,6 +100,203 @@ pub struct ReleaseAsset {
     pub tag_name: String,
     pub version: String,
     pub download_url: String,
+    pub sha256: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PrereleaseIdentifier {
+    Numeric(String),
+    Text(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SemVersion {
+    core: [u64; 3],
+    prerelease: Option<Vec<PrereleaseIdentifier>>,
+}
+
+impl SemVersion {
+    fn parse(value: &str) -> Result<Self, Error> {
+        let (without_build, build) = value
+            .split_once('+')
+            .map_or((value, None), |(version, build)| (version, Some(build)));
+        if value.matches('+').count() > 1
+            || build.is_some_and(|build| !valid_identifiers(build, false))
+        {
+            return Err(Error::msg(format!("invalid semantic version: {value}")));
+        }
+        let (core, prerelease) = without_build
+            .split_once('-')
+            .map_or((without_build, None), |(core, pre)| (core, Some(pre)));
+        let core_parts: Vec<&str> = core.split('.').collect();
+        if core_parts.len() != 3 {
+            return Err(Error::msg(format!("invalid semantic version: {value}")));
+        }
+        let mut parsed_core = [0_u64; 3];
+        for (index, part) in core_parts.iter().enumerate() {
+            if !valid_numeric_identifier(part) {
+                return Err(Error::msg(format!("invalid semantic version: {value}")));
+            }
+            parsed_core[index] = part
+                .parse()
+                .map_err(|_| Error::msg(format!("semantic version component overflow: {value}")))?;
+        }
+        let prerelease = match prerelease {
+            Some(pre) if valid_identifiers(pre, true) => Some(
+                pre.split('.')
+                    .map(|identifier| {
+                        if identifier.bytes().all(|byte| byte.is_ascii_digit()) {
+                            PrereleaseIdentifier::Numeric(identifier.to_string())
+                        } else {
+                            PrereleaseIdentifier::Text(identifier.to_string())
+                        }
+                    })
+                    .collect(),
+            ),
+            Some(_) => return Err(Error::msg(format!("invalid semantic version: {value}"))),
+            None => None,
+        };
+        Ok(Self {
+            core: parsed_core,
+            prerelease,
+        })
+    }
+}
+
+fn valid_numeric_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| byte.is_ascii_digit())
+        && (value == "0" || !value.starts_with('0'))
+}
+
+fn valid_identifiers(value: &str, reject_numeric_leading_zero: bool) -> bool {
+    !value.is_empty()
+        && value.split('.').all(|identifier| {
+            !identifier.is_empty()
+                && identifier
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+                && (!reject_numeric_leading_zero
+                    || !identifier.bytes().all(|byte| byte.is_ascii_digit())
+                    || valid_numeric_identifier(identifier))
+        })
+}
+
+impl Ord for SemVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.core
+            .cmp(&other.core)
+            .then_with(|| match (&self.prerelease, &other.prerelease) {
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (Some(left), Some(right)) => {
+                    for (left, right) in left.iter().zip(right) {
+                        let ordering = match (left, right) {
+                            (
+                                PrereleaseIdentifier::Numeric(left),
+                                PrereleaseIdentifier::Numeric(right),
+                            ) => left.len().cmp(&right.len()).then_with(|| left.cmp(right)),
+                            (PrereleaseIdentifier::Numeric(_), PrereleaseIdentifier::Text(_)) => {
+                                Ordering::Less
+                            }
+                            (PrereleaseIdentifier::Text(_), PrereleaseIdentifier::Numeric(_)) => {
+                                Ordering::Greater
+                            }
+                            (
+                                PrereleaseIdentifier::Text(left),
+                                PrereleaseIdentifier::Text(right),
+                            ) => left.cmp(right),
+                        };
+                        if ordering != Ordering::Equal {
+                            return ordering;
+                        }
+                    }
+                    left.len().cmp(&right.len())
+                }
+            })
+    }
+}
+
+impl PartialOrd for SemVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn parse_sha256(value: &str) -> Result<[u8; 32], Error> {
+    let hex = value
+        .strip_prefix("sha256:")
+        .ok_or_else(|| Error::msg("release asset digest must use sha256:<hex>"))?;
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(Error::msg(
+            "release asset SHA-256 digest must be 64 lowercase hexadecimal characters",
+        ));
+    }
+    let mut digest = [0_u8; 32];
+    for (index, byte) in digest.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16)
+            .map_err(|_| Error::msg("release asset has invalid SHA-256 digest"))?;
+    }
+    Ok(digest)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReleaseUrlMode {
+    Https,
+    File,
+}
+
+fn validate_release_url(url: &str, allow_file: bool) -> Result<ReleaseUrlMode, Error> {
+    if url.is_empty()
+        || url.contains(['?', '#', '\\'])
+        || url
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+    {
+        return Err(Error::msg("release download URL is not allowed"));
+    }
+    if let Some(rest) = url.strip_prefix("https://") {
+        let authority = rest.split('/').next().unwrap_or("");
+        if authority.is_empty() || authority.contains('@') {
+            return Err(Error::msg("release download URL is not allowed"));
+        }
+        return Ok(ReleaseUrlMode::Https);
+    }
+    if allow_file
+        && url
+            .strip_prefix("file://")
+            .is_some_and(|path| path.starts_with('/'))
+    {
+        return Ok(ReleaseUrlMode::File);
+    }
+    Err(Error::msg("release download URL is not allowed"))
+}
+
+fn validate_asset_url(url: &str, api_mode: ReleaseUrlMode) -> Result<(), Error> {
+    let asset_mode = validate_release_url(url, true)
+        .map_err(|_| Error::msg("release asset has invalid download URL"))?;
+    if asset_mode == ReleaseUrlMode::File && api_mode != ReleaseUrlMode::File {
+        return Err(Error::msg(
+            "file release assets require an explicit file TINK_RELEASES_API override",
+        ));
+    }
+    Ok(())
+}
+
+fn run_bounded(command: &mut Command, timeout: Duration, context: &str) -> Result<Output, Error> {
+    let missing = format!("{context} is required for tink update");
+    crate::process::run_bounded(command, timeout, context, Some(&missing))
+}
+
+fn release_version(tag_name: &str) -> Result<String, Error> {
+    let version = tag_name.strip_prefix('v').unwrap_or(tag_name);
+    SemVersion::parse(version).map_err(|_| Error::msg("release metadata has invalid tag_name"))?;
+    Ok(version.to_string())
 }
 
 /// Pick the asset for `target` from a GitHub Releases API latest-release JSON body.
@@ -90,29 +308,39 @@ pub fn select_release_asset(json: &str, target: &str) -> Result<ReleaseAsset, Er
         .and_then(|v| v.as_str())
         .ok_or_else(|| Error::msg("release metadata missing tag_name"))?
         .to_string();
-    let version = tag_name
-        .strip_prefix('v')
-        .unwrap_or(tag_name.as_str())
-        .to_string();
+    let version = release_version(&tag_name)?;
     let want = asset_name(&version, target);
     let assets = value
         .get("assets")
         .and_then(|v| v.as_array())
         .ok_or_else(|| Error::msg("release metadata missing assets"))?;
-    for asset in assets {
-        let name = asset.get("name").and_then(|v| v.as_str()).unwrap_or("");
-        if name == want {
-            let download_url = asset
-                .get("browser_download_url")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| Error::msg(format!("asset {want} missing browser_download_url")))?
-                .to_string();
-            return Ok(ReleaseAsset {
-                tag_name,
-                version,
-                download_url,
-            });
-        }
+    let matches: Vec<&serde_json::Value> = assets
+        .iter()
+        .filter(|asset| asset.get("name").and_then(|v| v.as_str()) == Some(want.as_str()))
+        .collect();
+    if matches.len() > 1 {
+        return Err(Error::msg(format!(
+            "expected exactly one release asset named {want}"
+        )));
+    }
+    if let Some(asset) = matches.first() {
+        let download_url = asset
+            .get("browser_download_url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::msg(format!("asset {want} missing browser_download_url")))?
+            .to_string();
+        validate_release_url(&download_url, true)
+            .map_err(|_| Error::msg(format!("asset {want} has invalid download URL")))?;
+        let digest = asset
+            .get("digest")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| Error::msg(format!("asset {want} missing digest")))?;
+        return Ok(ReleaseAsset {
+            tag_name,
+            version,
+            download_url,
+            sha256: parse_sha256(digest)?,
+        });
     }
     let names: Vec<&str> = assets
         .iter()
@@ -124,106 +352,255 @@ pub fn select_release_asset(json: &str, target: &str) -> Result<ReleaseAsset, Er
     )))
 }
 
-fn releases_api_url() -> String {
-    env::var("TINK_RELEASES_API").unwrap_or_else(|_| DEFAULT_RELEASES_API.to_string())
+fn releases_api_url() -> Result<(String, ReleaseUrlMode), Error> {
+    match env::var("TINK_RELEASES_API") {
+        Ok(url) => {
+            let mode = validate_release_url(&url, true)
+                .map_err(|_| Error::msg("TINK_RELEASES_API is not an allowed release URL"))?;
+            Ok((url, mode))
+        }
+        Err(_) => Ok((DEFAULT_RELEASES_API.to_string(), ReleaseUrlMode::Https)),
+    }
 }
 
 fn require_tool(name: &str) -> Result<(), Error> {
-    match Command::new(name).arg("--version").output() {
-        Ok(_) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            Err(Error::msg(format!("{name} is required for tink update")))
-        }
-        Err(e) => Err(Error::msg(format!("{name}: {e}"))),
+    let output = run_bounded(Command::new(name).arg("--version"), TOOL_TIMEOUT, name)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(Error::msg(format!("{name} is unavailable for tink update")))
     }
 }
 
-fn curl_to_file(budget: CurlBudget, url: &str, dest: &Path) -> Result<(), Error> {
+fn curl_to_file(budget: CurlBudget, url: &str, dest: &Path, context: &str) -> Result<(), Error> {
     if dest.to_str().is_none() {
         return Err(Error::msg("non-utf8 download path"));
     }
-    let output = Command::new("curl")
-        .args(curl_command_args(budget, url, dest))
-        .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                Error::msg("curl is required for tink update")
-            } else {
-                Error::msg(format!("curl: {e}"))
-            }
-        })?;
+    let timeout = Duration::from_secs(budget.max_time_seconds().parse::<u64>().unwrap_or(300) + 5);
+    let output = run_bounded(
+        Command::new("curl").args(curl_command_args(budget, url, dest)),
+        timeout,
+        "curl",
+    )?;
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let detail = stderr.lines().last().unwrap_or("curl failed").trim();
-        return Err(Error::msg(format!("could not download {url}: {detail}")));
+        return Err(Error::msg(format!("could not download {context}")));
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<[u8; 32], Error> {
+    let mut file = fs::File::open(path)
+        .map_err(|error| Error::msg(format!("read {}: {error}", path.display())))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .map_err(|error| Error::msg(format!("read {}: {error}", path.display())))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(hasher.finalize().into())
+}
+
+fn verify_archive_digest(path: &Path, expected: &[u8; 32]) -> Result<(), Error> {
+    if sha256_file(path)? != *expected {
+        return Err(Error::msg("release archive SHA-256 digest mismatch"));
+    }
+    Ok(())
+}
+
+fn tar_output(archive: &Path, verbose: bool) -> Result<std::process::Output, Error> {
+    let list_flag = if verbose { "-tvzf" } else { "-tzf" };
+    run_bounded(
+        Command::new("tar").arg(list_flag).arg(archive),
+        TAR_TIMEOUT,
+        "tar archive inspection",
+    )
+}
+
+fn validate_archive_inventory(archive: &Path) -> Result<(), Error> {
+    let listing = tar_output(archive, false)?;
+    if !listing.status.success() {
+        return Err(Error::msg("failed to inspect release archive"));
+    }
+    let entries = String::from_utf8(listing.stdout)
+        .map_err(|_| Error::msg("release archive has non-UTF-8 entry names"))?;
+    let entries: Vec<&str> = entries.lines().collect();
+    if entries != ["tink"] {
+        return Err(Error::msg(
+            "release archive must contain exactly one top-level tink file",
+        ));
+    }
+
+    let verbose = tar_output(archive, true)?;
+    if !verbose.status.success() {
+        return Err(Error::msg("failed to inspect release archive entry type"));
+    }
+    let details = String::from_utf8(verbose.stdout)
+        .map_err(|_| Error::msg("release archive has invalid entry metadata"))?;
+    let rows: Vec<&str> = details.lines().collect();
+    if rows.len() != 1 || !rows[0].trim_start().starts_with('-') {
+        return Err(Error::msg(
+            "release archive tink entry must be a regular file",
+        ));
     }
     Ok(())
 }
 
 fn extract_tink_binary(archive: &Path, into: &Path) -> Result<PathBuf, Error> {
-    let status = Command::new("tar")
-        .args(["-xzf"])
-        .arg(archive)
-        .arg("-C")
-        .arg(into)
-        .status()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                Error::msg("tar is required for tink update")
-            } else {
-                Error::msg(format!("tar: {e}"))
-            }
-        })?;
-    if !status.success() {
+    validate_archive_inventory(archive)?;
+    let output = run_bounded(
+        Command::new("tar")
+            .args(["-xzf"])
+            .arg(archive)
+            .arg("-C")
+            .arg(into),
+        TAR_TIMEOUT,
+        "tar archive extraction",
+    )?;
+    if !output.status.success() {
         return Err(Error::msg("failed to extract release archive"));
     }
     let candidate = into.join("tink");
-    if candidate.is_file() {
+    let metadata = fs::symlink_metadata(&candidate)
+        .map_err(|_| Error::msg("release archive did not contain a tink binary"))?;
+    if metadata.file_type().is_file() {
         return Ok(candidate);
-    }
-    // Tolerate a single nested directory containing tink.
-    let entries = fs::read_dir(into).map_err(|e| Error::msg(format!("extract dir: {e}")))?;
-    for entry in entries.flatten() {
-        let path = entry.path().join("tink");
-        if path.is_file() {
-            return Ok(path);
-        }
     }
     Err(Error::msg("release archive did not contain a tink binary"))
 }
 
-fn replace_binary(current: &Path, new_bin: &Path) -> Result<(), Error> {
+fn probe_candidate(candidate: &Path, expected_version: &str) -> Result<(), Error> {
+    let result = run_bounded(
+        Command::new(candidate).arg("--version"),
+        CANDIDATE_TIMEOUT,
+        "release candidate probe",
+    )?;
+    let expected = format!("tink {expected_version}\n");
+    if !result.status.success() || result.stdout != expected.as_bytes() {
+        return Err(Error::msg(format!(
+            "release candidate failed version probe for tink {expected_version}"
+        )));
+    }
+    Ok(())
+}
+
+fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Result<(), Error> {
     let parent = current.parent().ok_or_else(|| {
         Error::msg(format!(
             "cannot update {}: no parent directory",
             current.display()
         ))
     })?;
-    let staging = parent.join(format!(".tink-update-{}", std::process::id()));
-    fs::copy(new_bin, &staging).map_err(|e| {
+    let staging = Builder::new()
+        .prefix(".tink-update-")
+        .tempfile_in(parent)
+        .map_err(|error| {
+            Error::msg(format!(
+                "cannot stage update beside {} ({error})",
+                current.display()
+            ))
+        })?;
+    let backup = Builder::new()
+        .prefix(".tink-backup-")
+        .tempfile_in(parent)
+        .map_err(|error| {
+            Error::msg(format!(
+                "cannot preserve {} before update ({error})",
+                current.display()
+            ))
+        })?;
+    fs::copy(current, backup.path()).map_err(|error| {
+        Error::msg(format!(
+            "cannot preserve {} before update ({error})",
+            current.display()
+        ))
+    })?;
+    fs::copy(new_bin, staging.path()).map_err(|e| {
         Error::msg(format!(
             "cannot write {} ({}). Re-run install.sh or fix permissions.",
-            staging.display(),
+            staging.path().display(),
             e
         ))
     })?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        if let Err(e) = fs::set_permissions(&staging, fs::Permissions::from_mode(0o755)) {
-            let _ = fs::remove_file(&staging);
-            return Err(Error::msg(format!("chmod {}: {e}", staging.display())));
-        }
+        fs::set_permissions(staging.path(), fs::Permissions::from_mode(0o755))
+            .map_err(|e| Error::msg(format!("chmod {}: {e}", staging.path().display())))?;
     }
-    fs::rename(&staging, current).map_err(|e| {
-        let _ = fs::remove_file(&staging);
+    probe_candidate(staging.path(), expected_version)?;
+    let published = staging.persist(current).map_err(|error| {
         Error::msg(format!(
             "cannot replace {} ({}). Re-run install.sh or fix permissions.",
             current.display(),
-            e
+            error.error
         ))
     })?;
+    drop(published);
+    if let Err(probe_error) = probe_candidate(current, expected_version) {
+        return match backup.persist(current) {
+            Ok(restored) => {
+                drop(restored);
+                Err(Error::msg(format!(
+                    "published tink failed exact version verification and was rolled back: {probe_error}"
+                )))
+            }
+            Err(restore_error) => {
+                let cause = restore_error.error;
+                let recovery = restore_error.file.into_temp_path().keep().ok();
+                let recovery = recovery.as_deref().map_or_else(
+                    || "unavailable".to_string(),
+                    |path| path.display().to_string(),
+                );
+                Err(Error::msg(format!(
+                    "published tink failed exact version verification ({probe_error}); rollback failed ({cause}); recovery backup: {recovery}"
+                )))
+            }
+        };
+    }
     Ok(())
+}
+
+fn validate_current_binary_target(current: &Path) -> Result<(), Error> {
+    let metadata = fs::symlink_metadata(current).map_err(|error| {
+        Error::msg(format!(
+            "cannot inspect current binary {}: {error}",
+            current.display()
+        ))
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(Error::msg(format!(
+            "refusing to replace non-file current binary {}",
+            current.display()
+        )));
+    }
+    Ok(())
+}
+
+fn current_binary_path() -> Result<PathBuf, Error> {
+    let current = env::current_exe().map_err(|e| Error::msg(format!("current exe: {e}")))?;
+    // Resolve a launcher symlink once, then validate and atomically replace its
+    // regular-file target without following any later destination changes.
+    let current = fs::canonicalize(&current).unwrap_or(current);
+    validate_current_binary_target(&current)?;
+    Ok(current)
+}
+
+fn verify_and_replace(
+    current: &Path,
+    archive: &Path,
+    expected_digest: &[u8; 32],
+    expected_version: &str,
+    extract_dir: &Path,
+) -> Result<(), Error> {
+    verify_archive_digest(archive, expected_digest)?;
+    let extracted = extract_tink_binary(archive, extract_dir)?;
+    probe_candidate(&extracted, expected_version)?;
+    replace_binary(current, &extracted, expected_version)
 }
 
 /// Fetch the latest release and replace the running binary when newer.
@@ -235,29 +612,49 @@ pub fn update_binary() -> Result<UpdateReport, Error> {
     require_tool("curl")?;
     require_tool("tar")?;
 
-    let api = releases_api_url();
+    let (api, api_mode) = releases_api_url()?;
     let temp = TempDir::new().map_err(|e| Error::msg(format!("temp dir: {e}")))?;
     let meta_path = temp.path().join("release.json");
-    curl_to_file(CurlBudget::Metadata, &api, &meta_path)?;
+    curl_to_file(CurlBudget::Metadata, &api, &meta_path, "release metadata")?;
     let json =
         fs::read_to_string(&meta_path).map_err(|e| Error::msg(format!("read metadata: {e}")))?;
     let asset = select_release_asset(&json, target)?;
+    validate_asset_url(&asset.download_url, api_mode)?;
 
     let current_version = env!("CARGO_PKG_VERSION");
-    if asset.version == current_version {
-        return Ok(UpdateReport::AlreadyLatest {
-            version: asset.version,
-            path: env::current_exe().unwrap_or_else(|_| PathBuf::from("tink")),
-        });
+    match SemVersion::parse(&asset.version)?.cmp(&SemVersion::parse(current_version)?) {
+        Ordering::Equal => {
+            return Ok(UpdateReport::AlreadyLatest {
+                version: asset.version,
+                path: env::current_exe().unwrap_or_else(|_| PathBuf::from("tink")),
+            });
+        }
+        Ordering::Less => {
+            return Err(Error::msg(format!(
+                "refusing to downgrade tink from v{current_version} to v{}",
+                asset.version
+            )));
+        }
+        Ordering::Greater => {}
     }
 
     let archive = temp.path().join("tink.tgz");
-    curl_to_file(CurlBudget::Asset, &asset.download_url, &archive)?;
-    let extracted = extract_tink_binary(&archive, temp.path())?;
-    let current = env::current_exe().map_err(|e| Error::msg(format!("current exe: {e}")))?;
-    // Resolve symlinks so we replace the real binary (e.g. cargo install shim).
-    let current = fs::canonicalize(&current).unwrap_or(current);
-    replace_binary(&current, &extracted)?;
+    curl_to_file(
+        CurlBudget::Asset,
+        &asset.download_url,
+        &archive,
+        "release asset",
+    )?;
+    let current = current_binary_path()?;
+    let extract_dir = temp.path().join("extract");
+    fs::create_dir(&extract_dir).map_err(|e| Error::msg(format!("extract dir: {e}")))?;
+    verify_and_replace(
+        &current,
+        &archive,
+        &asset.sha256,
+        &asset.version,
+        &extract_dir,
+    )?;
 
     Ok(UpdateReport::Updated {
         from: current_version.to_string(),
@@ -279,30 +676,31 @@ pub enum UpdateReport {
     },
 }
 
-pub fn print_report(report: &UpdateReport) {
+pub fn print_report(report: &UpdateReport) -> Result<(), Error> {
     let style = CliStyle::auto_stdout();
     match report {
         UpdateReport::AlreadyLatest { version, path } => {
-            println!(
+            output::stdout_line(format_args!(
                 "{} {} ({})",
                 style.muted("Up to date"),
                 style.accent(format!("v{version}")),
                 style.muted(path.display())
-            );
+            ))?;
         }
         UpdateReport::Updated { from, to, path } => {
-            println!(
+            output::stdout_line(format_args!(
                 "{} {} → {}",
                 style.success("Updated"),
                 style.muted(format!("v{from}")),
                 style.accent(format!("v{to}"))
-            );
-            println!(
+            ))?;
+            output::stdout_line(format_args!(
                 "{}",
                 style.muted(format!("Installed to {}", path.display()))
-            );
+            ))?;
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -316,6 +714,10 @@ mod tests {
             curl_command_args(CurlBudget::Metadata, "https://example.test/meta", dest),
             [
                 "-fsSL",
+                "--proto",
+                "=https",
+                "--proto-redir",
+                "=https",
                 "--connect-timeout",
                 CURL_CONNECT_TIMEOUT_SECONDS,
                 "--max-time",
@@ -338,6 +740,84 @@ mod tests {
             .expect("--max-time present");
         assert_eq!(asset_args[max_time_idx + 1], CURL_ASSET_MAX_TIME_SECONDS);
         assert_ne!(CURL_METADATA_MAX_TIME_SECONDS, CURL_ASSET_MAX_TIME_SECONDS);
+        let file_args = curl_command_args(
+            CurlBudget::Asset,
+            "file:///tmp/tink.tgz",
+            Path::new("/tmp/download.tgz"),
+        );
+        assert!(
+            file_args
+                .windows(2)
+                .any(|args| args == ["--proto", "=file"])
+        );
+    }
+
+    #[test]
+    fn file_asset_requires_explicit_file_api_mode() {
+        assert!(validate_asset_url("file:///tmp/tink.tgz", ReleaseUrlMode::Https).is_err());
+        assert!(validate_asset_url("file:///tmp/tink.tgz", ReleaseUrlMode::File).is_ok());
+        assert!(validate_asset_url("https://example.test/tink.tgz", ReleaseUrlMode::Https).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_process_kills_and_reaps_timeout() {
+        let started = Instant::now();
+        let err = run_bounded(
+            Command::new("sh").args(["-c", "exec sleep 2"]),
+            Duration::from_millis(30),
+            "timeout fixture",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_process_times_out_when_descendant_holds_output_pipes() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("descendant-survived");
+        let started = Instant::now();
+        let err = run_bounded(
+            Command::new("sh")
+                .args(["-c", "(sleep 0.2; : > \"$TINK_TIMEOUT_MARKER\") & exit 0"])
+                .env("TINK_TIMEOUT_MARKER", &marker),
+            Duration::from_millis(30),
+            "descendant pipe fixture",
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        thread::sleep(Duration::from_millis(300));
+        assert!(!marker.exists(), "timed-out descendant was left running");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_process_cleans_descendants_after_direct_child_succeeds() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("descendant-survived");
+        let output = run_bounded(
+            Command::new("sh")
+                .args([
+                    "-c",
+                    "(sleep 0.2; : > \"$TINK_TIMEOUT_MARKER\") >/dev/null 2>&1 & printf done",
+                ])
+                .env("TINK_TIMEOUT_MARKER", &marker),
+            Duration::from_secs(1),
+            "successful descendant fixture",
+        )
+        .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"done");
+        thread::sleep(Duration::from_millis(300));
+        assert!(
+            !marker.exists(),
+            "successful child left a descendant running"
+        );
     }
 
     #[test]
@@ -346,6 +826,30 @@ mod tests {
             asset_name("0.2.0", "aarch64-apple-darwin"),
             "tink-0.2.0-aarch64-apple-darwin.tar.gz"
         );
+    }
+
+    #[test]
+    fn semantic_version_comparison_is_numeric_and_prerelease_aware() {
+        assert!(SemVersion::parse("0.3.10").unwrap() > SemVersion::parse("0.3.9").unwrap());
+        assert!(SemVersion::parse("1.0.0").unwrap() > SemVersion::parse("1.0.0-rc.1").unwrap());
+        assert!(
+            SemVersion::parse("1.0.0-rc.10").unwrap() > SemVersion::parse("1.0.0-rc.2").unwrap()
+        );
+        assert!(
+            SemVersion::parse("1.0.0-100000000000000000000").unwrap()
+                > SemVersion::parse("1.0.0-99999999999999999999").unwrap()
+        );
+        assert_eq!(
+            SemVersion::parse("1.0.0+build.2").unwrap(),
+            SemVersion::parse("1.0.0+build.1").unwrap()
+        );
+    }
+
+    #[test]
+    fn semantic_version_parser_rejects_ambiguous_versions() {
+        for version in ["1.2", "01.2.3", "1.2.3-01", "1.2.3+", "1.2.3/evil"] {
+            assert!(SemVersion::parse(version).is_err(), "accepted {version}");
+        }
     }
 
     #[test]
@@ -359,7 +863,8 @@ mod tests {
             },
             {
               "name": "tink-0.2.0-aarch64-apple-darwin.tar.gz",
-              "browser_download_url": "https://example.test/mac.tgz"
+              "browser_download_url": "https://example.test/mac.tgz",
+              "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             }
           ]
         }"#;
@@ -367,6 +872,154 @@ mod tests {
         assert_eq!(asset.version, "0.2.0");
         assert_eq!(asset.tag_name, "v0.2.0");
         assert_eq!(asset.download_url, "https://example.test/mac.tgz");
+        assert_eq!(
+            asset.sha256,
+            parse_sha256("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn select_release_asset_rejects_missing_digest() {
+        let json = r#"{
+          "tag_name": "v0.2.0",
+          "assets": [
+            {
+              "name": "tink-0.2.0-aarch64-apple-darwin.tar.gz",
+              "browser_download_url": "https://example.test/mac.tgz"
+            }
+          ]
+        }"#;
+        let err = select_release_asset(json, "aarch64-apple-darwin").unwrap_err();
+        assert!(err.to_string().contains("digest"));
+    }
+
+    #[test]
+    fn select_release_asset_rejects_malformed_sha256_digest() {
+        let json = r#"{
+          "tag_name": "v0.2.0",
+          "assets": [
+            {
+              "name": "tink-0.2.0-aarch64-apple-darwin.tar.gz",
+              "browser_download_url": "https://example.test/mac.tgz",
+              "digest": "sha256:not-a-digest"
+            }
+          ]
+        }"#;
+        let err = select_release_asset(json, "aarch64-apple-darwin").unwrap_err();
+        assert!(err.to_string().contains("SHA-256"));
+    }
+
+    #[test]
+    fn select_release_asset_rejects_duplicate_exact_names() {
+        let json = r#"{
+          "tag_name": "v0.2.0",
+          "assets": [
+            {
+              "name": "tink-0.2.0-aarch64-apple-darwin.tar.gz",
+              "browser_download_url": "https://example.test/first.tgz",
+              "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            },
+            {
+              "name": "tink-0.2.0-aarch64-apple-darwin.tar.gz",
+              "browser_download_url": "https://example.test/second.tgz",
+              "digest": "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+            }
+          ]
+        }"#;
+
+        let err = select_release_asset(json, "aarch64-apple-darwin").unwrap_err();
+
+        assert!(err.to_string().contains("exactly one"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replace_binary_rolls_back_when_published_probe_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("installed-tink");
+        let candidate = temp.path().join("candidate-tink");
+        let original = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+        fs::write(&current, original).unwrap();
+        fs::set_permissions(&current, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::write(
+            &candidate,
+            b"#!/bin/sh\ncase \"$0\" in\n  */installed-tink) exit 7 ;;\nesac\nprintf 'tink 99.0.0\\n'\n",
+        )
+        .unwrap();
+        fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = replace_binary(&current, &candidate, "99.0.0").unwrap_err();
+
+        assert!(err.to_string().contains("published"));
+        assert_eq!(fs::read(&current).unwrap(), original);
+        assert_eq!(
+            fs::metadata(&current).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+
+    #[test]
+    fn select_release_asset_rejects_urls_with_credentials_query_or_fragment() {
+        for url in [
+            "https://user@example.test/tink.tgz",
+            "https://example.test/tink.tgz?token=secret",
+            "https://example.test/tink.tgz#asset",
+        ] {
+            let json = format!(
+                r#"{{
+                  "tag_name": "v0.2.0",
+                  "assets": [{{
+                    "name": "tink-0.2.0-aarch64-apple-darwin.tar.gz",
+                    "browser_download_url": "{url}",
+                    "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                  }}]
+                }}"#
+            );
+            let err = select_release_asset(&json, "aarch64-apple-darwin").unwrap_err();
+            assert!(
+                err.to_string().contains("download URL"),
+                "accepted or leaked {url}: {err}"
+            );
+            assert!(!err.to_string().contains(url));
+        }
+    }
+
+    #[test]
+    fn verify_archive_digest_rejects_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("tink.tgz");
+        fs::write(&archive, b"downloaded archive bytes").unwrap();
+        let expected: [u8; 32] = Sha256::digest(b"different archive bytes").into();
+
+        let err = verify_archive_digest(&archive, &expected).unwrap_err();
+
+        assert!(err.to_string().contains("digest mismatch"));
+    }
+
+    #[test]
+    fn validate_archive_inventory_rejects_extra_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let stage = temp.path().join("stage");
+        fs::create_dir(&stage).unwrap();
+        fs::write(stage.join("tink"), b"candidate").unwrap();
+        fs::write(stage.join("extra"), b"unexpected").unwrap();
+        let archive = temp.path().join("tink.tgz");
+        let status = Command::new("tar")
+            .args(["-czf"])
+            .arg(&archive)
+            .arg("-C")
+            .arg(&stage)
+            .args(["tink", "extra"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let err = validate_archive_inventory(&archive).unwrap_err();
+
+        assert!(err.to_string().contains("exactly one"));
     }
 
     #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -4776,6 +4776,99 @@ fn u15_update_interrupt_kills_candidate_group_and_preserves_binary() {
 
 #[cfg(unix)]
 #[test]
+fn u16_update_output_escapes_terminal_controls_in_binary_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("escaped-update-output-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let version = package_version();
+    let bin = assert_cmd::cargo::cargo_bin!("tink");
+    let metadata = write_release_fixture(&fixture, &version, bin);
+    let install_dir = ws.root.join("install\u{1b}[31m\nrow");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    fs::copy(bin, &installed).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = StdCommand::new(&installed)
+        .arg("update")
+        .env("NO_COLOR", "1")
+        .env("TINK_HOME", &ws.inventory)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .output()
+        .expect("run updater from control-bearing path");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "update failed: {stdout:?}");
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "raw ESC in stdout: {stdout:?}"
+    );
+    assert_eq!(
+        output.stdout.iter().filter(|byte| **byte == b'\n').count(),
+        1
+    );
+    assert!(stdout.contains("install\\x1b[31m\\nrow"), "{stdout:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn u17_install_script_rejects_probe_output_over_capture_limit() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("overflowing-probe-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let candidate = fixture.join("overflowing-tink");
+    fs::write(
+        &candidate,
+        b"#!/bin/sh\nprintf started > \"$TINK_PROBE_STARTED\"\npython3 - <<'PY'\nimport sys\nsys.stdout.buffer.write(b'x' * (17 * 1024 * 1024))\nsys.stdout.flush()\nPY\nexec sleep 120\n",
+    )
+    .unwrap();
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &candidate);
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let candidate_started = ws.root.join("overflowing-candidate-started");
+
+    let mut command = StdCommand::new("sh");
+    command
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_PROBE_STARTED", &candidate_started)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command
+        .spawn()
+        .expect("spawn overflowing installer fixture");
+    wait_for_marker(&candidate_started, &mut child);
+    let output = wait_for_output_bounded(
+        child,
+        std::time::Duration::from_secs(4),
+        "installer probe output limit",
+    );
+
+    assert!(!output.status.success());
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[cfg(unix)]
+#[test]
 fn v6_install_script_keeps_verified_install_successful_when_stdout_is_closed() {
     use std::os::fd::OwnedFd;
     use std::os::unix::fs::PermissionsExt;

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -4719,6 +4719,72 @@ fn u14_install_interrupt_kills_candidate_group_without_traceback() {
 
 #[cfg(unix)]
 #[test]
+fn u18_install_handles_interrupt_raised_during_candidate_spawn() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let installer = include_str!("../install.sh");
+    let (run_bounded, probe_exact) = installer
+        .split_once("probe_exact()")
+        .expect("installer probe_exact function");
+    for (name, supervisor) in [("run_bounded", run_bounded), ("probe_exact", probe_exact)] {
+        let handler = supervisor
+            .find("signal.signal(watched, interrupt)")
+            .unwrap_or_else(|| panic!("{name} is missing interrupt handlers"));
+        let spawn = supervisor
+            .find("subprocess.Popen(")
+            .unwrap_or_else(|| panic!("{name} is missing supervised spawn"));
+        assert!(
+            handler < spawn,
+            "{name} must arm interrupt handlers before spawning its child"
+        );
+    }
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("install-spawn-cancel-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let candidate = fixture.join("spawn-cancel-tink");
+    let survived = ws.root.join("spawn-cancel-candidate-survived");
+    fs::write(
+        &candidate,
+        b"#!/bin/sh\nkill -TERM \"$PPID\"\nsleep 2\nprintf survived > \"$TINK_CANCEL_SURVIVED\"\nprintf 'tink 99.0.0\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &candidate);
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_CANCEL_SURVIVED", &survived)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .output()
+        .expect("run spawn-interrupted installer");
+
+    assert!(!output.status.success());
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("Traceback"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::thread::sleep(std::time::Duration::from_millis(2300));
+    assert!(
+        !survived.exists(),
+        "spawn-time interruption left candidate running"
+    );
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[cfg(unix)]
+#[test]
 fn u15_update_interrupt_kills_candidate_group_and_preserves_binary() {
     use std::os::unix::fs::PermissionsExt;
     use std::os::unix::process::CommandExt;

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -53,10 +53,31 @@ impl Workspace {
     }
 
     fn catalog_meta(&self, project_name: &str) -> PathBuf {
-        self.inventory
-            .join("catalog")
-            .join("by-project")
+        let project = self
+            .root
             .join(project_name)
+            .canonicalize()
+            .expect("canonical project");
+        let by_project = self.inventory.join("catalog").join("by-project");
+        if let Ok(entries) = fs::read_dir(&by_project) {
+            for entry in entries.flatten() {
+                let meta = entry.path().join("meta.json");
+                let Ok(raw) = fs::read_to_string(&meta) else {
+                    continue;
+                };
+                let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+                    continue;
+                };
+                let Some(root) = value.get("root").and_then(serde_json::Value::as_str) else {
+                    continue;
+                };
+                if Path::new(root).canonicalize().ok().as_deref() == Some(project.as_path()) {
+                    return meta;
+                }
+            }
+        }
+        by_project
+            .join(format!(".missing-{project_name}"))
             .join("meta.json")
     }
 
@@ -77,7 +98,8 @@ impl Workspace {
     }
 
     fn assert_cataloged(&self, project_name: &str, skill: &str) {
-        let raw = fs::read_to_string(self.catalog_meta(project_name))
+        let meta = self.catalog_meta(project_name);
+        let raw = fs::read_to_string(&meta)
             .unwrap_or_else(|_| panic!("missing catalog for {project_name}"));
         assert!(
             raw.contains(&format!("\"{skill}\"")),
@@ -88,11 +110,9 @@ impl Workspace {
             "expected library at skills/{skill}"
         );
         assert!(
-            !self
-                .inventory
-                .join("catalog")
-                .join("by-project")
-                .join(project_name)
+            !meta
+                .parent()
+                .expect("catalog project directory")
                 .join(skill)
                 .exists(),
             "must not copy skill trees into catalog/by-project"
@@ -629,6 +649,51 @@ fn a6_add_repairs_divergent_library_and_installs_project() {
     assert!(!archived.contains("from app"));
 }
 
+#[cfg(unix)]
+#[test]
+fn a6b_closed_warning_pipe_does_not_interrupt_completed_add() {
+    use std::os::fd::OwnedFd;
+    use std::os::unix::net::UnixStream;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let app = ws.project("app");
+    let other = ws.project("other");
+    for project in [&app, &other] {
+        ws.cmd(project)
+            .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+            .assert()
+            .success();
+    }
+    let first = ws.root.join("demo-a");
+    let second = ws.root.join("demo-b");
+    write_skill(&first, "demo-skill", "from app");
+    write_skill(&second, "demo-skill", "from other");
+    ws.cmd(&app)
+        .args(["skill", "add", first.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let (read_end, write_end) = UnixStream::pair().expect("stderr pipe");
+    drop(read_end);
+    let write_end: OwnedFd = write_end.into();
+    let status = StdCommand::new(assert_cmd::cargo::cargo_bin!("tink"))
+        .current_dir(&other)
+        .env("TINK_HOME", &ws.inventory)
+        .args(["skill", "add", second.to_str().unwrap()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(write_end))
+        .status()
+        .expect("add with closed warning pipe");
+
+    assert_eq!(status.code(), Some(0));
+    let project =
+        fs::read_to_string(Workspace::skill_path(&other, "demo-skill").join("SKILL.md")).unwrap();
+    let archived = fs::read_to_string(ws.library_skill("demo-skill").join("SKILL.md")).unwrap();
+    assert!(project.contains("from other"));
+    assert!(archived.contains("from other"));
+}
+
 #[test]
 fn a8_add_uses_library_when_remote_tip_matches() {
     let ws = Workspace::new();
@@ -893,6 +958,120 @@ fn a12_add_refuses_unrelated_existing_tink_home() {
     assert!(!project.join("skills").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn a14_add_preserves_executable_permissions_in_project_and_library() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    let source = ws.root.join("executable-skill");
+    write_skill(&source, "executable-skill", "mode fixture");
+    let script = source.join("run.sh");
+    fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    for copied in [
+        Workspace::skill_path(&project, "executable-skill").join("run.sh"),
+        ws.library_skill("executable-skill").join("run.sh"),
+    ] {
+        assert_eq!(
+            fs::metadata(copied).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn a15_add_preserves_distinct_non_utf8_unix_filenames() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    let source = ws.root.join("opaque-name-skill");
+    write_skill(&source, "opaque-name-skill", "raw filename fixture");
+    let names = [
+        OsString::from_vec(vec![0x80]),
+        OsString::from_vec(vec![0x81]),
+    ];
+    for (name, body) in names
+        .iter()
+        .zip([b"first".as_slice(), b"second".as_slice()])
+    {
+        if let Err(error) = fs::write(source.join(name), body) {
+            #[cfg(target_os = "macos")]
+            {
+                assert_eq!(error.raw_os_error(), Some(92), "unexpected fixture error");
+                assert!(!Workspace::skill_path(&project, "opaque-name-skill").exists());
+                return;
+            }
+            #[cfg(not(target_os = "macos"))]
+            panic!("filesystem rejected non-UTF-8 fixture: {error}");
+        }
+    }
+
+    ws.cmd(&project)
+        .args(["skill", "add", source.to_str().unwrap()])
+        .assert()
+        .success();
+
+    for root in [
+        Workspace::skill_path(&project, "opaque-name-skill"),
+        ws.library_skill("opaque-name-skill"),
+    ] {
+        assert_eq!(fs::read(root.join(&names[0])).unwrap(), b"first");
+        assert_eq!(fs::read(root.join(&names[1])).unwrap(), b"second");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn a16_standalone_add_refuses_receipt_owned_sources_before_any_mutation() {
+    for dangling_receipt in [false, true] {
+        let ws = Workspace::new();
+        let project = ws.project("app");
+        let source = ws.root.join("common-skillset");
+        write_skill(
+            &source,
+            "common-skillset",
+            "receipt ownership boundary fixture",
+        );
+        let receipt = source.join(".tink-skillset.json");
+        if dangling_receipt {
+            std::os::unix::fs::symlink(source.join("missing-receipt"), &receipt).unwrap();
+        } else {
+            fs::write(&receipt, "{}\n").unwrap();
+        }
+
+        ws.cmd(&project)
+            .args(["skill", "add", source.to_str().unwrap()])
+            .assert()
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(
+                "tink skillset add common-skillset",
+            ));
+
+        assert!(!project.join(".agents").exists());
+        assert!(!ws.inventory.exists());
+    }
+}
+
 // --- K*: skillsets ---
 
 #[test]
@@ -941,6 +1120,10 @@ fn k1_skillset_add_installs_explicit_members_and_checks_digest() {
     assert!(library.join("alpha/SKILL.md").is_file());
     assert!(library.join("beta/SKILL.md").is_file());
     assert!(library.join(".tink-skillset.json").is_file());
+    let receipt: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(installed.join(".tink-skillset.json")).unwrap())
+            .unwrap();
+    assert_eq!(receipt["digestVersion"], 2);
 
     ws.cmd(&project)
         .args(["skillset", "add", "common-skillset"])
@@ -1895,7 +2078,7 @@ fn m1_skill_verify_accepts_empty_manifest_for_empty_project() {
     .unwrap();
     fs::write(
         project.join(".tink").join("skills.lock"),
-        "version = 1\nskills = []\n",
+        "version = 2\nskills = []\n",
     )
     .unwrap();
     ws.cmd(&project)
@@ -2032,6 +2215,147 @@ fn m6_skill_verify_requires_manifest() {
         .stderr(predicate::str::contains("Missing project manifest"));
 }
 
+#[test]
+fn m7_skill_sync_rejects_late_bad_hash_before_any_publication() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    for name in ["alpha", "beta"] {
+        let source = project.join("sources").join(name);
+        write_skill(&source, name, "manifest preflight fixture");
+        ws.cmd(&project)
+            .args(["skill", "add", source.to_str().unwrap()])
+            .assert()
+            .success();
+    }
+    ws.cmd(&project)
+        .args([
+            "skill",
+            "lock",
+            "--source",
+            "alpha=sources/alpha",
+            "--source",
+            "beta=sources/beta",
+        ])
+        .assert()
+        .success();
+    for name in ["alpha", "beta"] {
+        ws.cmd(&project)
+            .args(["skill", "remove", name])
+            .assert()
+            .success();
+        fs::remove_dir_all(ws.library_skill(name)).unwrap();
+    }
+    let lock_path = project.join(".tink/skills.lock");
+    let mut lock = fs::read_to_string(&lock_path).unwrap();
+    let hash_start = lock.rfind("sha256 = \"").unwrap() + "sha256 = \"".len();
+    lock.replace_range(hash_start..hash_start + 64, &"0".repeat(64));
+    fs::write(&lock_path, lock).unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "sync"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Skill content hash mismatch: beta",
+        ));
+
+    assert!(!Workspace::skill_path(&project, "alpha").exists());
+    assert!(!ws.library_skill("alpha").exists());
+    assert!(!ws.catalog_meta("app").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn m8_skill_sync_preflights_late_library_refusal_before_publication() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    for name in ["alpha", "beta"] {
+        let source = project.join("sources").join(name);
+        write_skill(&source, name, "library preflight fixture");
+        ws.cmd(&project)
+            .args(["skill", "add", source.to_str().unwrap()])
+            .assert()
+            .success();
+    }
+    ws.cmd(&project)
+        .args([
+            "skill",
+            "lock",
+            "--source",
+            "alpha=sources/alpha",
+            "--source",
+            "beta=sources/beta",
+        ])
+        .assert()
+        .success();
+    for name in ["alpha", "beta"] {
+        ws.cmd(&project)
+            .args(["skill", "remove", name])
+            .assert()
+            .success();
+        fs::remove_dir_all(ws.library_skill(name)).unwrap();
+    }
+    let outside = ws.root.join("outside-library-target");
+    fs::create_dir_all(&outside).unwrap();
+    std::os::unix::fs::symlink(&outside, ws.library_skill("beta")).unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "sync"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("symlink"));
+
+    assert!(!Workspace::skill_path(&project, "alpha").exists());
+    assert!(!ws.library_skill("alpha").exists());
+    assert!(!ws.catalog_meta("app").exists());
+}
+
+#[test]
+fn m9_legacy_lock_requires_relock_and_migrates_to_v2() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+    fs::create_dir_all(project.join(".tink")).unwrap();
+    fs::write(
+        project.join(".tink/skills.toml"),
+        "version = 1\nskills = []\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join(".tink/skills.lock"),
+        "version = 1\nskills = []\n",
+    )
+    .unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("run `tink skill lock`"));
+    ws.cmd(&project).args(["skill", "lock"]).assert().success();
+
+    assert!(
+        fs::read_to_string(project.join(".tink/skills.lock"))
+            .unwrap()
+            .starts_with("version = 2\n")
+    );
+    ws.cmd(&project)
+        .args(["skill", "verify"])
+        .assert()
+        .success();
+}
+
 // --- L*: list ---
 
 #[test]
@@ -2081,6 +2405,75 @@ fn l3_skill_list_catalog_prints_tsv() {
                 .and(predicate::str::contains("demo-skill"))
                 .and(predicate::str::contains("manage-tink")),
         );
+}
+
+#[test]
+fn l11_hidden_project_remains_visible_in_catalog_listing() {
+    let ws = Workspace::new();
+    let project = ws.project(".app");
+    ws.cmd(&project).arg("init").assert().success();
+    let canonical = project.canonicalize().unwrap();
+
+    ws.cmd(&project)
+        .args(["skill", "list", "--catalog"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            ".app\t{}\tmanage-tink",
+            canonical.display()
+        )));
+}
+
+#[test]
+fn l12_catalog_listing_escapes_row_delimiters_without_changing_columns() {
+    let ws = Workspace::new();
+    let project = ws.project("project\trow\nnext\u{1b}[31m");
+    ws.cmd(&project).arg("init").assert().success();
+    let canonical = project.canonicalize().unwrap();
+    let escaped_root = canonical
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\r', "\\r")
+        .replace('\n', "\\n")
+        .replace('\u{1b}', "\\x1b");
+
+    let output = ws
+        .cmd(&project)
+        .args(["skill", "list", "--catalog"])
+        .output()
+        .expect("run skill list --catalog");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "catalog output must remain one row per skill"
+    );
+    assert_eq!(lines[0], "project\troot\tskill");
+    let fields: Vec<_> = lines[1].split('\t').collect();
+    assert_eq!(
+        fields,
+        [
+            "project\\trow\\nnext\\x1b[31m",
+            &escaped_root,
+            "manage-tink"
+        ]
+    );
+}
+
+#[test]
+fn l13_empty_catalog_listing_is_header_only_tsv() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.initialize_inventory();
+
+    ws.cmd(&project)
+        .args(["skill", "list", "--catalog"])
+        .assert()
+        .success()
+        .stdout("project\troot\tskill\n");
 }
 
 #[test]
@@ -2243,6 +2636,55 @@ fn l9_skill_list_refuses_symlinked_home_owner_directories() {
         assert!(owned.is_symlink());
         assert!(outside.is_dir());
     }
+}
+
+#[test]
+fn l10_catalog_distinguishes_projects_with_the_same_basename() {
+    let ws = Workspace::new();
+    let first = ws.root.join("first/app");
+    let second = ws.root.join("second/app");
+    fs::create_dir_all(&first).unwrap();
+    fs::create_dir_all(&second).unwrap();
+    for project in [&first, &second] {
+        ws.cmd(project)
+            .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+            .assert()
+            .success();
+    }
+    let alpha = ws.root.join("alpha");
+    let beta = ws.root.join("beta");
+    write_skill(&alpha, "alpha", "first project");
+    write_skill(&beta, "beta", "second project");
+    ws.cmd(&first)
+        .args(["skill", "add", alpha.to_str().unwrap()])
+        .assert()
+        .success();
+    ws.cmd(&second)
+        .args(["skill", "add", beta.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let output = ws
+        .cmd(&first)
+        .args(["skill", "list", "--catalog"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(&format!(
+        "app\t{}\talpha",
+        first.canonicalize().unwrap().display()
+    )));
+    assert!(stdout.contains(&format!(
+        "app\t{}\tbeta",
+        second.canonicalize().unwrap().display()
+    )));
+    assert_eq!(
+        fs::read_dir(ws.inventory.join("catalog/by-project"))
+            .unwrap()
+            .count(),
+        2
+    );
 }
 
 // --- H*: library ---
@@ -2556,6 +2998,45 @@ fn h8_skill_harvest_skips_tink_home_and_unsafe_trees() {
     assert!(home_body.contains("stash resident"));
 }
 
+#[cfg(unix)]
+#[test]
+fn h14_harvest_skips_receipt_owned_sources_without_library_publication() {
+    for dangling_receipt in [false, true] {
+        let ws = Workspace::new();
+        let home = ws.root.join("home");
+        let project = ws.project("app");
+        let source = home.join(".agents").join("skills").join("common-skillset");
+        write_skill(
+            &source,
+            "common-skillset",
+            "receipt ownership boundary fixture",
+        );
+        let receipt = source.join(".tink-skillset.json");
+        if dangling_receipt {
+            std::os::unix::fs::symlink(source.join("missing-receipt"), &receipt).unwrap();
+        } else {
+            fs::write(&receipt, "{}\n").unwrap();
+        }
+
+        ws.cmd(&project)
+            .env("HOME", &home)
+            .args(["skill", "harvest"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("0 harvested"))
+            .stderr(
+                predicate::str::contains("Skipped")
+                    .and(predicate::str::contains("common-skillset"))
+                    .and(predicate::str::contains(
+                        "tink skillset add common-skillset",
+                    )),
+            );
+
+        assert!(!ws.library_skill("common-skillset").exists());
+        assert!(!project.join(".agents").exists());
+    }
+}
+
 #[test]
 fn h9_completion_offers_current_library_matches_without_creating_home() {
     let ws = Workspace::new();
@@ -2729,7 +3210,11 @@ fn h13_exact_cache_match_does_not_publish_skillset_as_standalone() {
         .args(["skill", "add", source.to_str().unwrap()])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Library entry is a skillset"));
+        .stderr(
+            predicate::str::contains("Source is owned by a skillset").and(
+                predicate::str::contains("tink skillset add bundle-skillset"),
+            ),
+        );
 
     assert_eq!(
         fs::read(library_root.join("SKILL.md")).unwrap(),
@@ -3169,7 +3654,7 @@ fn p8_refresh_all_preflights_before_updating_any_skill() {
 // --- D*: destroy ---
 
 #[test]
-fn d1_destroy_yes_removes_agents_zen_agents_md() {
+fn d1_destroy_yes_removes_agents_and_preserves_guidance() {
     let ws = Workspace::new();
     let project = ws.project("app");
     ws.cmd(&project)
@@ -3185,6 +3670,8 @@ fn d1_destroy_yes_removes_agents_zen_agents_md() {
     assert!(project.join(".agents").is_dir());
     assert!(project.join("ZEN.md").is_file());
     assert!(project.join("AGENTS.md").is_file());
+    let zen_before = fs::read(project.join("ZEN.md")).unwrap();
+    let agents_before = fs::read(project.join("AGENTS.md")).unwrap();
     assert!(ws.inventory.join("layout.json").is_file());
     ws.assert_cataloged("app", "manage-tink");
     ws.assert_cataloged("app", "extra-skill");
@@ -3195,8 +3682,8 @@ fn d1_destroy_yes_removes_agents_zen_agents_md() {
         .success();
 
     assert!(!project.join(".agents").exists());
-    assert!(!project.join("ZEN.md").exists());
-    assert!(!project.join("AGENTS.md").exists());
+    assert_eq!(fs::read(project.join("ZEN.md")).unwrap(), zen_before);
+    assert_eq!(fs::read(project.join("AGENTS.md")).unwrap(), agents_before);
     assert!(ws.inventory.join("layout.json").is_file());
     assert!(
         ws.library_skill("manage-tink").join("SKILL.md").is_file(),
@@ -3251,10 +3738,12 @@ fn d4_destroy_refuses_symlinked_catalog_without_external_or_project_writes() {
     let project = ws.project("app");
     ws.cmd(&project).arg("init").assert().success();
     let catalog = ws.inventory.join("catalog");
+    let catalog_meta = ws.catalog_meta("app");
+    let catalog_meta_relative = catalog_meta.strip_prefix(&catalog).unwrap().to_path_buf();
     let external = ws.root.join("external-catalog-destroy");
     fs::rename(&catalog, &external).unwrap();
     std::os::unix::fs::symlink(&external, &catalog).unwrap();
-    let external_meta = external.join("by-project").join("app").join("meta.json");
+    let external_meta = external.join(catalog_meta_relative);
     let catalog_before = fs::read(&external_meta).unwrap();
     let project_before =
         fs::read(Workspace::skill_path(&project, "manage-tink").join("SKILL.md")).unwrap();
@@ -3272,6 +3761,28 @@ fn d4_destroy_refuses_symlinked_catalog_without_external_or_project_writes() {
         project_before
     );
     assert!(project.join(".agents").is_dir());
+}
+
+#[test]
+fn d5_destroy_preserves_unrelated_agents_siblings() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills"])
+        .assert()
+        .success();
+    let foreign = project.join(".agents/foreign-config.json");
+    fs::write(&foreign, b"keep\n").unwrap();
+
+    ws.cmd(&project)
+        .args(["destroy", "--yes"])
+        .assert()
+        .success();
+
+    assert!(!project.join(".agents/skills").exists());
+    assert_eq!(fs::read(&foreign).unwrap(), b"keep\n");
+    assert!(project.join(".agents").is_dir());
+    assert!(!ws.catalog_meta("app").exists());
 }
 
 // --- X*: skill remove ---
@@ -3524,10 +4035,12 @@ fn x7_remove_refuses_symlinked_catalog_without_external_or_project_writes() {
         .success();
 
     let catalog = ws.inventory.join("catalog");
+    let catalog_meta = ws.catalog_meta("app");
+    let catalog_meta_relative = catalog_meta.strip_prefix(&catalog).unwrap().to_path_buf();
     let external = ws.root.join("external-catalog-remove");
     fs::rename(&catalog, &external).unwrap();
     std::os::unix::fs::symlink(&external, &catalog).unwrap();
-    let external_meta = external.join("by-project").join("app").join("meta.json");
+    let external_meta = external.join(catalog_meta_relative);
     let catalog_before = fs::read(&external_meta).unwrap();
     let project_skill = Workspace::skill_path(&project, "demo-skill");
     let project_before = fs::read(project_skill.join("SKILL.md")).unwrap();
@@ -3632,6 +4145,15 @@ fn package_version() -> String {
 }
 
 fn write_release_fixture(dir: &Path, version: &str, binary_src: &Path) -> PathBuf {
+    write_release_fixture_with_mode(dir, version, binary_src, 0o755)
+}
+
+fn write_release_fixture_with_mode(
+    dir: &Path,
+    version: &str,
+    binary_src: &Path,
+    unix_mode: u32,
+) -> PathBuf {
     let target = host_release_target();
     assert_ne!(
         target, "unsupported",
@@ -3645,7 +4167,7 @@ fn write_release_fixture(dir: &Path, version: &str, binary_src: &Path) -> PathBu
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&staged_bin, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(&staged_bin, fs::Permissions::from_mode(unix_mode)).unwrap();
     }
     let archive = dir.join(&asset);
     let status = StdCommand::new("tar")
@@ -3657,6 +4179,11 @@ fn write_release_fixture(dir: &Path, version: &str, binary_src: &Path) -> PathBu
         .status()
         .expect("tar");
     assert!(status.success());
+    let archive_digest = {
+        use sha2::{Digest, Sha256};
+        let bytes = fs::read(&archive).unwrap();
+        format!("{:x}", Sha256::digest(bytes))
+    };
 
     let archive_url = format!("file://{}", archive.display());
     let meta = dir.join("release.json");
@@ -3666,13 +4193,633 @@ fn write_release_fixture(dir: &Path, version: &str, binary_src: &Path) -> PathBu
   "assets": [
     {{
       "name": "{asset}",
-      "browser_download_url": "{archive_url}"
+      "browser_download_url": "{archive_url}",
+      "digest": "sha256:{archive_digest}"
     }}
   ]
 }}"#
     );
     fs::write(&meta, body).unwrap();
     meta
+}
+
+#[cfg(unix)]
+fn wait_for_marker(path: &Path, child: &mut std::process::Child) {
+    let started = std::time::Instant::now();
+    while !path.exists() {
+        if let Some(status) = child.try_wait().expect("poll fixture process") {
+            panic!(
+                "fixture process exited with {status} before marker: {}",
+                path.display()
+            );
+        }
+        if started.elapsed() >= std::time::Duration::from_secs(60) {
+            interrupt_process_group(child.id());
+            let _ = child.wait();
+            panic!("timed out waiting for fixture marker: {}", path.display());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
+#[cfg(unix)]
+fn interrupt_process_group(process_group: u32) {
+    let status = StdCommand::new("python3")
+        .args([
+            "-c",
+            "import os, signal, sys; os.killpg(int(sys.argv[1]), signal.SIGINT)",
+            &process_group.to_string(),
+        ])
+        .status()
+        .expect("signal process group");
+    assert!(
+        status.success(),
+        "could not interrupt fixture process group"
+    );
+}
+
+#[cfg(unix)]
+fn terminate_process(process: u32) {
+    let status = StdCommand::new("python3")
+        .args([
+            "-c",
+            "import os, signal, sys; os.kill(int(sys.argv[1]), signal.SIGTERM)",
+            &process.to_string(),
+        ])
+        .status()
+        .expect("signal fixture process");
+    assert!(status.success(), "could not terminate fixture process");
+}
+
+#[cfg(unix)]
+fn wait_for_output_bounded(
+    mut child: std::process::Child,
+    timeout: std::time::Duration,
+    context: &str,
+) -> std::process::Output {
+    let process_group = child.id();
+    let started = std::time::Instant::now();
+    loop {
+        if child.try_wait().expect("poll bounded fixture").is_some() {
+            return child.wait_with_output().expect("collect bounded fixture");
+        }
+        if started.elapsed() >= timeout {
+            interrupt_process_group(process_group);
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("{context} exceeded {timeout:?} after candidate start");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn v4_closed_stdout_does_not_panic_or_exit_101() {
+    use std::os::fd::OwnedFd;
+    use std::os::unix::net::UnixStream;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let (read_end, write_end) = UnixStream::pair().expect("stdout pipe");
+    drop(read_end);
+    let write_end: OwnedFd = write_end.into();
+    let output = StdCommand::new(assert_cmd::cargo::cargo_bin!("tink"))
+        .current_dir(&project)
+        .env("TINK_HOME", &ws.inventory)
+        .args(["skill", "list"])
+        .stdout(Stdio::from(write_end))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn tink with closed stdout")
+        .wait_with_output()
+        .expect("wait for tink");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "closed stdout must exit cleanly: stderr={stderr:?}"
+    );
+    assert!(!stderr.contains("panicked at"));
+}
+
+#[cfg(unix)]
+#[test]
+fn v5_closed_stderr_does_not_hide_command_failure() {
+    use std::os::fd::OwnedFd;
+    use std::os::unix::net::UnixStream;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let missing = project.join("missing-skill");
+    let (read_end, write_end) = UnixStream::pair().expect("stderr pipe");
+    drop(read_end);
+    let write_end: OwnedFd = write_end.into();
+
+    let status = StdCommand::new(assert_cmd::cargo::cargo_bin!("tink"))
+        .current_dir(&project)
+        .env("TINK_HOME", &ws.inventory)
+        .args(["skill", "add"])
+        .arg(&missing)
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(write_end))
+        .status()
+        .expect("run tink with closed stderr");
+
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "closed stderr must not turn an underlying command failure into success"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn u6_install_script_rejects_invalid_payload_and_preserves_existing_binary() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("install-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let invalid_payload = fixture.join("invalid-tink");
+    fs::write(&invalid_payload, b"this is not a tink executable\n").unwrap();
+    fs::set_permissions(&invalid_payload, fs::Permissions::from_mode(0o644)).unwrap();
+    let meta = write_release_fixture_with_mode(&fixture, "99.0.0", &invalid_payload, 0o644);
+
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_RELEASES_API", format!("file://{}", meta.display()))
+        .output()
+        .expect("run install.sh");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let installed_after = fs::read(&installed).unwrap();
+
+    assert!(
+        !output.status.success()
+            && !stdout.contains("Installed tink")
+            && installed_after == known_good,
+        "invalid installer payload must fail without success output or clobbering: status={:?}, stdout={stdout:?}, stderr={stderr:?}, preserved={}",
+        output.status.code(),
+        installed_after == known_good
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn u7_install_script_publishes_verified_payload_after_successful_probe() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("valid-install-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let replacement = fixture.join("replacement-tink");
+    fs::write(&replacement, b"#!/bin/sh\nprintf 'tink 99.0.0\\n'\n").unwrap();
+    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o755)).unwrap();
+    let meta = write_release_fixture(&fixture, "99.0.0", &replacement);
+
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    fs::write(&installed, b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n").unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_RELEASES_API", format!("file://{}", meta.display()))
+        .output()
+        .expect("run install.sh");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "install failed: {stdout}");
+    assert!(stdout.contains("Installed tink v99.0.0"));
+    assert!(stdout.contains("tink 99.0.0"));
+
+    assert_eq!(
+        fs::read(&installed).unwrap(),
+        fs::read(&replacement).unwrap()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn u8_install_script_rejects_non_semver_metadata_cleanly() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("invalid-semver-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let metadata = fixture.join("release.json");
+    fs::write(&metadata, r#"{"tag_name":"v01.2.3","assets":[]}"#).unwrap();
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .output()
+        .expect("run install.sh");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("invalid semantic version"), "{stderr}");
+    assert!(!stderr.contains("Traceback"), "{stderr}");
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[test]
+fn u9_install_script_rejects_and_redacts_unsafe_api_url() {
+    let ws = Workspace::new();
+    let install_dir = ws.root.join("install");
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env(
+            "TINK_RELEASES_API",
+            "https://user:supersecret@example.test/releases?token=private",
+        )
+        .output()
+        .expect("run install.sh");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("not an allowed release URL"), "{stderr}");
+    assert!(!stderr.contains("supersecret"), "{stderr}");
+    assert!(!stderr.contains("private"), "{stderr}");
+    assert!(!install_dir.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn u10_install_script_bounds_candidate_probe_and_preserves_existing_binary() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("hanging-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let hanging = fixture.join("hanging-tink");
+    fs::write(
+        &hanging,
+        b"#!/bin/sh\nprintf started > \"$TINK_PROBE_STARTED\"\nexec sleep 120\n",
+    )
+    .unwrap();
+    fs::set_permissions(&hanging, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &hanging);
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let candidate_started = ws.root.join("hanging-candidate-started");
+
+    let mut command = StdCommand::new("sh");
+    command
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_PROBE_STARTED", &candidate_started)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command.spawn().expect("spawn bounded installer fixture");
+    wait_for_marker(&candidate_started, &mut child);
+    let output = wait_for_output_bounded(
+        child,
+        std::time::Duration::from_secs(25),
+        "bounded installer probe",
+    );
+
+    assert!(!output.status.success());
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[cfg(unix)]
+#[test]
+fn u11_install_script_rejects_non_ascii_semver_digits_and_preserves_existing_binary() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("non-ascii-semver-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let metadata = fixture.join("release.json");
+    fs::write(&metadata, r#"{"tag_name":"v١.2.3","assets":[]}"#).unwrap();
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .output()
+        .expect("run install.sh");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("invalid semantic version"), "{stderr}");
+    assert!(!stderr.contains("Traceback"), "{stderr}");
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[cfg(unix)]
+#[test]
+fn u12_install_script_kills_timed_out_candidate_descendants() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("descendant-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let candidate = fixture.join("descendant-tink");
+    fs::write(
+        &candidate,
+        b"#!/bin/sh\nprintf started > \"$TINK_PROBE_STARTED\"\n(sleep 6; printf survived > \"$TINK_DESCENDANT_MARKER\") &\nexit 0\n",
+    )
+    .unwrap();
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &candidate);
+    let marker = ws.root.join("descendant-survived");
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let candidate_started = ws.root.join("descendant-candidate-started");
+
+    let mut command = StdCommand::new("sh");
+    command
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_PROBE_STARTED", &candidate_started)
+        .env("TINK_DESCENDANT_MARKER", &marker)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command
+        .spawn()
+        .expect("spawn descendant-cleanup installer fixture");
+    wait_for_marker(&candidate_started, &mut child);
+    let output = wait_for_output_bounded(
+        child,
+        std::time::Duration::from_secs(25),
+        "bounded installer descendant cleanup",
+    );
+
+    assert!(!output.status.success());
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    assert!(!marker.exists(), "timed-out candidate descendant survived");
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[cfg(unix)]
+#[test]
+fn u13_install_script_rolls_back_when_published_probe_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("published-probe-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let candidate = fixture.join("path-sensitive-tink");
+    fs::write(
+        &candidate,
+        b"#!/bin/sh\ncase \"$0\" in */install/tink) exit 7 ;; esac\nprintf 'tink 99.0.0\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &candidate);
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .output()
+        .expect("run install.sh");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(!stdout.contains("Installed"), "{stdout}");
+    assert!(stderr.contains("published tink failed"), "{stderr}");
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+    assert_eq!(
+        fs::metadata(&installed).unwrap().permissions().mode() & 0o777,
+        0o755
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn u14_install_interrupt_kills_candidate_group_without_traceback() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("install-cancel-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let candidate = fixture.join("cancel-tink");
+    fs::write(
+        &candidate,
+        b"#!/bin/sh\nprintf started > \"$TINK_CANCEL_STARTED\"\nsleep 3\nprintf survived > \"$TINK_CANCEL_SURVIVED\"\nprintf 'tink 99.0.0\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &candidate);
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    let known_good = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+    fs::write(&installed, known_good).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let started = ws.root.join("install-candidate-started");
+    let survived = ws.root.join("install-candidate-survived");
+
+    let mut command = StdCommand::new("sh");
+    command
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_CANCEL_STARTED", &started)
+        .env("TINK_CANCEL_SURVIVED", &survived)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command.spawn().expect("spawn install cancellation fixture");
+    let process_group = child.id();
+    wait_for_marker(&started, &mut child);
+    interrupt_process_group(process_group);
+    let output = child
+        .wait_with_output()
+        .expect("wait for interrupted installer");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(!stderr.contains("Traceback"), "{stderr}");
+    std::thread::sleep(std::time::Duration::from_millis(3300));
+    assert!(
+        !survived.exists(),
+        "interrupted installer left candidate running"
+    );
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[cfg(unix)]
+#[test]
+fn u15_update_interrupt_kills_candidate_group_and_preserves_binary() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("update-cancel-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let candidate = fixture.join("cancel-tink");
+    fs::write(
+        &candidate,
+        b"#!/bin/sh\nprintf started > \"$TINK_CANCEL_STARTED\"\nsleep 3\nprintf survived > \"$TINK_CANCEL_SURVIVED\"\nprintf 'tink 99.0.0\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &candidate);
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    fs::copy(assert_cmd::cargo::cargo_bin!("tink"), &installed).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let known_good = fs::read(&installed).unwrap();
+    let started = ws.root.join("update-candidate-started");
+    let survived = ws.root.join("update-candidate-survived");
+
+    let mut command = StdCommand::new(&installed);
+    command
+        .arg("update")
+        .env("TINK_HOME", &ws.inventory)
+        .env("TINK_CANCEL_STARTED", &started)
+        .env("TINK_CANCEL_SURVIVED", &survived)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0);
+    let mut child = command.spawn().expect("spawn update cancellation fixture");
+    let process_group = child.id();
+    wait_for_marker(&started, &mut child);
+    interrupt_process_group(process_group);
+    let output = child
+        .wait_with_output()
+        .expect("wait for interrupted updater");
+
+    assert!(!output.status.success());
+    std::thread::sleep(std::time::Duration::from_millis(3300));
+    assert!(
+        !survived.exists(),
+        "interrupted update left candidate running"
+    );
+    assert_eq!(fs::read(&installed).unwrap(), known_good);
+}
+
+#[cfg(unix)]
+#[test]
+fn v6_install_script_keeps_verified_install_successful_when_stdout_is_closed() {
+    use std::os::fd::OwnedFd;
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::UnixStream;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("closed-stdout-install-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let replacement = fixture.join("replacement-tink");
+    let replacement_bytes = b"#!/bin/sh\nprintf 'tink 99.0.0\\n'\n";
+    fs::write(&replacement, replacement_bytes).unwrap();
+    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &replacement);
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    fs::write(&installed, b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n").unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let (read_end, write_end) = UnixStream::pair().expect("stdout pipe");
+    drop(read_end);
+    let write_end: OwnedFd = write_end.into();
+
+    let output = StdCommand::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env(
+            "TINK_RELEASES_API",
+            format!("file://{}", metadata.display()),
+        )
+        .stdout(Stdio::from(write_end))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn install.sh with closed stdout")
+        .wait_with_output()
+        .expect("wait for install.sh");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "verified install must survive closed advisory stdout: {stderr:?}"
+    );
+    assert_eq!(fs::read(&installed).unwrap(), replacement_bytes);
 }
 
 #[test]
@@ -3687,7 +4834,7 @@ fn u1_update_fails_closed_on_bad_releases_api() {
         )
         .assert()
         .failure()
-        .stderr(predicate::str::contains("could not download"));
+        .stderr(predicate::str::contains("not an allowed release URL"));
 }
 
 #[test]
@@ -3697,13 +4844,13 @@ fn u2_update_reports_up_to_date_for_current_version() {
     fs::create_dir_all(&fixture).unwrap();
     let version = package_version();
     let bin = assert_cmd::cargo::cargo_bin!("tink");
-    let meta = write_release_fixture(&fixture, &version, &bin);
+    let meta = write_release_fixture(&fixture, &version, bin);
     let api = format!("file://{}", meta.display());
 
     let install_dir = ws.root.join("install");
     fs::create_dir_all(&install_dir).unwrap();
     let installed = install_dir.join("tink");
-    fs::copy(&bin, &installed).unwrap();
+    fs::copy(bin, &installed).unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -3728,13 +4875,20 @@ fn u3_update_replaces_binary_when_newer_release_exists() {
     let fixture = ws.root.join("release-fixture");
     fs::create_dir_all(&fixture).unwrap();
     let bin = assert_cmd::cargo::cargo_bin!("tink");
-    let meta = write_release_fixture(&fixture, "99.0.0", &bin);
+    let replacement = fixture.join("replacement-tink");
+    fs::write(&replacement, b"#!/bin/sh\nprintf 'tink 99.0.0\\n'\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let meta = write_release_fixture(&fixture, "99.0.0", &replacement);
     let api = format!("file://{}", meta.display());
 
     let install_dir = ws.root.join("install");
     fs::create_dir_all(&install_dir).unwrap();
     let installed = install_dir.join("tink");
-    fs::copy(&bin, &installed).unwrap();
+    fs::copy(bin, &installed).unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -3754,8 +4908,82 @@ fn u3_update_replaces_binary_when_newer_release_exists() {
         .stdout(predicate::str::contains("Updated").and(predicate::str::contains("v99.0.0")));
 
     assert!(installed.is_file());
+    assert_eq!(
+        fs::read(&installed).unwrap(),
+        fs::read(&replacement).unwrap()
+    );
     let after = fs::metadata(&installed).unwrap().modified().unwrap();
     assert!(after >= before);
+}
+
+#[cfg(unix)]
+#[test]
+fn u4_update_rejects_invalid_payload_and_preserves_running_binary() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("invalid-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let invalid_payload = fixture.join("invalid-tink");
+    fs::write(&invalid_payload, b"this is not a tink executable\n").unwrap();
+    fs::set_permissions(&invalid_payload, fs::Permissions::from_mode(0o644)).unwrap();
+    let meta = write_release_fixture_with_mode(&fixture, "99.0.0", &invalid_payload, 0o644);
+    let api = format!("file://{}", meta.display());
+
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    fs::copy(assert_cmd::cargo::cargo_bin!("tink"), &installed).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let before = fs::read(&installed).unwrap();
+
+    let output = StdCommand::new(&installed)
+        .arg("update")
+        .env("TINK_RELEASES_API", &api)
+        .env("TINK_HOME", &ws.inventory)
+        .output()
+        .expect("run tink update");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let after = fs::read(&installed).unwrap();
+
+    assert!(
+        !output.status.success() && !stdout.contains("Updated") && after == before,
+        "invalid update payload must fail without success output or replacing the running binary: status={:?}, stdout={stdout:?}, stderr={stderr:?}, preserved={}",
+        output.status.code(),
+        after == before
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn u5_update_refuses_downgrade_and_preserves_running_binary() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("older-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let payload = fixture.join("older-tink");
+    fs::write(&payload, b"#!/bin/sh\nprintf 'tink 0.0.1\\n'\n").unwrap();
+    fs::set_permissions(&payload, fs::Permissions::from_mode(0o755)).unwrap();
+    let meta = write_release_fixture(&fixture, "0.0.1", &payload);
+
+    let install_dir = ws.root.join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    fs::copy(assert_cmd::cargo::cargo_bin!("tink"), &installed).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let before = fs::read(&installed).unwrap();
+
+    Command::new(&installed)
+        .arg("update")
+        .env("TINK_RELEASES_API", format!("file://{}", meta.display()))
+        .env("TINK_HOME", &ws.inventory)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("refusing to downgrade"));
+
+    assert_eq!(fs::read(&installed).unwrap(), before);
 }
 
 // --- G*: GitHub source inspection ---
@@ -4131,4 +5359,83 @@ fn g8_inspect_preserves_project_and_home_bytes() {
     );
     assert_eq!(fs::read(ws.inventory.join("marker")).unwrap(), home_before);
     assert!(!project.join(".agents").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn g9_inspect_termination_reaps_git_process_group() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Stdio;
+
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let fake_bin = ws.root.join("fake-git-bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let fake_git = fake_bin.join("git");
+    fs::write(
+        &fake_git,
+        b"#!/bin/sh\nprintf started > \"$TINK_GIT_STARTED\"\nsleep 3\nprintf survived > \"$TINK_GIT_SURVIVED\"\nexit 1\n",
+    )
+    .unwrap();
+    fs::set_permissions(&fake_git, fs::Permissions::from_mode(0o755)).unwrap();
+    let started = ws.root.join("git-started");
+    let survived = ws.root.join("git-survived");
+    let path = std::env::join_paths(std::iter::once(fake_bin.clone()).chain(
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()),
+    ))
+    .unwrap();
+
+    let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin!("tink"));
+    command
+        .current_dir(&project)
+        .args(["inspect", "https://github.com/example/repository"])
+        .env("TINK_HOME", &ws.inventory)
+        .env("PATH", path)
+        .env("TINK_GIT_STARTED", &started)
+        .env("TINK_GIT_SURVIVED", &survived)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().expect("spawn Git cancellation fixture");
+    wait_for_marker(&started, &mut child);
+    terminate_process(child.id());
+    let output = wait_for_output_bounded(
+        child,
+        std::time::Duration::from_secs(10),
+        "Git cancellation fixture",
+    );
+
+    assert!(!output.status.success());
+    std::thread::sleep(std::time::Duration::from_millis(3300));
+    assert!(!survived.exists(), "terminated Tink left Git running");
+}
+
+#[cfg(unix)]
+#[test]
+fn g10_inspect_escapes_terminal_controls_in_remote_paths() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let repo = ws.root.join("control-path-repo");
+    init_repo(&repo);
+    let unsafe_name = "evil\u{1b}[31m\nrow\tpart";
+    write_skill(&repo.join(unsafe_name), "safe-skill", "control fixture");
+    commit_all(&repo, "control path");
+    let public = "https://github.com/example/control-path.git";
+    let redirect = github_redirect(&repo, public);
+    let mut command = ws.cmd(&project);
+    command.args(["inspect", "https://github.com/example/control-path"]);
+    for (key, value) in &redirect {
+        command.env(key, value);
+    }
+    let output = command.output().expect("inspect control path fixture");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(
+        !stdout.contains('\u{1b}'),
+        "raw escape reached stdout: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("evil\\x1b[31m\\nrow\\tpart"),
+        "escaped path missing from stdout: {stdout:?}"
+    );
 }

--- a/tests/acceptance_traceability.rs
+++ b/tests/acceptance_traceability.rs
@@ -20,7 +20,7 @@ fn contract_id(value: &str) -> Option<String> {
 fn sensor_override(expectation: &str) -> Option<Option<String>> {
     let (_, suffix) = expectation.split_once("Sensor: ")?;
     let value = suffix
-        .split(|ch: char| ch == '.' || ch == ' ' || ch == ')')
+        .split(['.', ' ', ')'])
         .next()
         .expect("sensor marker has a value");
     if value.eq_ignore_ascii_case("manual") {

--- a/tests/workflow_contract.rs
+++ b/tests/workflow_contract.rs
@@ -1,0 +1,98 @@
+//! Static delivery-workflow invariants. GitHub's native runs remain the
+//! authoritative evidence that the platform matrix executes successfully.
+
+const CI: &str = include_str!("../.github/workflows/ci.yml");
+const BUMP: &str = include_str!("../.github/workflows/bump-release.yml");
+const RELEASE: &str = include_str!("../.github/workflows/release.yml");
+
+fn position(haystack: &str, needle: &str) -> usize {
+    haystack
+        .find(needle)
+        .unwrap_or_else(|| panic!("workflow is missing {needle:?}"))
+}
+
+fn between<'a>(text: &'a str, start: &str, end: &str) -> &'a str {
+    let start_at = position(text, start);
+    let tail = &text[start_at..];
+    let after_header = &tail[start.len()..];
+    let end = after_header
+        .find(end)
+        .map(|offset| start.len() + offset)
+        .unwrap_or_else(|| panic!("workflow section is missing {end:?}"));
+    &tail[..end]
+}
+
+#[test]
+fn bump_gates_the_tag_on_every_platform_and_publishes_refs_atomically() {
+    for pair in [
+        "target: aarch64-apple-darwin\n            os: macos-15",
+        "target: x86_64-apple-darwin\n            os: macos-15-intel",
+        "target: x86_64-unknown-linux-gnu\n            os: ubuntu-22.04",
+        "target: aarch64-unknown-linux-gnu\n            os: ubuntu-22.04-arm",
+    ] {
+        assert!(BUMP.contains(pair), "missing native release gate {pair:?}");
+    }
+    assert!(BUMP.contains("needs: [verify, audit, platform]"));
+    assert!(BUMP.contains("git push --atomic origin HEAD:main"));
+    assert!(!BUMP.contains("git push origin HEAD:main\n"));
+    assert!(!BUMP.contains("git push origin \"${tag}\""));
+
+    let current_tag = position(BUMP, "current_tag=\"v${current}\"");
+    let current_release = position(BUMP, "gh release view \"${current_tag}\" --json isDraft");
+    let reconcile = position(BUMP, "gh workflow run release.yml --ref \"${current_tag}\"");
+    let next_version = position(BUMP, "new=\"${major}.${minor}.$((patch + 1))\"");
+    assert!(current_tag < current_release && current_release < reconcile);
+    assert!(
+        reconcile < next_version,
+        "release gaps must stop the next bump"
+    );
+
+    let existing_tag = position(
+        BUMP,
+        "if git rev-parse --verify --quiet \"refs/tags/${tag}\"",
+    );
+    let release_check = position(BUMP, "gh release view \"${tag}\" --json isDraft");
+    let dispatch = position(BUMP, "gh workflow run release.yml --ref \"${tag}\"");
+    assert!(existing_tag < release_check && release_check < dispatch);
+}
+
+#[test]
+fn release_uploads_an_exact_asset_set_to_a_draft_before_publication() {
+    let create = position(RELEASE, "gh release create \"${tag}\"");
+    let draft = position(RELEASE, "--verify-tag --draft");
+    let upload = position(RELEASE, "gh release upload \"${tag}\"");
+    let clobber = position(RELEASE, "--clobber");
+    let local_digest = position(RELEASE, "sha256sum \"${asset}\"");
+    let remote_digest = upload + position(&RELEASE[upload..], ".digest // \"\"");
+    let validation = position(
+        RELEASE,
+        "Release asset state or digest does not match the local artifact",
+    );
+    let publish = position(RELEASE, "gh release edit \"${tag}\" --draft=false");
+
+    assert!(create < draft && draft < upload);
+    assert!(local_digest < upload);
+    assert!(upload < clobber && clobber < remote_digest);
+    assert!(remote_digest < validation && validation < publish);
+    assert!(RELEASE.contains("expected_assets=("));
+    assert!(RELEASE.contains("actual_assets=("));
+    assert!(RELEASE.contains("^sha256:[0-9a-f]{64}$"));
+}
+
+#[test]
+fn dependency_audit_token_is_isolated_from_repository_code_execution() {
+    for (workflow, quality_name, next_job, after_audit) in [
+        (BUMP, "\n  verify:\n", "\n  audit:\n", "\n  platform:\n"),
+        (RELEASE, "\n  quality:\n", "\n  audit:\n", "\n  build:\n"),
+        (CI, "\n  quality:\n", "\n  audit:\n", "\n  platform:\n"),
+    ] {
+        let quality = between(workflow, quality_name, next_job);
+        assert!(!quality.contains("checks: write"));
+        assert!(!quality.contains("rustsec/audit-check"));
+
+        let audit = between(workflow, "\n  audit:\n", after_audit);
+        assert!(audit.contains("checks: write"));
+        assert!(audit.contains("rustsec/audit-check"));
+        assert!(!audit.contains("run: cargo"));
+    }
+}

--- a/tests/workflow_contract.rs
+++ b/tests/workflow_contract.rs
@@ -76,7 +76,25 @@ fn release_uploads_an_exact_asset_set_to_a_draft_before_publication() {
     assert!(remote_digest < validation && validation < publish);
     assert!(RELEASE.contains("expected_assets=("));
     assert!(RELEASE.contains("actual_assets=("));
-    assert!(RELEASE.contains("^sha256:[0-9a-f]{64}$"));
+}
+
+#[test]
+fn release_retries_require_exact_published_digests_and_never_regress_latest() {
+    let published = between(
+        RELEASE,
+        "if [ \"${release_draft}\" = \"false\" ]; then",
+        "if [ -z \"${release_draft}\" ]; then",
+    );
+    assert!(
+        published.contains("${published_assets[$index]}\" != \"${expected_uploads[$index]}"),
+        "published retries must compare GitHub digests with the local artifacts"
+    );
+
+    let latest_lookup = position(RELEASE, "latest_tag=\"");
+    let monotonic_refusal = position(RELEASE, "Refusing to publish older release");
+    let create = position(RELEASE, "gh release create \"${tag}\"");
+    assert!(latest_lookup < monotonic_refusal && monotonic_refusal < create);
+    assert!(RELEASE.contains("group: tink-release-publication"));
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- hardens skill-tree identity, path containment, ownership boundaries, manifest preflight, catalog identity, and rollback recovery
- adds bounded subprocess supervision, signal cleanup, output caps, and terminal-safe rendering
- makes install and update fail closed on unverified payloads while preserving recoverable replacement semantics
- pins the Rust toolchain and adds native four-platform CI, isolated dependency auditing, atomic release refs, retryable draft publication, and producer-side asset digest verification
- serializes release publication, refuses latest-version regressions, verifies published asset digests against local artifacts, and arms installer cancellation before child spawn
- aligns public documentation and acceptance traceability with the implemented contracts

## Why

The Rust CLI quality review and final review-and-ship pass found integrity, lifecycle, release-recovery, portability, output-contract, and release-publication gaps that crossed shared publication and filesystem boundaries. This change closes those gaps at their common owners and adds regression sensors for each contract.

## User and developer impact

Users get safer add/sync/refresh/destroy/update behavior, clearer refusal semantics, portable skill digests, resilient installs, and deterministic catalog output. Maintainers get a pinned toolchain, stronger native release gates, explicit recovery contracts, monotonic release publication, and expanded acceptance traceability.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked` (110 unit, 151 acceptance, 1 traceability, 4 workflow contracts)
- `cargo test --workspace --locked --doc`
- `cargo build --workspace --release --locked`
- `sh -n install.sh`
- `shellcheck -x install.sh`
- extracted publish-step Bash syntax and ShellCheck
- simulated refusal of an older latest release and a published asset digest mismatch
- `git diff --check`

Local `cargo-audit` is unavailable; the isolated PR audit job is the authoritative RustSec gate.