### PR TITLE
Strengthen manage-tink operation policy

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -268,7 +268,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | X2 | `skill remove <missing>` | Exit ≠ 0; mentions not found / missing; nothing deleted |
 | X3 | `skill remove` when `.agents` is a symlink | Exit ≠ 0; mentions symlink; tree unchanged |
 | X4 | Successful `skill remove <name>` | Does **not** delete `$TINK_HOME/skills/<name>/` |
-| X5 | `init` installs `manage-tink` | Embedded skill covers standalone skill lifecycle, manifests, library promotion/harvest, read-only GitHub inspection, canonical nested skillsets, project-first library authority, catalog effects, CLI update, and destroy; removals preserve library state |
+| X5 | `init` installs `manage-tink` | Embedded skill covers standalone lifecycle, operation-specific proof and partial-state reporting, project-contained lock sources, session-versus-persistent completion authority, any-update re-embed warning, library/catalog effects, skillsets, update, and destroy |
 | X6 | `skill remove <name>` when that project's catalog metadata is malformed | Exit ≠ 0; project and library skill trees remain intact |
 | X7 | `skill remove <name>` when `$TINK_HOME/catalog` is a symlink | Exit ≠ 0; mentions the symlink; project skill and external catalog target remain byte-identical |
 

--- a/skills/manage-tink/SKILL.md
+++ b/skills/manage-tink/SKILL.md
@@ -76,14 +76,18 @@ harness roots, and only the matching `tink skillset add`, `refresh`, or
 known.
 
 **On failure:** Stop and report the failure. Do not repair Tink-managed state
-by hand.
+by hand. Init, add, skillset refresh, and re-embedding can fail after an
+earlier project, library, catalog, or guidance write succeeded. Report each
+surface known or possibly changed; do not describe the failure as a no-op
+unless that was proved.
 
 ### Step 4: Offer Reproducible Project State
 
 After adding or changing project skills, check for `.tink/skills.toml` and
 `.tink/skills.lock`. If absent, ask whether the user wants a reproducible
 manifest. Only after approval, run `tink skill lock`, supplying
-`--source NAME=PATH` for each local skill. If `skill verify` reports a legacy
+`--source NAME=PATH` for each local skill. Each local source path must resolve
+inside the project. If `skill verify` reports a legacy
 version-1 lock digest, ask before rerunning `skill lock`; that explicit relock
 rewrites version 2 and includes raw Unix path bytes and portable executable modes. If
 both files already exist, use `tink skill sync` only when the user requested
@@ -107,16 +111,21 @@ Use the shell-specific command only after the user asks for completion:
 - Bash: use `source <(COMPLETE=bash tink)`.
 - Fish: use `COMPLETE=fish tink | source`.
 
-**Expected:** Completion is configured for the requested shell only.
+**Expected:** Completion is configured for the current requested shell session
+only. Editing a startup file for future sessions is a separate filesystem
+mutation and requires authority for that exact file.
 
 **On failure:** Report the shell and command failure. Do not edit unrelated
 shell configuration.
 
 ### Step 6: Re-embed Manage Tink When Separately Authorized
 
-After a major binary upgrade, explain that the live skill may be stale. Do not
-replace it automatically. If the user explicitly authorizes re-embedding, run
-`tink skill remove manage-tink`, then `tink init --no-zen --no-tink-skills`.
+After any binary update or observed contract mismatch, explain that the live
+skill may be stale. Do not replace it automatically. Before `destroy`, compare
+the active `tink destroy --help` boundary with this skill's ownership contract;
+if it is broader, stop and renew approval. If the user explicitly authorizes
+re-embedding, run `tink skill remove manage-tink`, then
+`tink init --no-zen --no-tink-skills`.
 
 **Expected:** Separate approval exists and the binary's embedded copy becomes
 the live project skill.
@@ -126,12 +135,22 @@ was removed. Do not conceal a partially completed replacement.
 
 ### Step 7: Prove the Post-state
 
-- After successful mutations other than removal or destroy, run
-  `tink skill check`.
-- After `skill remove`, run `tink skill list` and `tink skill list --catalog`.
-- After `skillset remove`, run `tink skillset list`; its definition and library
-  copy should remain.
+- After `init`, run `tink skill check`, project/catalog/library listings, and
+  verify the requested optional guidance or bundle state.
+- After add, promotion, refresh, or sync, run `tink skill check` and verify the
+  affected project, catalog, and library entries. After sync, also run
+  `tink skill verify`.
+- After harvest, use its summary and `tink library list`; project check does not
+  prove a library-only mutation.
 - After `skill lock`, run `tink skill verify`.
+- After skillset add or refresh, run `tink skill check`, `tink skillset list`,
+  and `tink skillset list --library`.
+- After `skill remove`, verify project/catalog absence and library retention.
+- After `skillset remove`, verify project absence and library presence; its
+  external definition should remain.
+- After update, resolve the active binary and probe its exact version. After
+  re-embedding, run project/catalog/library listings plus `tink skill check`;
+  structural check alone does not prove embedded payload identity.
 - After `destroy`, confirm `.agents/skills/` is gone, `.agents/` is gone only if
   it became empty, `ZEN.md` and `AGENTS.md` are preserved, unrelated `.agents/`
   siblings remain, and the project has no catalog rows; do not run `skill check`.
@@ -181,6 +200,8 @@ from the mutation command alone.
 | Add / refresh / remove a canonical skillset | The matching `tink skillset … NAME-skillset` command |
 | Author a pinned skillset definition | Only the exact `catalog/by-skillset/NAME-skillset/meta.json` input; does not authorize install |
 | Configure shell completion | Only the matching shell command |
