### PR TITLE
Add `tink library list` command surface

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -31,8 +31,11 @@ closed stdout is a normal pipeline termination that exits 0 without panic.
 
 ## Commands
 
-Standalone skill verbs live only under `tink skill`. There are no top-level `add` /
-`check` / `refresh` aliases. CLI binary updates use top-level `tink update`.
+Standalone skill mutation and validation verbs live under `tink skill`. The
+library has the dedicated read-only `tink library list` surface, with
+`tink skill list --library` retained as a compatibility alias. There are no
+top-level `add` / `check` / `refresh` aliases. CLI binary updates use top-level
+`tink update`.
 
 | Command | Meaning |
 |---|---|
@@ -40,7 +43,8 @@ Standalone skill verbs live only under `tink skill`. There are no top-level `add
 | `tink skill add <source> [--skill <name-or-path>]` | Install one local path, public GitHub skill, or library skill by name; remote selectors may be unique names or repository-relative paths |
 | `tink skill list` | List project skills under `.agents/skills/` (read-only) |
 | `tink skill list --catalog` | List offline by-project catalog (`project`, `root`, `skill` TSV) |
-| `tink skill list --library` | List standalone skill names in the library; receipt-backed skillset roots are excluded |
+| `tink library list` | List standalone skill names in the library; receipt-backed skillset roots are excluded |
+| `tink skill list --library` | Compatibility alias for `tink library list` |
 | `tink skill harvest` | Copy complete skill trees from known harness roots into the library (create-only; no project writes) |
 | `tink skill check` | Validate project skills; no network; no writes |
 | `tink skill lock [--source <name=source>]` | Record the installed project skills in `.tink/skills.toml` and `.tink/skills.lock` |
@@ -210,12 +214,13 @@ Ids are stable. Tests must name or comment the id they prove.
 | L11 | A project directory name begins with `.` | Its hashed catalog identity remains visible in `skill list --catalog`; hidden project names are not mistaken for staging entries |
 | L12 | A cataloged project name or root contains tab, CR, LF, backslash, or another terminal control | `skill list --catalog` emits visible backslash escapes (including `\\t`, `\\r`, `\\n`, `\\\\`, and `\\x1b`); every data row remains exactly three TSV columns and contains no raw terminal controls |
 | L13 | `skill list --catalog` with no catalog entries | Exit 0; emits the TSV header and no data rows |
+| L14 | Compare `library list` with `skill list --library` | Both exit 0 with identical stdout and stderr |
 
 ### Library
 
 | Id | Action | Expect |
 |---|---|---|
-| H1 | `skill list --library` after init+add | Exit 0; stdout includes library skill names (at least the added skill) |
+| H1 | `library list` after init+add | Exit 0; stdout includes library skill names (at least the added skill) |
 | H2 | `skill add <name>` when library has that skill and project lacks it | Exit 0; installs under `.agents/skills/<name>/`; catalogs name; **no** network; stdout notes library |
 | H3 | `skill add <missing-bare-name>` | Exit ≠ 0; mentions library not found / missing; **no** GitHub network fetch |
 | H4 | `skill add <name>` when library has skill and project skill exists and differs | Exit ≠ 0; "Refusing to overwrite"; project target unchanged |

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ tink skillset list --library
 tink skillset refresh common-skillset
 tink skillset remove common-skillset
 tink inspect https://github.com/mattpocock/skills
+tink library list
 tink skill list
 tink skill check
 tink skill refresh
@@ -142,7 +143,8 @@ tink skill refresh skill-name
 tink skill remove skill-name
 ```
 
-- A bare standalone `skill-name` promotes from the library (`tink skill list --library`).
+- A bare standalone `skill-name` promotes from the library (`tink library list`;
+  `tink skill list --library` remains a compatibility alias).
   Receipt-backed roots remain skillsets and require `tink skillset ...` commands.
 - `--skill` recursively selects a unique skill name from a remote repository.
   If that name occurs more than once, use the repository-relative path reported
