### PR TITLE
Harden path and digest boundaries

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -1,12 +1,11 @@
 # Acceptance boundary (v1)
 
-**Outcome:** A smaller Tink core in Rust that installs complete Agent Skills into
-a project's `.agents/skills/`, proves them offline, refreshes clean GitHub
-imports, removes a project skill on request, ensures a home root at `~/.tink`
-(override: `TINK_HOME`), can list or promote skills from the library
-(`skills/<name>/`) into a project, can harvest complete skill trees from known
-harness locations into that library (create-only), and can update the CLI binary
-from GitHub Releases via `tink update`.
+**Outcome:** A Rust CLI that manages complete standalone Agent Skills and pinned
+skillsets under a project's `.agents/skills/`; validates them offline; records and
+restores standalone intent through a project manifest and lockfile; maintains a
+reusable home inventory at `~/.tink` (override: `TINK_HOME`); inspects public GitHub
+skill structures without persistent writes; removes only explicitly managed project
+state; and updates the CLI binary from verified GitHub Releases.
 
 **Authority:** This file is the evaluator. A row is complete when its named automated
 sensor passes on a supported CI host with `git` on `PATH`. Rows explicitly marked
@@ -32,7 +31,7 @@ closed stdout is a normal pipeline termination that exits 0 without panic.
 
 ## Commands
 
-Skill verbs live only under `tink skill`. There are no top-level `add` /
+Standalone skill verbs live only under `tink skill`. There are no top-level `add` /
 `check` / `refresh` aliases. CLI binary updates use top-level `tink update`.
 
 | Command | Meaning |
@@ -49,6 +48,10 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | `tink skill verify` | Verify installed project skills against the manifest and lockfile |
 | `tink skill refresh [name]` | Refresh clean GitHub imports; refuse local edits |
 | `tink skill remove <name>` | Delete one project skill under `.agents/skills/<name>/` and drop that name from the by-project catalog (not library) |
+| `tink skillset add <name>-skillset` | Install one externally authored, revision-pinned skillset definition as a nested project tree and mirror it to the library |
+| `tink skillset list [--library]` | Group receipt-backed project or library skillsets with their member names (read-only) |
+| `tink skillset refresh <name>-skillset` | Replace one clean installed skillset from its current pinned definition; refuse local edits |
+| `tink skillset remove <name>-skillset` | Delete only the installed project skillset; preserve its definition and library copy |
 | `tink inspect <GITHUB_URL>` | Inspect skills and source-defined skillsets in a public GitHub URL without writing project or home state |
 | `tink update` | Replace this binary with a newer verified public GitHub Release (requires `curl` + `tar`) |
 | `tink destroy [--yes]` | Remove `.agents/skills/` and an empty `.agents/`; preserve `AGENTS.md`, `ZEN.md`, unrelated `.agents/` siblings, and the library; drop this project's catalog entry |
@@ -58,10 +61,13 @@ Skill verbs live only under `tink skill`. There are no top-level `add` /
 | Artifact | Contract |
 |---|---|
 | Live skills | `<project>/.agents/skills/<name>/` with `SKILL.md` |
+| Live skillsets | `<project>/.agents/skills/<name>-skillset/<member>/` with one `SKILL.md` per explicitly named member |
 | Receipt | `.tink-source.json` with exactly `source`, `revision`, `path` (non-empty strings) |
 | Home root | `$TINK_HOME` or `~/.tink` (relative `$TINK_HOME` absolutized against cwd), with `layout.json` (`kind`: `tink-skill-inventory`) |
 | Library | `skills/<name>/` skill trees copied on successful add (rebuildable collection; identical tip may install project from library; divergent → repair + warn; project overwrite still refused; not an agent discovery root) |
 | Offline catalog | `catalog/by-project/<bounded-name>-<sha256(raw-canonical-root)>/meta.json` with display `name`, `root`, raw-path `identity`, and `skills` name list; owned basename-only entries migrate on the next deposit |
+| Skillset definition | `catalog/by-skillset/<name>-skillset/meta.json` is externally authored desired state with `source`, immutable `revision`, repository-relative `sourceRoot`, and explicit `members`; Tink validates and consumes it but has no CLI writer |
+| Project manifest | `.tink/skills.toml` version 1 declares each standalone skill's `name`, typed `source`, and optional repository-relative `path` |
 | Project lock | `.tink/skills.lock` version 2; a domain-separated, length-framed SHA-256 pins path bytes, entry kind, canonical executable/non-executable mode, and contents (receipt excluded). Version 1 must be regenerated with `skill lock`. |
 | Skillset receipt | `.tink-skillset.json` digest version 2 pins the same tree semantics; `skillset refresh` is the migration path for a legacy receipt. |
 
