### PR TITLE
Fix draft release asset verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
           gh release upload "${tag}" "${expected_assets[@]}" --clobber
           uploaded_assets=()
           mapfile -t uploaded_assets < <(
-            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+            gh release view "${tag}" --json assets \
               --jq '.assets[] | [.name, .state, (.digest // "")] | @tsv' |
               sort
           )

--- a/tests/workflow_contract.rs
+++ b/tests/workflow_contract.rs
@@ -63,6 +63,11 @@ fn release_uploads_an_exact_asset_set_to_a_draft_before_publication() {
     let upload = position(RELEASE, "gh release upload \"${tag}\"");
     let clobber = position(RELEASE, "--clobber");
     let local_digest = position(RELEASE, "sha256sum \"${asset}\"");
+    let draft_asset_query = upload
+        + position(
+            &RELEASE[upload..],
+            "gh release view \"${tag}\" --json assets",
+        );
     let remote_digest = upload + position(&RELEASE[upload..], ".digest // \"\"");
     let validation = position(
         RELEASE,
@@ -72,7 +77,8 @@ fn release_uploads_an_exact_asset_set_to_a_draft_before_publication() {
 
     assert!(create < draft && draft < upload);
     assert!(local_digest < upload);
-    assert!(upload < clobber && clobber < remote_digest);
+    assert!(upload < clobber && clobber < draft_asset_query);
+    assert!(draft_asset_query < remote_digest);
     assert!(remote_digest < validation && validation < publish);
     assert!(RELEASE.contains("expected_assets=("));
     assert!(RELEASE.contains("actual_assets=("));


### PR DESCRIPTION
## Summary
- query draft release assets through `gh release view --json assets` after upload
- retain exact name, state, and SHA-256 validation before publication
- pin the draft-capable query ordering in the workflow contract test

## Incident evidence
- recovery run 31607853354 built and uploaded all four v0.3.15 artifacts
- publication failed because `GET /releases/tags/v0.3.15` returned 404 while the release was still a draft
- the four post-recovery draft assets were independently matched to downloaded run artifacts before v0.3.15 was promoted

## Validation
- `cargo test --test workflow_contract --locked`
- `cargo fmt --all -- --check`
- exact `gh release view v0.3.15 --json assets --jq ...` smoke query
- `git diff --check`
- independent read-only workflow review