### PR TITLE
Verification spike: issue #29 durable atomic skill-tree swap

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -149,7 +149,12 @@ The most important ownership sensors are:
   case-insensitive SHA-256 metadata, URL
   redaction/policy, bounded candidate probes and output capture, exact published
   version probes, terminal-safe update output, and preservation or rollback of an
-  existing binary.
+  existing binary. `update.rs` unit tests also cover binary rollback failure with
+  an explicit retained recovery backup path; see
+  [`issue-29-verification-spike.md`](issue-29-verification-spike.md).
+- `skills.rs` unit tests cover tree publish rollback success and double-failure
+  recovery backup retention (#68). `manifest.rs` unit tests cover manifest/lock
+  pair rollback when lock publication fails.
 - G9-G10 pin Git process-group cleanup on parent-only termination and visible escaping
   of terminal controls in untrusted repository paths.
 - L10-L13 and `catalog.rs` unit tests cover hashed catalog identity, bounded

--- a/docs/issue-29-verification-spike.md
+++ b/docs/issue-29-verification-spike.md
@@ -1,0 +1,151 @@
+# Verification spike: issue #29 durable atomic skill-tree swap
+
+Spike date: 2026-09-09. Base: `main` @ `4552a04` (includes #68 / post-#26 close).
+
+Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://github.com/jon-devlapaz/tink/issues/26) (closed), [#68](https://github.com/jon-devlapaz/tink/pull/68).
+
+## Verdict
+
+**Mostly done for the safety invariant; still needed for consolidation and durable naming.**
+
+| #29 design pillar | Status on `main` |
+|---|---|
+| Stage beside destination | **Mitigated** — all tree replace paths use `tempdir_in` / `tempfile_in` beside the destination root |
+| Move live → backup before publish | **Mitigated** for replace paths via `publish_staged_tree` (`target → staging/old`) |
+| Publish staged → live | **Mitigated** — rename publish in `publish_staged_tree`, `install_local`, create-only paths |
+| On failure: restore; if restore fails, **keep** backup and name path | **Mitigated** for `publish_staged_tree`, `manifest::write_atomic`, and `update::replace_binary`; **Missing** for `library::deposit_at` divergent repair and first-install-only paths |
+| Shared helper across call sites | **Missing** — three independent implementations remain |
+| Durable orphan names (`.tink-orphan-*`) | **Missing** — recovery dirs/files keep temp prefixes (`.tink-update-*`, `.skills-manifest-backup-*`, `.tink-backup-*`) |
+
+**Recommendation:** Keep #29 open but **narrow the next implement PR** to `publish_staged_tree` only: introduce a small internal helper + durable orphan rename on double failure. Defer manifest/binary unification and `deposit_at` divergent repair to follow-up issues. Do **not** close #29 until consolidation scope is explicitly split or the first slice lands.
+
+---
+
+## Refreshed acceptance checklist (#29)
+
+| Item | Status | Evidence |
+|---|---|---|
+| `replace_verified` / new install use a shared helper | **Open** | Replace uses `publish_staged_tree`; fresh install uses direct rename in `install_local` — no shared abstraction |
+| Failure after live-move leaves recoverable path + error names it | **Done** for replace/publish paths | `rollback_or_retain_backup` + `TempDir::keep()` (#53/#68); tests below |
+| Characterization for restore-failure path | **Done** for tree helper | `rollback_failure_retains_recovery_backup`, `publish_staged_tree_restores_target_when_publish_fails`; manifest/binary keep paths characterized in this spike |
+| Closes or fully addresses #26 | **Done** | #26 closed; silent `TempDir` drop on refresh replace is fixed |
+
+---
+
+## Call-site inventory
+
+Legend: **Keep** = explicit `TempDir::keep()` / `NamedTempFile::keep()` / `TempPath::keep()` on double failure. **Drop-risk** = staging/backup lives only in a `Drop`-deleting temp with no keep-on-failure path.
+
+### Tree swap core (`src/skills.rs`)
+
+| Lines | Function | Stage | Live→backup | Publish | Rollback | Keep on double failure |
+|---|---|---|---|---|---|---|
+| 736–745 | `install_local` (Ready) | `.tink-stage-*` beside dest | — (no prior live tree) | `rename(staged → target)` | — | **Drop-risk** for staged new tree only; live tree untouched |
+| 752–773 | `rollback_or_retain_backup` | — | — | — | `rename(backup → target)` | **Keep** staging dir; error names `recovery backup` |
+| 778–788 | `publish_staged_tree` | caller-owned staging | `rename(target → old)` | `rename(staged → target)` | via `rollback_or_retain_backup` | **Keep** |
+| 805–820 | `replace_verified_inner` | `.tink-update-*` + copy to `new/` | via `publish_staged_tree` | via `publish_staged_tree` | via `publish_staged_tree` | **Keep** |
+
+### Callers of `publish_staged_tree`
+
+| File:line | Caller | Staging prefix | Notes |
+|---|---|---|---|
+| `src/refresh.rs:177` | `skills::replace_verified` (via `apply_refresh`) | `.tink-update-*` | Skill refresh; pre-image snapshotted separately for `skill rollback` |
+| `src/rollback.rs:169` | `skills::replace_verified` | `.tink-update-*` | Restores refresh snapshot |
+| `src/manage_tink.rs:146` | `skills::replace_embedded_verified` | `.tink-update-*` | Embedded manage-tink replace |
+| `src/library.rs:163` | `library::promote_at` (replace branch) | `.tink-promote-*` | Project → library promotion |
+| `src/skillsets.rs:527` | `replace_from_checkout` | `.tink-skillset-stage-*` | Skillset refresh replace |
+| `src/skillsets.rs:1252` | `copy_project_tree` (replace branch) | `.tink-skillset-library-*` | Project → library skillset mirror |
+
+### Other tree paths (no `publish_staged_tree`)
+
+| File:line | Function | Pattern | Keep / Drop-risk |
+|---|---|---|---|
+| `src/library.rs:166` | `promote_at` (create) | single `rename(staged → target)` | **Drop-risk** (staging only; no prior live tree) |
+| `src/library.rs:249–250` | `deposit_at` (Divergent) | `clear_path` then `install_local` | **Missing** — removes live tree before install; no backup/keep |
+| `src/skillsets.rs:448` | `install_from_checkout` | single rename; `_staging` dropped on success | **Drop-risk** for staging on failure before rename |
+| `src/skillsets.rs:1248` | `copy_project_tree` (create) | single rename | **Drop-risk** (staging only) |
+| `src/inventory.rs:38,57` | `publish` / `publish_from_library` | `install_local` | see `install_local` |
+
+### Manifest pair (`src/manifest.rs`)
+
+| Lines | Function | Stage | Backup | Publish | Rollback | Keep |
+|---|---|---|---|---|---|---|
+| 296–368 | `write_atomic` | `.skills-toml-*`, `.skills-lock-*` temps | `.skills-manifest-backup-*` temp file of prior manifest | rename manifest then lock | restore manifest from backup or remove new manifest | **Keep** backup temp on manifest rollback failure; error names `recovery state` |
+| 256 | `lock` (caller) | — | — | calls `write_atomic` | — | — |
+
+### Binary update (`src/update.rs`)
+
+| Lines | Function | Stage | Backup | Publish | Rollback | Keep |
+|---|---|---|---|---|---|---|
+| 375–454 | `replace_binary` | `.tink-update-*` temp file | `.tink-backup-*` copy of current | `TempPath::persist` | `backup.persist(current)` on probe failure | **Keep** backup temp on restore failure; error names `recovery backup` |
+| 492 | `verify_and_replace` | — | — | calls `replace_binary` | — | — |
+
+---
+
+## Gap matrix vs #29 design target
+
+Design target: **stage beside dest → durable backup name → publish → restore-or-keep**.
+
+| Site | Stage | Durable backup | Publish | Restore-or-keep | Overall |
+|---|---|---|---|---|---|
+| `publish_staged_tree` (+ callers) | Mitigated | Partial (backup under temp dir, not `.tink-orphan-*`) | Mitigated | Mitigated (`keep()` + named error) | **Partial** |
+| `install_local` (Ready) | Mitigated | Missing (N/A — no live tree) | Mitigated | N/A | **Partial** (different shape; not #26-class) |
+| `library::deposit_at` (Divergent) | Missing | Missing | Partial (`install_local`) | Missing | **Missing** |
+| `library::promote` create / skillset create paths | Mitigated | Missing | Mitigated | N/A | **Partial** |
+| `manifest::write_atomic` | Mitigated | Partial (temp backup file) | Mitigated | Mitigated (`keep()`) | **Partial** |
+| `update::replace_binary` | Mitigated | Partial (temp backup file) | Mitigated | Mitigated (`keep()`) | **Partial** (file not tree; acceptable per #29) |
+
+---
+
+## Executable proof (tests run on spike branch)
+
+```bash
+cargo test rollback_failure_retains_recovery_backup -- --nocapture
+cargo test publish_staged_tree_restores_target_when_publish_fails -- --nocapture
+cargo test write_atomic_restores_manifest_when_lock_publish_fails -- --nocapture
+cargo test replace_binary_retains_recovery_backup_when_rollback_fails -- --nocapture
+cargo test replace_binary_rolls_back_when_published_probe_fails -- --nocapture
+cargo test --workspace --all-targets --locked
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+```
+
+| Test | Proves |
+|---|---|
+| `skills::tests::rollback_failure_retains_recovery_backup` (#68) | Tree double failure: `keep()` + recovery path in error |
+| `skills::tests::publish_staged_tree_restores_target_when_publish_fails` (#68) | Single failure: rollback restores live bytes; no orphan |
+| `manifest::tests::write_atomic_restores_manifest_when_lock_publish_fails` (this spike) | Manifest pair: lock publish failure rolls back manifest |
+| `update::tests::replace_binary_retains_recovery_backup_when_rollback_fails` (this spike) | Binary double failure: `keep()` + recovery path in error |
+| `update::tests::replace_binary_rolls_back_when_published_probe_fails` | Binary single failure: successful rollback |
+
+### Not proven (honest gaps)
+
+- End-to-end double failure injected through full `replace_verified` rename window without calling `rollback_or_retain_backup` directly (would need concurrent target recreation or test hooks).
+- `library::deposit_at` divergent `clear_path` data-loss path (documented; no deterministic unit test without invasive hooks).
+- Durable `.tink-orphan-*` naming (not implemented).
+- Windows, concurrent locks, cross-filesystem rename (explicitly out of v1).
+
+---
+
+## Residual risks
+
+1. **Temp-named recovery artifacts** — operator must discover `.tink-update-*` / `.tink-promote-*` dirs beside the skills root; not renamed to a stable orphan name.
+2. **`deposit_at` divergent repair** — `clear_path` deletes the library tree before `install_local`; install failure leaves no recovery backup (#29 class gap, separate from #26).
+3. **Three parallel implementations** — behavior drift risk between `publish_staged_tree`, `write_atomic`, and `replace_binary`.
+4. **First-install staging** — failed rename drops staged new tree only; existing live content unaffected.
+5. **Concurrent target recreation** — documented; recovery depends on winning the race after rollback failure.
+
+---
+
+## Recommended next implement slice (one PR)
+
+**Scope:** `publish_staged_tree` only (~1 module + call-site prefix constants unchanged).
+
+1. Extract a private `stage_tree_swap(staging, staged, target) -> Result<_, SwapFailure>` that implements steps 2–4 of the design target.
+2. On rollback failure, **rename** `staging/old` to `<dest-root>/.tink-orphan-<skill-name>-<pid or random>` before returning (durable name beside destination, not temp prefix).
+3. Wire `replace_verified_inner`, `library::promote_at`, and skillset callers through the helper without changing staging prefix behavior on the happy path.
+4. Add one characterization test asserting orphan dir name pattern on double failure.
+
+**Defer:** manifest/binary unification, `install_local` / `deposit_at` divergent repair, shared crate-level abstraction across file vs tree shapes.
+
+**Alternative:** Close #29 as “safety done” and open `#29a` (orphan naming), `#29b` (shared helper), `#29c` (`deposit_at` divergent backup) — if maintainers prefer smaller tracked units.

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -703,6 +703,40 @@ mod tests {
     }
 
     #[test]
+    fn write_atomic_restores_manifest_when_lock_publish_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path();
+        let directory = project.join(DIRECTORY);
+        fs::create_dir_all(&directory).unwrap();
+        let manifest_path = directory.join(MANIFEST_FILE);
+        let lock_path = directory.join(LOCK_FILE);
+        fs::write(&manifest_path, "version = 1\n\nskills = []\n").unwrap();
+        fs::write(&lock_path, "version = 2\n\nskills = []\n").unwrap();
+        fs::remove_file(&lock_path).unwrap();
+        fs::create_dir_all(&lock_path).unwrap();
+
+        let error = write_atomic(
+            project,
+            "version = 1\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\n",
+            "version = 2\n\n[[skills]]\nname = \"alpha\"\nsource = \"sources/alpha\"\nsha256 = \"0000000000000000000000000000000000000000000000000000000000000000\"\n",
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("skills.lock"),
+            "expected lock publish failure: {error}"
+        );
+        assert!(
+            !error.to_string().contains("recovery state"),
+            "manifest rollback should succeed without retaining a recovery backup: {error}"
+        );
+        assert_eq!(
+            fs::read_to_string(&manifest_path).unwrap(),
+            "version = 1\n\nskills = []\n"
+        );
+    }
+
+    #[test]
     fn sync_preflights_and_publishes_embedded_skill() {
         let temp = tempfile::tempdir().unwrap();
         let project = temp.path().join("project");

--- a/src/update.rs
+++ b/src/update.rs
@@ -855,6 +855,43 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn replace_binary_retains_recovery_backup_when_rollback_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path();
+        let current = parent.join("installed-tink");
+        let candidate = temp.path().join("candidate-tink");
+        let original = b"#!/bin/sh\nprintf 'tink 0.3.14\\n'\n";
+        fs::write(&current, original).unwrap();
+        fs::set_permissions(&current, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::write(
+            &candidate,
+            b"#!/bin/sh\ncase \"$0\" in\n  */installed-tink)\n    chmod 000 \"$(dirname \"$0\")\" 2>/dev/null || true\n    printf 'tink 0.0.0\\n'\n    ;;\n  *) printf 'tink 99.0.0\\n' ;;\nesac\n",
+        )
+        .unwrap();
+        fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = replace_binary(&current, &candidate, "99.0.0").unwrap_err();
+
+        assert!(
+            err.to_string().contains("recovery backup"),
+            "expected retained backup path in error: {err}"
+        );
+        assert!(
+            err.to_string().contains(".tink-backup-"),
+            "expected temp backup prefix in recovery path: {err}"
+        );
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o755)).unwrap();
+        assert_ne!(
+            fs::read(&current).unwrap(),
+            original,
+            "rollback failed; published candidate should remain at current"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn replace_binary_rolls_back_when_published_probe_fails() {
         use std::os::unix::fs::PermissionsExt;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Verdict on #29 today

**Mostly done for the safety invariant; still needed for consolidation and durable naming.**

Post-#68 / closed-#26, the original silent `TempDir` drop on refresh replace is **fixed**. Tree replace paths (`publish_staged_tree` and its six callers) implement stage → live→backup → publish → restore-or-keep. Manifest pair writes and binary update follow the same “orphans are explicit” rule via independent `keep()` paths.

What remains open for #29:
- **No shared helper** — three parallel implementations (`publish_staged_tree`, `manifest::write_atomic`, `update::replace_binary`)
- **No durable orphan names** — recovery artifacts keep temp prefixes (`.tink-update-*`, `.skills-manifest-backup-*`, `.tink-backup-*`)
- **`library::deposit_at` divergent repair** — `clear_path` then `install_local` with no backup (residual data-loss class gap)

Full analysis: [`docs/issue-29-verification-spike.md`](docs/issue-29-verification-spike.md)

---

## Call-site matrix

| Site | Stage | Live→backup | Publish | Restore-or-keep | Overall |
|---|---|---|---|---|---|
| `publish_staged_tree` + 6 callers (`refresh`, `rollback`, `manage_tink`, `library::promote`, `skillsets` ×2) | ✓ | ✓ (under temp) | ✓ | ✓ `keep()` | **Partial** |
| `install_local` (Ready) | ✓ | N/A | ✓ | N/A | **Partial** (first install) |
| `library::deposit_at` (Divergent) | ✗ | ✗ | partial | ✗ | **Missing** |
| `manifest::write_atomic` | ✓ | ✓ (temp file) | ✓ | ✓ `keep()` | **Partial** |
| `update::replace_binary` | ✓ | ✓ (temp file) | ✓ | ✓ `keep()` | **Partial** (file shape) |

Detailed inventory with file:line references is in the spike doc.

---

## Residual risks

1. Recovery dirs/files are temp-named beside the destination — operator-visible but not `.tink-orphan-*` stable names
2. `deposit_at` divergent path deletes the library tree before reinstall with no recovery backup
3. Three independent swap implementations — drift risk
4. Concurrent target recreation during rollback window (documented; no lock)
5. Cross-filesystem rename (explicitly out of v1)

---

## Recommended next implement slice (one PR)

**`publish_staged_tree` only** (~1 module):

1. Extract a private tree-swap helper implementing live→backup → publish → restore-or-keep
2. On rollback failure, rename backup to `<dest-root>/.tink-orphan-<name>-<suffix>` and name it in the error
3. One characterization test for orphan dir naming on double failure

Defer manifest/binary unification and `deposit_at` divergent repair to follow-up issues.

---

## Changes in this PR

- Add [`docs/issue-29-verification-spike.md`](docs/issue-29-verification-spike.md) — full inventory, refreshed #29 checklist (#26 item marked done), gap matrix, test evidence
- Add `manifest::tests::write_atomic_restores_manifest_when_lock_publish_fails`
- Add `update::tests::replace_binary_retains_recovery_backup_when_rollback_fails`
- Note new coverage in `docs/TESTING.md`

## Tests run

```bash
cargo test rollback_failure_retains_recovery_backup publish_staged_tree_restores_target_when_publish_fails write_atomic_restores_manifest_when_lock_publish_fails replace_binary_retains_recovery_backup_when_rollback_fails replace_binary_rolls_back_when_published_probe_fails
cargo test --workspace --all-targets --locked
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
```

All passed on Linux x86_64.

Relates to #29
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25e34d3b-830f-4a9a-af70-f3ed7fc2f40e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25e34d3b-830f-4a9a-af70-f3ed7fc2f40e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