@@ -208,7 +210,7 @@ structure. Inspection never writes the project, catalog, or home library.
 Library, catalog, init flags, and destroy:
 
 ```console
-tink skill list --library
+tink library list
 tink skill add skill-name
 tink skill harvest
 tink skill list --catalog

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -29,7 +29,8 @@ If `tink` is missing, report the installation command and stop:
 Otherwise, run only the read command matching the request:
 
 - Project state or names: `tink skill check` or `tink skill list`.
-- Catalog or library: `tink skill list --catalog` or `tink skill list --library`.
+- Catalog or library: `tink skill list --catalog` or `tink library list`
+  (`tink skill list --library` remains a compatibility alias).
 - Project or library skillsets: `tink skillset list` or
   `tink skillset list --library`.
 - Public GitHub structure: `tink inspect GITHUB_URL`.
@@ -173,7 +174,7 @@ from the mutation command alone.
 | …and ZEN / tink-skills / skip manage-tink | Only the matching `--with-*` / `--no-*` flags |
 | Add / list / check / refresh / remove … | The matching `tink skill …` command |
 | List catalog | `tink skill list --catalog` |
-| List library / promote from library | `tink skill list --library` / `tink skill add NAME` |
+| List library / promote from library | `tink library list` (`tink skill list --library` compatibility alias) / `tink skill add NAME` |
 | Harvest harness skills into library | `tink skill harvest` |
 | Inspect a public GitHub skill source | `tink inspect GITHUB_URL` (read-only) |
 | List project / library skillsets | `tink skillset list` / `tink skillset list --library` |

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -17,7 +17,7 @@ form for add, list, check, refresh, and remove.
 | Inspect a public GitHub repository or tree | `tink inspect GITHUB_URL` |
 | List (this project) | `tink skill list` |
 | List (catalog) | `tink skill list --catalog` |
-| List (library) | `tink skill list --library` |
+| List (library) | `tink library list` (`tink skill list --library` compatibility alias) |
 | Check | `tink skill check` |
 | Generate project manifest and lockfile | `tink skill lock --source NAME=PATH` for each local skill |
 | Verify manifest, lockfile, and installed trees | `tink skill verify` |
@@ -43,7 +43,8 @@ form for add, list, check, refresh, and remove.
   mutating commands.
 - Home (`$TINK_HOME` or `~/.tink`) is not an agent discovery root. Installs
   library trees at `skills/<name>/`. List the library with
-  `tink skill list --library`; promote into a project with
+  `tink library list` (`tink skill list --library` remains a compatibility
+  alias); promote into a project with
   `tink skill add NAME` (bare standalone library skill name). Receipt-backed
   roots and receipt-bearing sources (including dangling receipt links) are excluded
   from standalone operations. `tink skill harvest` copies complete trees

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,11 @@ pub enum Command {
         #[command(subcommand)]
         command: SkillCommand,
     },
+    /// Inspect the reusable standalone skill library
+    Library {
+        #[command(subcommand)]
+        command: LibraryCommand,
+    },
     /// Install grouped member skills as one nested project tree
     Skillset {
         #[command(subcommand)]
@@ -160,6 +165,12 @@ pub enum SkillCommand {
     },
     /// Copy harness skill trees into the library (create-only)
     Harvest,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LibraryCommand {
+    /// List standalone skill names in the library
+    List,
 }
 
 #[derive(Debug, Subcommand)]
@@ -236,6 +247,9 @@ fn dispatch(cli: Cli, cwd: PathBuf) -> Result<(), Error> {
             flag_tri(with_manage_tink, no_manage_tink),
         ),
         Command::Skill { command } => dispatch_skill(&cwd, command),
+        Command::Library { command } => match command {
+            LibraryCommand::List => dispatch_skill_list_library(),
+        },
         Command::Skillset { command } => dispatch_skillset(&cwd, command),
         Command::Inspect { url } => dispatch_inspect(&url),
         Command::Destroy { yes } => {

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -2414,6 +2414,29 @@ fn l1_skill_list_after_init_includes_manage_tink() {
 }
 
 #[test]
+fn l14_library_list_top_level_matches_legacy_alias() {
+    let ws = Workspace::new();
+    let project = ws.project("app");
+    ws.cmd(&project).arg("init").assert().success();
+
+    let canonical = ws
+        .cmd(&project)
+        .args(["library", "list"])
+        .output()
+        .expect("run library list");
+    let legacy = ws
+        .cmd(&project)
+        .args(["skill", "list", "--library"])
+        .output()
+        .expect("run skill list --library");
+
+    assert!(canonical.status.success());
+    assert!(legacy.status.success());
+    assert_eq!(canonical.stdout, legacy.stdout);
+    assert_eq!(canonical.stderr, legacy.stderr);
+}
+
+#[test]
 fn l2_skill_list_fails_without_skills_dir() {
     let ws = Workspace::new();
     let project = ws.project("app");


### PR DESCRIPTION
## Summary
- add `tink library list` as the canonical standalone-library listing command
- preserve `tink skill list --library` as a compatibility alias
- update acceptance contracts, README, and embedded manage-tink guidance

## Validation
- `cargo fmt --check`
- `cargo test` (112 unit, 157 acceptance, traceability, workflow-contract, and doc tests)
- open-code-review-delegate: 6/6 changed files reviewed

Closes #18