@@ -170,6 +176,8 @@ Ids are stable. Tests must name or comment the id they prove.
 | C3 | `skill check` when `.agents` is a symlink | Exit ≠ 0; refuse |
 | C4 | `skill check` | Performs no network I/O and no filesystem writes. Sensor: manual. |
 | C5 | `skill check` after an installed skill's frontmatter name is corrupted | Exit ≠ 0; reports the skill-name mismatch |
+| C6 | `skill check` after an installed `SKILL.md` loses its YAML frontmatter | Exit ≠ 0; reports that YAML frontmatter is required |
+| C7 | `skill check` after an installed `SKILL.md` has unclosed frontmatter | Exit ≠ 0; reports that the frontmatter is not closed |
 
 ### Project manifest
 
@@ -232,6 +240,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | V4 | Close stdout before a successful listing command writes | Exit 0; no panic and no exit 101 |
 | V5 | Close stderr while an underlying command fails | Exit 1; diagnostic delivery failure does not hide the command failure |
 | V6 | Close `install.sh` stdout after a verified installation reaches advisory reporting | Exit 0 with the verified destination intact; broken advisory output cannot turn completed installation into retry ambiguity |
+| V7 | Trigger a catalog failure from a path containing terminal control characters | Exit ≠ 0; stderr renders controls as visible escapes and remains one stable output row |
 
 ### Refresh
 
@@ -290,6 +299,8 @@ Ids are stable. Tests must name or comment the id they prove.
 | U16 | `tink update` runs from a path containing terminal control characters | Exit 0 for an up-to-date binary; stdout renders controls as visible escapes with one stable output row |
 | U17 | `install.sh` receives a candidate whose probe output exceeds the capture limit | Reject before publication within the bounded probe budget; retain at most 16 MiB per stream; preserve the existing binary |
 | U18 | The installer candidate signals the supervisor while the candidate process is still being spawned | Exit nonzero without traceback; terminate and reap the candidate process group; preserve the existing binary |
+| U19 | GitHub asset metadata spells the SHA-256 algorithm and hexadecimal digest with mixed or uppercase case | Both `tink update` and `install.sh` accept the valid digest, verify the exact archive bytes, and publish normally |
+| U20 | GitHub asset metadata uses a non-ASCII case-folding confusable in the SHA-256 algorithm name | Both `tink update` and `install.sh` reject the digest metadata and preserve existing binaries byte-for-byte |
 
 ### Safety (cross-cutting)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ curl -fsSL https://raw.githubusercontent.com/jon-devlapaz/tink/main/install.sh |
 
 That installs a release binary into `~/.local/bin/tink` (override with
 `TINK_INSTALL_DIR`). Requires `curl`, `tar`, and Python 3. The installer checks
-GitHub's SHA-256 asset digest, accepts exactly one regular `tink` archive entry,
+GitHub's SHA-256 asset digest (accepting case-insensitive algorithm and hex
+spelling), accepts exactly one regular `tink` archive entry,
 probes the advertised version, and atomically replaces the destination.
 Supported hosts: macOS and Linux on x86_64/arm64.
 
@@ -165,7 +166,24 @@ Tink never appends or removes that suffix. `skillset add NAME-skillset` reads
 the pinned definition at
 `$TINK_HOME/catalog/by-skillset/NAME-skillset/meta.json`. The definition contains an
 absolute HTTPS Git URL, a full commit SHA, a repository-relative `sourceRoot`,
-and explicit member names. Tink copies those member skill trees atomically
+and explicit member names. Tink validates and consumes this externally authored
+file but has no command that writes it. For example:
+
+```json
+{
+  "source": "https://github.com/example/agent-skills.git",
+  "revision": "0123456789abcdef0123456789abcdef01234567",
+  "sourceRoot": "skills/review",
+  "members": ["code-review", "security-review"]
+}
+```
+
+Creating or changing that exact definition is a separate, explicitly authorized
+authoring step. `tink inspect` can propose source structure, but it never creates a
+definition. Do not hand-edit `.tink-skillset.json` receipts, installed skillset
+trees, or derived `catalog/by-project` entries.
+
+Tink copies those member skill trees atomically
 under `.agents/skills/NAME-skillset/`, validates the project tree, then mirrors
 that exact tree to `$TINK_HOME/skills/NAME-skillset/`. The project is primary;
 the home library conforms to it and never overwrites it. Both copies carry

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,10 +70,13 @@ roots, while `skillset list` provides the grouped member view.
    bytes, entry kind, regular-file mode, and contents. A version-1 lock requires an
    explicit `skill lock`; a legacy skillset receipt can migrate only through a clean
    `skillset refresh`.
