### PR TITLE
Durable orphan naming for publish_staged_tree double failure (#29 slice 1)

### DIFF
--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -115,10 +115,11 @@ manifest/lock pairs.
 Skill refresh and other tree replacements that use `skills::publish_staged_tree`
 (`replace_verified`, library promotion) move the live tree into a staging backup,
 attempt the staged publish, and roll back on publish failure. If rollback also fails,
-the staging directory is kept with `TempDir::keep()` and the error names the recovery
-backup path (`old/` under a `.tink-update-*` or `.tink-promote-*` directory beside
-the destination). That path is temp-named and operator-visible rather than silently
-dropped; #29 tracks a shared durable helper for the same pattern elsewhere.
+the displaced original tree is renamed beside the destination root to
+`.tink-orphan-<skill-name>-<unique>` and the error names that recovery path. The
+temp staging directory is dropped when the orphan move succeeds. Manifest and binary
+replace paths still retain temp-prefixed recovery artifacts; #29 tracks unifying those
+call sites.
 
 `tink destroy` removes only `.agents/skills/`, then removes `.agents/` if that
 directory is empty. It preserves files outside `.agents/` (including `AGENTS.md`),

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -195,7 +195,8 @@ records deliberate bundled coverage; `Sensor: manual` records an unresolved proo
   sequential project, library, and catalog publications. Expected validation and
   ownership refusals are preflighted; retry is the operational recovery model.
 - Skill refresh double-failure retention (`publish_staged_tree` publish + rollback
-  both fail) is covered by `skills::tests::rollback_failure_retains_recovery_backup`
+  both fail) is covered by
+  `skills::tests::rollback_failure_retains_recovery_backup_at_durable_orphan_path`
   plus a successful-rollback characterization in
   `publish_staged_tree_restores_target_when_publish_fails`. A deterministic
   end-to-end double-failure injection through the full rename window is not

--- a/docs/issue-29-verification-spike.md
+++ b/docs/issue-29-verification-spike.md
@@ -15,7 +15,7 @@ Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://gi
 | Publish staged → live | **Mitigated** — rename publish in `publish_staged_tree`, `install_local`, create-only paths |
 | On failure: restore; if restore fails, **keep** backup and name path | **Mitigated** for `publish_staged_tree`, `manifest::write_atomic`, and `update::replace_binary`; **Missing** for `library::deposit_at` divergent repair and first-install-only paths |
 | Shared helper across call sites | **Missing** — three independent implementations remain |
-| Durable orphan names (`.tink-orphan-*`) | **Missing** — recovery dirs/files keep temp prefixes (`.tink-update-*`, `.skills-manifest-backup-*`, `.tink-backup-*`) |
+| Durable orphan names (`.tink-orphan-*`) | **Partial** — `publish_staged_tree` renames displaced originals to `.tink-orphan-*` on double failure; manifest/binary paths still use temp prefixes |
 
 **Recommendation:** Keep #29 open but **narrow the next implement PR** to `publish_staged_tree` only: introduce a small internal helper + durable orphan rename on double failure. Defer manifest/binary unification and `deposit_at` divergent repair to follow-up issues. Do **not** close #29 until consolidation scope is explicitly split or the first slice lands.
 
@@ -88,7 +88,7 @@ Design target: **stage beside dest → durable backup name → publish → resto
 
 | Site | Stage | Durable backup | Publish | Restore-or-keep | Overall |
 |---|---|---|---|---|---|
