### PR TITLE
Offer Triangulate in the init bundle

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -92,7 +92,7 @@ Ids are stable. Tests must name or comment the id they prove.
 | I7 | `init --no-manage-tink` | Does **not** install `manage-tink` |
 | I8 | `init` with relative `TINK_HOME` (e.g. `../home`) from project cwd | Exit 0; home is the absolutized sibling path (not nested under the project); stdout shows an absolute home path |
 | I9 | Run non-interactive `init` twice with an unchanged project | Second run exits 0, reports `Ready` / `Already present`, and leaves project/home contract files byte-identical |
-| I10 | Run `init --with-tink-skills` against an incomplete optional bundle, repair the bundle, then rerun the same command | First run fails but preserves completed setup; second run exits 0 and converges to `manage-tink` plus both bundle skills |
+| I10 | Run `init --with-tink-skills` against an incomplete optional bundle, repair the bundle, then rerun the same command | First run fails but preserves completed setup; second run exits 0 and converges to `manage-tink`, `skill-scout`, and `triangulate-me` |
 | I11 | Run `init` with `TINK_HOME` pointed at the non-empty project directory | Exit ≠ 0; refuses to claim the directory and leaves the project byte-identical |
 | I12 | Run `init` with a marker-only partial Tink home left by interrupted initialization | Exit 0; recreates the owned library/catalog directories and leaves a valid inventory |
 

--- a/README.md
+++ b/README.md
@@ -81,16 +81,15 @@ In an empty project directory:
 
 ```console
 tink init
-tink skill add jon-devlapaz/tink-skills --skill skill-scout
 tink skill list
 tink skill check
 ```
 
-That installs live skill directories under `.agents/skills/`. Optional:  
-`tink init --with-tink-skills` pulls the full
-[tink-skills](https://github.com/jon-devlapaz/tink-skills) bundle (scout +
-eval loop). On a TTY, `init` may ask about ZEN and that bundle; non-interactive
-runs skip them unless you pass flags.
+On a TTY, `init` asks whether to install `skill-scout` and `triangulate-me`
+from [tink-skills](https://github.com/jon-devlapaz/tink-skills). Accept that
+prompt to install both live skill directories under `.agents/skills/`.
+Non-interactive runs skip the optional bundle unless you pass
+`--with-tink-skills`.
 
 Defaults after `init`:
 
@@ -135,7 +134,7 @@ tink skill add ../my-skill
 tink skill add skill-name
 tink skill add owner/repository --skill skill-name
 tink skill add owner/repository --skill packages/group/skills/skill-name
-tink skill add jon-devlapaz/tink-skills --skill skill-eval-loop
+tink skill add jon-devlapaz/skill-eval-loop --skill skill-eval-loop
 tink skillset add common-skillset
 tink skillset list
 tink skillset list --library

--- a/src/init.rs
+++ b/src/init.rs
@@ -165,7 +165,7 @@ pub fn init_project(project_root: &Path, options: InitOptions) -> Result<InitRep
             "{}{} and {}{}{}?",
             style.warn("Add "),
             style.skill("skill-scout"),
-            style.skill("skill-eval-loop"),
+            style.skill("triangulate-me"),
             style.warn(" from "),
             style.link(
                 &format!("https://github.com/{TINK_SKILLS_SOURCE}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub enum Command {
         /// Skip ZEN.md
         #[arg(long, group = "zen")]
         no_zen: bool,
-        /// Add skill-scout and skill-eval-loop from GitHub (tink-skills)
+        /// Add skill-scout and triangulate-me from GitHub (tink-skills)
         #[arg(long = "with-tink-skills", group = "tink_skills")]
         with_tink_skills: bool,
         /// Skip tink-skills bundle

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -14,4 +14,4 @@ Follow the maintainability principles in [ZEN.md](ZEN.md).
 pub const ZEN_REFERENCE_MARKER: &str = "[ZEN.md](ZEN.md)";
 
 pub const TINK_SKILLS_SOURCE: &str = "jon-devlapaz/tink-skills";
-pub const TINK_SKILLS: &[&str] = &["skill-scout", "skill-eval-loop"];
+pub const TINK_SKILLS: &[&str] = &["skill-scout", "triangulate-me"];

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -432,12 +432,12 @@ fn i10_init_bundle_failure_is_resumable() {
     first
         .assert()
         .failure()
-        .stderr(predicate::str::contains("skill-eval-loop"));
+        .stderr(predicate::str::contains("triangulate-me"));
 
     ws.assert_cataloged("app", "manage-tink");
     ws.assert_cataloged("app", "skill-scout");
-    assert!(!Workspace::skill_path(&project, "skill-eval-loop").exists());
-    assert!(!ws.library_skill("skill-eval-loop").exists());
+    assert!(!Workspace::skill_path(&project, "triangulate-me").exists());
+    assert!(!ws.library_skill("triangulate-me").exists());
     ws.cmd(&project).args(["skill", "check"]).assert().success();
     let manage_before =
         fs::read(Workspace::skill_path(&project, "manage-tink").join("SKILL.md")).unwrap();
@@ -445,11 +445,11 @@ fn i10_init_bundle_failure_is_resumable() {
         fs::read(Workspace::skill_path(&project, "skill-scout").join("SKILL.md")).unwrap();
 
     write_skill(
-        &remote.join("skills").join("skill-eval-loop"),
-        "skill-eval-loop",
-        "Evaluate skills.",
+        &remote.join("skills").join("triangulate-me"),
+        "triangulate-me",
+        "Triangulate a claim.",
     );
-    commit_all(&remote, "add skill-eval-loop");
+    commit_all(&remote, "add triangulate-me");
 
     let mut second = ws.cmd(&project);
     second.args(args);
@@ -459,11 +459,11 @@ fn i10_init_bundle_failure_is_resumable() {
     second
         .assert()
         .success()
-        .stdout(predicate::str::contains("Added skill-eval-loop"));
+        .stdout(predicate::str::contains("Added triangulate-me"));
 
     ws.assert_cataloged("app", "manage-tink");
     ws.assert_cataloged("app", "skill-scout");
-    ws.assert_cataloged("app", "skill-eval-loop");
+    ws.assert_cataloged("app", "triangulate-me");
     assert_eq!(
         fs::read(Workspace::skill_path(&project, "manage-tink").join("SKILL.md")).unwrap(),
         manage_before,


### PR DESCRIPTION
## What changed

- replace `skill-eval-loop` with `triangulate-me` in Tink's optional init bundle
- update the interactive prompt and `--with-tink-skills` help text
- keep resumable bundle installation covered by acceptance test I10
- document the new bundle and the evaluator's standalone repository

## Why

The init wizard should offer the two end-user skills from `tink-skills`: discovery through `skill-scout` and reasoning through `triangulate-me`. The evaluation harness is now maintained separately and should remain an explicit install.

## Impact

Users who accept the optional bundle prompt, or pass `--with-tink-skills`, receive `skill-scout` and `triangulate-me`. Existing opt-in behavior and flags are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`
- `cargo test --workspace --locked --doc`