-9. **Multi-owner publication is sequential and retryable, not transactional.** Tink
-   preflights expected ownership and validation refusals before publication where the
-   workflow spans project, library, and catalog state. Unexpected operational failures
-   can still interrupt later writes; rerunning the idempotent command is recovery.
+9. **Multi-owner publication is sequential and retryable, not transactional.**
+   Workflows such as `skill sync` explicitly preflight every expected project,
+   library, and catalog refusal before publishing the first skill. Standalone add
+   first ensures layout and preflights its project destination, but a later catalog
+   refusal can leave valid project/library writes in place; rerunning the idempotent
+   command repairs that derived index. Unexpected operational failures can still
+   interrupt later writes, and retry remains the recovery model.
 
 ## Standalone `skill add`
 
@@ -98,7 +101,9 @@ For a local or GitHub source, the complete publication order is:
 
 A bare-name promotion starts from step 3 with the structurally validated library tree.
 Positive cache and repair behavior is intentional; receipt ownership is the boundary,
-not a ban on library reuse.
+not a ban on library reuse. The project destination is protected before library or
+project-tree publication, but catalog parsing/deposit follows those writes by design;
+acceptance A9 pins this resumable exception to full multi-owner preflight.
 
 ## `skillset add`
 

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -22,7 +22,7 @@
 | Smell | Location | Refactoring | Status |
 |---|---|---|---|
 | no formal legacy safety net in this repository before this journey | `docs/` | create baseline test-oriented docs and pin top-risk CLI behavior | complete |
-| Manual edge-cases for malformed installed skills are only partially characterized | `src/check.rs` and `.agents/skills/*` | extend with additional targeted tests (non-YAML, mismatch path, missing frontmatter variants) | backlog |
+| Broader malformed frontmatter field/value cases remain beyond the installed-skill structural sensors | `src/check.rs` and `.agents/skills/*` | C5-C7 now pin name/path mismatch, missing frontmatter, and unclosed frontmatter; add narrower field-shape cases only when a concrete failure appears | backlog |
 | `src/update.rs` staging/replace binary logic is separated by responsibility | `src/update.rs` | resolved by phase-3 refactor | complete |
 | `src/check.rs` skill-entry parsing is separated from read/validate flow | `src/check.rs` | resolved by phase-4 refactor | complete |
 | Catalog metadata modeling and ownership semantics (`name`, `root`, `skills`) | `src/catalog.rs` | move from loose JSON parsing helpers to `CatalogMeta` aggregate | complete |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -142,8 +142,11 @@ The most important ownership sensors are:
 - A14 plus `skills.rs` unit tests cover portable executable-mode propagation, umask
   normalization, and distinct non-UTF-8 Unix names. Digest tests pin unambiguous
   framing and executable-mode sensitivity.
-- V4-V6 pin closed stdout/stderr exit semantics for the CLI and installer. U4-U18
-  cover invalid payloads, downgrade refusal, strict semantic versions, URL
+- V4-V6 pin closed stdout/stderr exit semantics for the CLI and installer. V7
+  and the updater unit tests pin terminal-safe rendering for representative
+  catalog and updater failure paths. U4-U20 cover invalid payloads, downgrade
+  refusal, strict semantic versions,
+  case-insensitive SHA-256 metadata, URL
   redaction/policy, bounded candidate probes and output capture, exact published
   version probes, terminal-safe update output, and preservation or rollback of an
   existing binary.
@@ -154,6 +157,8 @@ The most important ownership sensors are:
   and stable three-column catalog output for hidden, delimiter-bearing, and empty
   project sets.
 - D1 and D5 prove guidance and unrelated `.agents/` siblings survive destroy.
+- C5-C7 characterize installed-skill name/path mismatch, missing YAML
+  frontmatter, and an unclosed frontmatter block.
 
 Use [`ACCEPTANCE.md`](../ACCEPTANCE.md) for detailed input/output contracts rather
 than copying every row here.

--- a/install.sh
+++ b/install.sh
@@ -345,12 +345,12 @@ asset_mode = url_mode(url, api_mode == "file")
 if asset_mode is None:
     sys.exit(f"asset {want} has invalid download URL")
 digest = asset.get("digest")
-if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest, re.IGNORECASE | re.ASCII):
     sys.exit(f"asset {want} has invalid SHA-256 digest")
 print(tag)
 print(version)
 print(url)
-print(digest[7:])
+print(digest[7:].lower())
 print(asset_mode)
 ' "${target}" "${tmp}/release.json" "${api_mode}" >"${tmp}/asset.txt" 2>"${tmp}/metadata-error.txt" \
   || die "$(cat "${tmp}/metadata-error.txt" 2>/dev/null || echo could not parse release metadata)"

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -49,7 +49,11 @@ registries, or substitute symlinks or manual copies.
 Require canonical skillset names ending in `-skillset`; never append or remove
 the suffix. `skillset add` reads
 `$TINK_HOME/catalog/by-skillset/NAME-skillset/meta.json`; inspection does not