+| Persist shell completion | Only the exact startup file the user authorizes |
+| Lock / verify / sync reproducible state | Only the matching `tink skill …` command; lock requires a project-contained source mapping for each local skill |
 | Re-embed manage-tink | `tink skill remove manage-tink`, then `tink init --no-zen --no-tink-skills` |
 | Remove one project skill | `tink skill remove NAME` |
 | Update the Tink binary | `tink update` only; re-embedding requires separate authority |

--- a/skills/manage-tink/references/commands.md
+++ b/skills/manage-tink/references/commands.md
@@ -19,7 +19,7 @@ form for add, list, check, refresh, and remove.
 | List (catalog) | `tink skill list --catalog` |
 | List (library) | `tink library list` (`tink skill list --library` compatibility alias) |
 | Check | `tink skill check` |
-| Generate project manifest and lockfile | `tink skill lock --source NAME=PATH` for each local skill |
+| Generate project manifest and lockfile | `tink skill lock --source NAME=PATH` for each local skill; every path must resolve inside the project |
 | Verify manifest, lockfile, and installed trees | `tink skill verify` |
 | Sync the exact pinned manifest set | `tink skill sync` (preflights expected project/library/catalog refusals, then publishes sequentially; rerun after an operational interruption) |
 | Refresh all clean imports | `tink skill refresh` |
@@ -48,22 +48,11 @@ form for add, list, check, refresh, and remove.
   `tink skill add NAME` (bare standalone library skill name). Receipt-backed
   roots and receipt-bearing sources (including dangling receipt links) are excluded
   from standalone operations. `tink skill harvest` copies complete trees
-  from known harness roots into the library create-only (never overwrites a
-  divergent library entry). Global roots include `~/.agents/skills`,
-  `~/.claude/skills`, `~/.codex/skills`, `~/.cursor/skills`,
-  `~/.cursor/skills-cursor`, `~/.copilot/skills`, `~/.github/skills`,
-  `~/.codeium/windsurf/skills`, `~/.cline/skills`, `~/.aider/skills`,
-  `~/.gemini/skills` (+ Antigravity paths), `~/.roo/skills`,
-  `~/.kilocode/skills`, `~/.amazonq/skills`, `~/.augment/skills`,
-  `~/.tabnine/skills`, `~/.sourcegraph/skills`, and
-  `~/.config/opencode/skills`. Project (cwd) roots include `.agents/skills`,
-  `.claude/skills`, `.codex/skills`, `.cursor/skills`, `.github/skills`,
-  `.windsurf/skills`, `.cline/skills`, `.clinerules/skills`, `.aider/skills`,
-  `.gemini/skills`, `.agent/skills`, `.roo/skills`, `.kilocode/skills`,
-  `.amazonq/skills`, `.augment/skills`, `.tabnine/skills`, `.opencode/skills`,
-  and `.sourcegraph/skills`. Matching GitHub tips install into the project
-  from that library; divergent library trees are repaired with a warning on
-  `skill add`. Names are recorded in
+  from CLI-owned supported harness roots into the library create-only (never
+  overwrites a divergent library entry). Do not duplicate or infer that root
+  inventory in agent policy. Matching GitHub tips install into the project from
+  that library; divergent library trees are repaired with a warning on `skill
+  add`. Names are recorded in
   `catalog/by-project/<bounded-name>-<sha256-identity>/meta.json`. List the catalog with
   `tink skill list --catalog` (always headered three-column TSV; backslash, tab, CR,
   and LF inside fields are escaped as `\\\\`, `\\t`, `\\r`, and `\\n`).

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -4081,6 +4081,42 @@ fn x5_manage_tink_documents_remove_and_catalog_sync() {
         !skill_md.contains("tink skill remove manage-tink && tink init"),
         "manage-tink must not chain re-embedding onto binary updates: {skill_md}"
     );
+    assert!(
+        skill_md.contains("After any binary update or observed contract mismatch")
+            && skill_md.contains("tink destroy --help"),
+        "manage-tink must treat every update as possible contract drift: {skill_md}"
+    );
+    assert!(
+        skill_md.contains("current requested shell session")
+            && skill_md.contains("exact startup file"),
+        "manage-tink must separate session completion from persistent mutation: {skill_md}"
+    );
+    for proof in [
+        "After `init`",
+        "After add, promotion, refresh, or sync",
+        "After harvest",
+        "After skillset add or refresh",
+        "After update",
+    ] {
+        assert!(
+            skill_md.contains(proof),
+            "manage-tink must document operation-specific proof {proof}: {skill_md}"
+        );
+    }
+    assert!(
+        skill_md.contains("possibly changed")
+            && skill_md.contains("describe the failure as a no-op"),
+        "manage-tink must report reachable partial publication: {skill_md}"
+    );
+    assert!(
+        commands.contains("every path must resolve inside the project"),
+        "commands.md must document the local lock source boundary: {commands}"
+    );
+    assert!(
+        commands.contains("CLI-owned supported harness roots")
+            && !commands.contains("~/.claude/skills"),
+        "commands.md must leave volatile harvest-root ownership with the CLI: {commands}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- require operation-specific post-state proof instead of treating `skill check` as universal evidence
- report reachable partial publication for sequential multi-surface operations
- treat every binary update as possible embedded-skill drift and preflight destructive runtime compatibility
- separate session completion from startup-file mutation authority
- keep volatile harvest-root inventory owned by the CLI and document project-contained local lock sources

## Audit disposition
The raw workstation-specific audit snapshot is intentionally excluded from this PR. Its remaining manifest lock finding is a separate implementation boundary.

## Validation
- `cargo fmt --check`
- `cargo test` (112 unit, 157 acceptance, traceability, workflow-contract, and doc tests)