-| `publish_staged_tree` (+ callers) | Mitigated | Partial (backup under temp dir, not `.tink-orphan-*`) | Mitigated | Mitigated (`keep()` + named error) | **Partial** |
+| `publish_staged_tree` (+ callers) | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (orphan rename + named error) | **Partial** (shared helper deferred) |
 | `install_local` (Ready) | Mitigated | Missing (N/A — no live tree) | Mitigated | N/A | **Partial** (different shape; not #26-class) |
 | `library::deposit_at` (Divergent) | Missing | Missing | Partial (`install_local`) | Missing | **Missing** |
 | `library::promote` create / skillset create paths | Mitigated | Missing | Mitigated | N/A | **Partial** |
@@ -100,7 +100,7 @@ Design target: **stage beside dest → durable backup name → publish → resto
 ## Executable proof (tests run on spike branch)
 
 ```bash
-cargo test rollback_failure_retains_recovery_backup -- --nocapture
+cargo test rollback_failure_retains_recovery_backup_at_durable_orphan_path -- --nocapture
 cargo test publish_staged_tree_restores_target_when_publish_fails -- --nocapture
 cargo test write_atomic_restores_manifest_when_lock_publish_fails -- --nocapture
 cargo test replace_binary_retains_recovery_backup_when_rollback_fails -- --nocapture
@@ -112,7 +112,7 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 
 | Test | Proves |
 |---|---|
-| `skills::tests::rollback_failure_retains_recovery_backup` (#68) | Tree double failure: `keep()` + recovery path in error |
+| `skills::tests::rollback_failure_retains_recovery_backup_at_durable_orphan_path` | Tree double failure: orphan rename + recovery path in error |
 | `skills::tests::publish_staged_tree_restores_target_when_publish_fails` (#68) | Single failure: rollback restores live bytes; no orphan |
 | `manifest::tests::write_atomic_restores_manifest_when_lock_publish_fails` (this spike) | Manifest pair: lock publish failure rolls back manifest |
 | `update::tests::replace_binary_retains_recovery_backup_when_rollback_fails` (this spike) | Binary double failure: `keep()` + recovery path in error |
@@ -122,14 +122,14 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 
 - End-to-end double failure injected through full `replace_verified` rename window without calling `rollback_or_retain_backup` directly (would need concurrent target recreation or test hooks).
 - `library::deposit_at` divergent `clear_path` data-loss path (documented; no deterministic unit test without invasive hooks).
-- Durable `.tink-orphan-*` naming (not implemented).
+- Durable `.tink-orphan-*` naming for manifest/binary/update paths (tree swap done).
 - Windows, concurrent locks, cross-filesystem rename (explicitly out of v1).
 
 ---
 
 ## Residual risks
 
-1. **Temp-named recovery artifacts** — operator must discover `.tink-update-*` / `.tink-promote-*` dirs beside the skills root; not renamed to a stable orphan name.
+1. **Temp-named recovery artifacts** — manifest/binary paths still use temp prefixes; tree swap uses `.tink-orphan-*`.
 2. **`deposit_at` divergent repair** — `clear_path` deletes the library tree before `install_local`; install failure leaves no recovery backup (#29 class gap, separate from #26).
 3. **Three parallel implementations** — behavior drift risk between `publish_staged_tree`, `write_atomic`, and `replace_binary`.
 4. **First-install staging** — failed rename drops staged new tree only; existing live content unaffected.

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -749,6 +749,24 @@ pub fn install_local(
     }
 }
 
+fn orphan_recovery_path(destination_root: &Path, target: &Path) -> PathBuf {
+    let skill_name = target
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("skill"));
+    let suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    );
+    destination_root.join(format!(
+        ".tink-orphan-{}-{suffix}",
+        skill_name.to_string_lossy()
+    ))
+}
+
 fn rollback_or_retain_backup(
     staging: tempfile::TempDir,
     backup: &Path,
@@ -758,23 +776,36 @@ fn rollback_or_retain_backup(
     match fs::rename(backup, target) {
         Ok(()) => map_io(target, publish_error),
         Err(rollback_error) => {
-            let recovery_root = staging.keep();
-            let recovery = recovery_root.join(
-                backup
-                    .file_name()
-                    .unwrap_or_else(|| std::ffi::OsStr::new("old")),
-            );
-            Error::msg(format!(
-                "could not publish {} ({publish_error}); rollback failed ({rollback_error}); recovery backup: {}",
-                output::display_path(target),
-                output::display_path(&recovery)
-            ))
+            let destination_root = target.parent().unwrap_or_else(|| Path::new("."));
+            let orphan = orphan_recovery_path(destination_root, target);
+            match fs::rename(backup, &orphan) {
+                Ok(()) => Error::msg(format!(
+                    "could not publish {} ({publish_error}); rollback failed ({rollback_error}); recovery backup: {}",
+                    output::display_path(target),
+                    output::display_path(&orphan)
+                )),
+                Err(orphan_error) => {
+                    let recovery_root = staging.keep();
+                    let recovery = recovery_root.join(
+                        backup
+                            .file_name()
+                            .unwrap_or_else(|| std::ffi::OsStr::new("old")),
+                    );
+                    Error::msg(format!(
+                        "could not publish {} ({publish_error}); rollback failed ({rollback_error}); could not move recovery backup to {} ({orphan_error}); recovery backup: {}",
+                        output::display_path(target),
+                        output::display_path(&orphan),
+                        output::display_path(&recovery)
+                    ))
+                }
+            }
         }
     }
 }
 
 /// Rename a fully staged replacement over an existing tree. If publication and
-/// rollback both fail, retain the only original at an explicit recovery path.
+/// rollback both fail, retain the displaced original at a durable `.tink-orphan-*`
+/// path beside the destination root.
 pub(crate) fn publish_staged_tree(
     staging: tempfile::TempDir,
     staged: PathBuf,
@@ -1023,8 +1054,21 @@ mod tests {
         .unwrap();
     }
 
+    fn orphan_dirs_in(root: &Path) -> Vec<PathBuf> {
+        fs::read_dir(root)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(".tink-orphan-"))
+            })
+            .collect()
+    }
+
     #[test]
-    fn rollback_failure_retains_recovery_backup() {
+    fn rollback_failure_retains_recovery_backup_at_durable_orphan_path() {
         let temp = TempDir::new().unwrap();
         let staging = tempfile::Builder::new()
             .prefix(".rollback-fixture-")
@@ -1045,11 +1089,24 @@ mod tests {
         );
 
         assert!(error.to_string().contains("recovery backup"), "{error}");
-        assert!(error.to_string().contains(&backup.display().to_string()));
-        assert_eq!(
-            fs::read(staging_path.join("old/original")).unwrap(),
-            b"preserve me"
+        let orphans = orphan_dirs_in(temp.path());
+        assert_eq!(orphans.len(), 1, "{error}");
+        let orphan = &orphans[0];
+        assert!(
+            orphan
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(".tink-orphan-target-")),
+            "unexpected orphan name: {}",
+            orphan.display()
         );
+        assert!(
+            error.to_string().contains(&orphan.display().to_string()),
+            "{error}"
+        );
+        assert_eq!(fs::read(orphan.join("original")).unwrap(), b"preserve me");
+        assert!(!staging_path.exists(), "temp staging dir should be removed");
+        assert!(!backup.exists(), "backup should move out of staging");
     }
 
     #[test]
@@ -1074,6 +1131,10 @@ mod tests {
         assert_eq!(
             fs::read(target.join("payload.txt")).unwrap(),
             b"original-bytes"
+        );
+        assert!(
+            orphan_dirs_in(dest.path()).is_empty(),
+            "successful rollback must not leave orphan dirs"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

On publish+rollback double failure, `rollback_or_retain_backup` (used by `skills::publish_staged_tree`) now renames the displaced original tree from `staging/old` to a durable path beside the destination root:

`.tink-orphan-<skill-name>-<pid>-<nanos>`

The error message names that orphan path. The temp staging directory is dropped when the orphan move succeeds. If the orphan rename itself fails, behavior falls back to the prior `TempDir::keep()` recovery under the temp prefix.

This addresses the first #29 slice: operators no longer need to hunt inside `.tink-update-*` / `.tink-promote-*` staging dirs for the original tree after a double failure. All existing callers (`replace_verified`, library promote, skillset replace) pick up the behavior automatically.

Happy-path publish and single-failure rollback are unchanged.

## How to prove

```bash
cargo test rollback_failure_retains_recovery_backup_at_durable_orphan_path -- --nocapture
cargo test publish_staged_tree_restores_target_when_publish_fails -- --nocapture
cargo test --workspace --all-targets --locked
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
```

Key tests:
- `skills::tests::rollback_failure_retains_recovery_backup_at_durable_orphan_path` — double failure leaves bytes at `.tink-orphan-*` and error names it
- `skills::tests::publish_staged_tree_restores_target_when_publish_fails` — single failure rollback restores live tree; no orphan dirs left

Docs: `docs/RELIABILITY.md` (orphan naming), `docs/TESTING.md`, `docs/issue-29-verification-spike.md` (status refresh).

## What remains on #29

- Shared helper unification across `publish_staged_tree`, `manifest::write_atomic`, and `update::replace_binary`
- Durable orphan naming for manifest/binary paths (still temp-prefixed)
- `library::deposit_at` divergent `clear_path` repair
- End-to-end double-failure injection through full rename window (no concurrency hooks)

Do **not** close #29 with this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f53c8214-f6ed-4ffd-972a-65fd7a4e5533?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f53c8214-f6ed-4ffd-972a-65fd7a4e5533&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