-create that definition.
+create that definition. Tink has no definition-writer command. Only when the user
+explicitly authorizes creating or changing a pinned skillset definition, author
+that exact external-input file using the schema in `references/commands.md`.
+Definition authoring does not authorize installing it or editing receipts,
+installed trees, or the derived by-project index.
 
 **Expected:** One primary command exactly matches the user's authority.
 
@@ -58,7 +62,10 @@ canonical name is missing, stop and ask for the missing authority or name.
 
 ### Step 3: Execute the Primary Mutation
 
-Run the selected command once. Honor create-only and divergence refusals. Use
+Execute the selected mutation once. For explicitly authorized external definition
+authoring, write only the exact `catalog/by-skillset/NAME-skillset/meta.json`
+input and stop unless installation was separately authorized. Honor create-only
+and divergence refusals. Use
 `tink skill add NAME` to promote a bare library skill. Receipt-backed roots
 remain skillsets. Use `tink skill harvest` to fill the library from known
 harness roots, and only the matching `tink skillset add`, `refresh`, or
@@ -149,7 +156,8 @@ from the mutation command alone.
   standalone skill; use `tink skillset add NAME-skillset` instead.
 - Inferring a skillset suffix or definition from inspection output.
 - Combining a binary update with project-skill replacement without approval.
-- Hand-editing receipts, catalog metadata, or divergent managed trees.
+- Treating external skillset-definition authoring as authority to edit receipts,
+  derived by-project catalog metadata, or divergent managed trees.
 - Treating command completion as proof of the requested outcome.
 
 ## Related Skills
@@ -170,6 +178,7 @@ from the mutation command alone.
 | Inspect a public GitHub skill source | `tink inspect GITHUB_URL` (read-only) |
 | List project / library skillsets | `tink skillset list` / `tink skillset list --library` |
 | Add / refresh / remove a canonical skillset | The matching `tink skillset … NAME-skillset` command |
+| Author a pinned skillset definition | Only the exact `catalog/by-skillset/NAME-skillset/meta.json` input; does not authorize install |
 | Configure shell completion | Only the matching shell command |
 | Re-embed manage-tink | `tink skill remove manage-tink`, then `tink init --no-zen --no-tink-skills` |
 | Remove one project skill | `tink skill remove NAME` |
@@ -184,6 +193,9 @@ from the mutation command alone.
 - Leave `.tink-skillset.json` untouched — it is skillset ownership and digest
   evidence. Its presence takes precedence over a root `SKILL.md`; standalone
   library commands must not expose, promote, or replace that root.
+- Skillset definitions under `catalog/by-skillset/` are the only externally
+  authored Tink-home metadata. Create or change one only with explicit authority;
+  never infer its revision or members from an inspection proposal.
 - On a refusal, stop and report it. Authorized deletes are only:
   - `tink skill remove NAME` → `.agents/skills/<name>/` and drops that name
     from the by-project catalog

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -66,7 +66,7 @@ form for add, list, check, refresh, and remove.
   `catalog/by-project/<bounded-name>-<sha256-identity>/meta.json`. List the catalog with
   `tink skill list --catalog` (always headered three-column TSV; backslash, tab, CR,
   and LF inside fields are escaped as `\\\\`, `\\t`, `\\r`, and `\\n`).
-  Do not hand-parse `meta.json` when the CLI is available. `skill remove`
+  Do not hand-parse this derived by-project `meta.json` when the CLI is available. `skill remove`
   deletes the project skill directory and drops that name from the by-project
   catalog; it does not prune the library. `destroy` removes
   `.agents/skills/`, removes `.agents/` only when it is then empty, and drops
@@ -86,7 +86,22 @@ form for add, list, check, refresh, and remove.
   anything or write a catalog definition.
 - Skillset definitions live at
   `catalog/by-skillset/<name>-skillset/meta.json` and pin an HTTPS Git source,
-  full revision, source root, and explicit members. Installed project and
+  full revision, source root, and explicit members. Tink validates and consumes
+  this external input but has no command that writes it. Only an explicitly
+  authorized authoring step may create or change the exact definition:
+
+  ```json
+  {
+    "source": "https://github.com/example/agent-skills.git",
+    "revision": "0123456789abcdef0123456789abcdef01234567",
+    "sourceRoot": "skills/review",
+    "members": ["code-review", "security-review"]
+  }
+  ```
+
+  `tink inspect` may inform a proposal, but never infer or write the pinned
+  revision or member list automatically. Definition authoring does not authorize
+  `skillset add`. Installed project and
   library trees carry `.tink-skillset.json`. A valid project tree is primary:
   it may repair its library copy, while library state never overwrites a
   divergent project. Receipt presence owns the root even when it also contains

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -16,6 +16,7 @@ use crate::home::{
     BY_PROJECT, by_project_path, ensure_inventory_root, existing_inventory_root,
     looks_like_legacy_catalog, resolve_home,
 };
+use crate::output;
 use crate::paths::{map_io, mkdir_p, refuse_symlink, require_directory, require_file};
 
 fn safe_project_dirname(name: &str) -> String {
@@ -109,7 +110,10 @@ impl CatalogMeta {
     fn read(meta_path: &Path, project_root: &Path) -> Result<Self, Error> {
         let raw = fs::read_to_string(meta_path).map_err(|e| map_io(meta_path, e))?;
         let value = serde_json::from_str(&raw).map_err(|e| {
-            Error::msg(format!("Invalid catalog meta {}: {e}", meta_path.display()))
+            Error::msg(format!(
+                "Invalid catalog meta {}: {e}",
+                output::display_path(meta_path)
+            ))
         })?;
         Ok(Self::from_value(project_root, &value))
     }
@@ -185,7 +189,7 @@ fn remove_catalog_dir(catalog: &Path) -> Result<(), Error> {
     if !catalog.is_dir() {
         return Err(Error::msg(format!(
             "Refusing to remove non-directory catalog: {}",
-            catalog.display()
+            output::display_path(catalog)
         )));
     }
     fs::remove_dir_all(catalog).map_err(|e| map_io(catalog, e))?;
@@ -200,7 +204,7 @@ fn validate_catalog_dir(catalog: &Path) -> Result<Option<PathBuf>, Error> {
     if !catalog.is_dir() {
         return Err(Error::msg(format!(
             "Refusing non-directory catalog: {}",
-            catalog.display()
+            output::display_path(catalog)
         )));
     }
     let meta = catalog.join("meta.json");
@@ -233,7 +237,7 @@ fn migrate_owned_legacy_catalog(
         {
             return Err(Error::msg(format!(
                 "Cannot migrate ambiguous legacy catalog {}; restore its canonical root field or remove the stale entry",
-                legacy.display()
+                output::display_path(&legacy)
             )));
         }
         return Ok(());
@@ -267,7 +271,7 @@ fn existing_project_catalog(
     if !by_project.is_dir() {
         return Err(Error::msg(format!(
             "Refusing non-directory catalog: {}",
-            by_project.display()
+            output::display_path(&by_project)
         )));
     }
 
@@ -312,7 +316,7 @@ pub(crate) fn preflight_deposit_skill_at(
         if !meta.catalog_owned_by(&project_root) {
             return Err(Error::msg(format!(
                 "Catalog identity belongs to another project: {}",
-                catalog.display()
+                output::display_path(&catalog)
             )));
         }
         return Ok(());
@@ -329,7 +333,7 @@ pub(crate) fn preflight_deposit_skill_at(
     {
         return Err(Error::msg(format!(
             "Cannot migrate ambiguous legacy catalog {}; restore its canonical root field or remove the stale entry",
-            legacy.display()
+            output::display_path(&legacy)
         )));
     }
     Ok(())
@@ -358,7 +362,7 @@ pub(crate) fn deposit_skill_at(
         if !meta.catalog_owned_by(&project_root) {
             return Err(Error::msg(format!(
                 "Catalog identity belongs to another project: {}",
-                catalog.display()
+                output::display_path(&catalog)
             )));
         }
         meta
@@ -486,8 +490,8 @@ pub fn list_catalog(home: Option<&Path>) -> Result<Vec<CatalogEntry>, Error> {
     if new.exists() && legacy_catalog {
         return Err(Error::msg(format!(
             "Catalog split across {} and {}: keep catalog/by-project, remove skills/by-project, then re-run",
-            legacy.display(),
-            new.display()
+            output::display_path(&legacy),
+            output::display_path(&new)
         )));
     }
     // Prefer new location; fall back to legacy catalog until migration runs.
@@ -506,7 +510,7 @@ pub fn list_catalog(home: Option<&Path>) -> Result<Vec<CatalogEntry>, Error> {
     if !by_project.is_dir() {
         return Err(Error::msg(format!(
             "Refusing to read non-directory catalog: {}",
-            by_project.display()
+            output::display_path(&by_project)
         )));
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -225,16 +225,15 @@ impl PartialOrd for SemVersion {
 }
 
 fn parse_sha256(value: &str) -> Result<[u8; 32], Error> {
-    let hex = value
-        .strip_prefix("sha256:")
+    let (algorithm, hex) = value
+        .split_once(':')
         .ok_or_else(|| Error::msg("release asset digest must use sha256:<hex>"))?;
-    if hex.len() != 64
-        || !hex
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    {
+    if !algorithm.eq_ignore_ascii_case("sha256") {
+        return Err(Error::msg("release asset digest must use sha256:<hex>"));
+    }
+    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(Error::msg(
-            "release asset SHA-256 digest must be 64 lowercase hexadecimal characters",
+            "release asset SHA-256 digest must be 64 hexadecimal characters",
         ));
     }
     let mut digest = [0_u8; 32];
@@ -390,13 +389,13 @@ fn curl_to_file(budget: CurlBudget, url: &str, dest: &Path, context: &str) -> Re
 
 fn sha256_file(path: &Path) -> Result<[u8; 32], Error> {
     let mut file = fs::File::open(path)
-        .map_err(|error| Error::msg(format!("read {}: {error}", path.display())))?;
+        .map_err(|error| Error::msg(format!("read {}: {error}", output::display_path(path))))?;
     let mut hasher = Sha256::new();
     let mut buffer = [0_u8; 64 * 1024];
     loop {
         let count = file
             .read(&mut buffer)
-            .map_err(|error| Error::msg(format!("read {}: {error}", path.display())))?;
+            .map_err(|error| Error::msg(format!("read {}: {error}", output::display_path(path))))?;
         if count == 0 {
             break;
         }
@@ -492,7 +491,7 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
     let parent = current.parent().ok_or_else(|| {
         Error::msg(format!(
             "cannot update {}: no parent directory",
-            current.display()
+            output::display_path(current)
         ))
     })?;
     let staging = Builder::new()
@@ -501,7 +500,7 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
         .map_err(|error| {
             Error::msg(format!(
                 "cannot stage update beside {} ({error})",
-                current.display()
+                output::display_path(current)
             ))
         })?;
     let backup = Builder::new()
@@ -510,27 +509,31 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
         .map_err(|error| {
             Error::msg(format!(
                 "cannot preserve {} before update ({error})",
-                current.display()
+                output::display_path(current)
             ))
         })?;
     fs::copy(current, backup.path()).map_err(|error| {
         Error::msg(format!(
             "cannot preserve {} before update ({error})",
-            current.display()
+            output::display_path(current)
         ))
     })?;
     fs::copy(new_bin, staging.path()).map_err(|e| {
         Error::msg(format!(
             "cannot write {} ({}). Re-run install.sh or fix permissions.",
-            staging.path().display(),
+            output::display_path(staging.path()),
             e
         ))
     })?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(staging.path(), fs::Permissions::from_mode(0o755))
-            .map_err(|e| Error::msg(format!("chmod {}: {e}", staging.path().display())))?;
+        fs::set_permissions(staging.path(), fs::Permissions::from_mode(0o755)).map_err(|e| {
+            Error::msg(format!(
+                "chmod {}: {e}",
+                output::display_path(staging.path())
+            ))
+        })?;
     }
     // Linux refuses to execute a file while a writable handle remains open.
     // TempPath retains cleanup/persist ownership after closing that handle.
@@ -539,7 +542,7 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
     staging.persist(current).map_err(|error| {
         Error::msg(format!(
             "cannot replace {} ({}). Re-run install.sh or fix permissions.",
-            current.display(),
+            output::display_path(current),
             error.error
         ))
     })?;
@@ -554,10 +557,9 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
             Err(restore_error) => {
                 let cause = restore_error.error;
                 let recovery = restore_error.file.into_temp_path().keep().ok();
-                let recovery = recovery.as_deref().map_or_else(
-                    || "unavailable".to_string(),
-                    |path| path.display().to_string(),
-                );
+                let recovery = recovery
+                    .as_deref()
+                    .map_or_else(|| "unavailable".to_string(), output::display_path);
                 Err(Error::msg(format!(
                     "published tink failed exact version verification ({probe_error}); rollback failed ({cause}); recovery backup: {recovery}"
                 )))
@@ -571,13 +573,13 @@ fn validate_current_binary_target(current: &Path) -> Result<(), Error> {
     let metadata = fs::symlink_metadata(current).map_err(|error| {
         Error::msg(format!(
             "cannot inspect current binary {}: {error}",
-            current.display()
+            output::display_path(current)
         ))
     })?;
     if !metadata.file_type().is_file() {
         return Err(Error::msg(format!(
             "refusing to replace non-file current binary {}",
-            current.display()
+            output::display_path(current)
         )));
     }
     Ok(())
@@ -879,6 +881,37 @@ mod tests {
             parse_sha256("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn parse_sha256_accepts_case_insensitive_metadata() {
+        let lowercase =
+            parse_sha256("sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+                .unwrap();
+        let mixed_case =
+            parse_sha256("ShA256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789")
+                .unwrap();
+
+        assert_eq!(mixed_case, lowercase);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_failure_paths_escape_terminal_controls() {
+        let temp = TempDir::new().unwrap();
+        let current = temp.path().join("tink-\u{1b}\nunsafe");
+        fs::create_dir(&current).unwrap();
+
+        let message = validate_current_binary_target(&current)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            !message.contains('\u{1b}'),
+            "raw escape leaked: {message:?}"
+        );
+        assert!(message.contains("\\x1b") && message.contains("\\nunsafe"));
+        assert_eq!(message.lines().count(), 1);
     }
 
     #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -2060,6 +2060,49 @@ description: corrupted metadata
         .stderr(predicate::str::contains("Skill name"));
 }
 
+#[test]
+fn c6_check_rejects_skill_without_yaml_frontmatter() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+
+    let installed = Workspace::skill_path(&project, "broken-skill");
+    fs::create_dir_all(&installed).expect("broken skill dir");
+    fs::write(installed.join("SKILL.md"), "# Missing frontmatter\n")
+        .expect("write malformed SKILL.md");
+
+    ws.cmd(&project)
+        .args(["skill", "check"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "SKILL.md must start with YAML frontmatter",
+        ));
+}
+
+#[test]
+fn c7_check_rejects_unclosed_skill_frontmatter() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+
+    let installed = Workspace::skill_path(&project, "broken-skill");
+    fs::create_dir_all(&installed).expect("broken skill dir");
+    fs::write(
+        installed.join("SKILL.md"),
+        "---\nname: broken-skill\ndescription: missing closing marker\n",
+    )
+    .expect("write malformed SKILL.md");
+
+    ws.cmd(&project)
+        .args(["skill", "check"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "SKILL.md frontmatter is not closed",
+        ));
+}
+
 // --- M*: project manifest ---
 
 #[test]
@@ -3972,6 +4015,28 @@ fn x5_manage_tink_documents_remove_and_catalog_sync() {
             "manage-tink SKILL.md must document {contract}: {skill_md}"
         );
     }
+    assert!(
+        skill_md.contains("no definition-writer command")
+            && skill_md.contains("explicitly authorizes")
+            && skill_md.contains("does not authorize installing"),
+        "manage-tink must bound external skillset-definition authoring: {skill_md}"
+    );
+    for field in [
+        "\"source\":",
+        "\"revision\":",
+        "\"sourceRoot\":",
+        "\"members\":",
+    ] {
+        assert!(
+            commands.contains(field),
+            "commands.md must show the complete skillset-definition field {field}: {commands}"
+        );
+    }
+    assert!(
+        commands.contains("has no command that writes it")
+            && commands.contains("Definition authoring does not authorize"),
+        "commands.md must document the external-authoring and install boundary: {commands}"
+    );
     for section in [
         "## When to Use",
         "## Inputs",
@@ -4203,6 +4268,28 @@ fn write_release_fixture_with_mode(
     meta
 }
 
+fn rewrite_release_digest(meta: &Path, algorithm: &str, uppercase_hex: bool) {
+    let mut release: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(meta).expect("read release metadata"))
+            .expect("parse release metadata");
+    let digest = release["assets"][0]["digest"]
+        .as_str()
+        .expect("release digest")
+        .to_string();
+    let (_, hex) = digest.split_once(':').expect("digest prefix");
+    let hex = if uppercase_hex {
+        hex.to_ascii_uppercase()
+    } else {
+        hex.to_string()
+    };
+    release["assets"][0]["digest"] = serde_json::Value::String(format!("{algorithm}:{hex}"));
+    fs::write(
+        meta,
+        format!("{}\n", serde_json::to_string_pretty(&release).unwrap()),
+    )
+    .expect("write uppercase release digest");
+}
+
 #[cfg(unix)]
 fn wait_for_marker(path: &Path, child: &mut std::process::Child) {
     let started = std::time::Instant::now();
@@ -4308,6 +4395,45 @@ fn v4_closed_stdout_does_not_panic_or_exit_101() {
         "closed stdout must exit cleanly: stderr={stderr:?}"
     );
     assert!(!stderr.contains("panicked at"));
+}
+
+#[test]
+fn v7_failure_paths_escape_terminal_controls() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    let inventory = ws.root.join("inventory-\u{1b}\nunsafe");
+    ws.cmd(&project)
+        .env("TINK_HOME", &inventory)
+        .args(["init", "--no-zen", "--no-tink-skills", "--no-manage-tink"])
+        .assert()
+        .success();
+
+    let by_project = inventory.join("catalog").join("by-project");
+    fs::remove_dir_all(&by_project).expect("remove catalog directory fixture");
+    fs::write(&by_project, "not a directory").expect("write catalog file fixture");
+
+    let output = cargo_bin_cmd!("tink")
+        .current_dir(&project)
+        .env("TINK_HOME", &inventory)
+        .args(["skill", "list", "--catalog"])
+        .output()
+        .expect("run failing catalog listing");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "catalog listing should fail");
+    assert!(
+        !output.stderr.contains(&0x1b),
+        "stderr leaked raw escape: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("\\x1b") && stderr.contains("\\nunsafe"),
+        "stderr did not visibly escape the unsafe path: {stderr:?}"
+    );
+    assert_eq!(
+        stderr.lines().count(),
+        1,
+        "escaped error must remain one line"
+    );
 }
 
 #[cfg(unix)]
@@ -5143,6 +5269,99 @@ fn u5_update_refuses_downgrade_and_preserves_running_binary() {
         .stderr(predicate::str::contains("refusing to downgrade"));
 
     assert_eq!(fs::read(&installed).unwrap(), before);
+}
+
+#[cfg(unix)]
+#[test]
+fn u19_update_and_installer_accept_case_insensitive_sha256_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("uppercase-digest-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let replacement = fixture.join("replacement-tink");
+    let replacement_bytes = b"#!/bin/sh\nprintf 'tink 99.0.0\\n'\n";
+    fs::write(&replacement, replacement_bytes).unwrap();
+    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &replacement);
+    rewrite_release_digest(&metadata, "ShA256", true);
+    let api = format!("file://{}", metadata.display());
+
+    let update_dir = ws.root.join("update-install");
+    fs::create_dir_all(&update_dir).unwrap();
+    let updated = update_dir.join("tink");
+    fs::copy(assert_cmd::cargo::cargo_bin!("tink"), &updated).unwrap();
+    fs::set_permissions(&updated, fs::Permissions::from_mode(0o755)).unwrap();
+    Command::new(&updated)
+        .arg("update")
+        .env("TINK_RELEASES_API", &api)
+        .env("TINK_HOME", &ws.inventory)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Updated"));
+    assert_eq!(fs::read(&updated).unwrap(), replacement_bytes);
+
+    let install_dir = ws.root.join("script-install");
+    fs::create_dir_all(&install_dir).unwrap();
+    Command::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_RELEASES_API", &api)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Installed tink v99.0.0"));
+    assert_eq!(
+        fs::read(install_dir.join("tink")).unwrap(),
+        replacement_bytes
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn u20_update_and_installer_reject_non_ascii_sha256_algorithm() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ws = Workspace::new();
+    let fixture = ws.root.join("non-ascii-digest-release-fixture");
+    fs::create_dir_all(&fixture).unwrap();
+    let replacement = fixture.join("replacement-tink");
+    fs::write(&replacement, b"#!/bin/sh\nprintf 'tink 99.0.0\\n'\n").unwrap();
+    fs::set_permissions(&replacement, fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata = write_release_fixture(&fixture, "99.0.0", &replacement);
+    rewrite_release_digest(&metadata, "ſha256", false);
+    let api = format!("file://{}", metadata.display());
+
+    let update_dir = ws.root.join("update-install");
+    fs::create_dir_all(&update_dir).unwrap();
+    let updated = update_dir.join("tink");
+    fs::copy(assert_cmd::cargo::cargo_bin!("tink"), &updated).unwrap();
+    fs::set_permissions(&updated, fs::Permissions::from_mode(0o755)).unwrap();
+    let update_before = fs::read(&updated).unwrap();
+    Command::new(&updated)
+        .arg("update")
+        .env("TINK_RELEASES_API", &api)
+        .env("TINK_HOME", &ws.inventory)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "release asset digest must use sha256:<hex>",
+        ));
+    assert_eq!(fs::read(&updated).unwrap(), update_before);
+
+    let install_dir = ws.root.join("script-install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let installed = install_dir.join("tink");
+    fs::copy(assert_cmd::cargo::cargo_bin!("tink"), &installed).unwrap();
+    fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+    let install_before = fs::read(&installed).unwrap();
+    Command::new("sh")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("install.sh"))
+        .env("TINK_INSTALL_DIR", &install_dir)
+        .env("TINK_RELEASES_API", &api)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid SHA-256 digest"));
+    assert_eq!(fs::read(&installed).unwrap(), install_before);
 }
 
 // --- G*: GitHub source inspection ---


### PR DESCRIPTION
## Summary
- render catalog and updater filesystem diagnostics with terminal-safe path escaping
- accept valid ASCII mixed-case SHA-256 metadata consistently across `tink update` and `install.sh`, while rejecting non-ASCII confusables
- align acceptance, architecture, testing, and embedded `manage-tink` documentation with shipped behavior
- add focused C6, C7, V7, U19, and U20 regression sensors

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked` (112 unit, 156 acceptance, 1 traceability, 4 workflow-contract)
- `cargo test --workspace --locked --doc`
- `cargo build --workspace --release --locked`
- `cargo audit --file Cargo.lock` (78 dependencies, no vulnerabilities)
- `sh -n install.sh`
- `shellcheck -x install.sh`
- `git diff --check`

## Boundaries
- C4, S1, and S2 remain explicit manual or partial proof gaps in `ACCEPTANCE.md`.
- This change documents external skillset-definition authoring; it does not add a new writer command.