### PR TITLE
Make library divergent deposit repair restore-or-orphan safe (#29)

### DIFF
--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -113,13 +113,13 @@ Tink does not claim atomicity across project trees, the library, skillset pins, 
 manifest/lock pairs.
 
 Skill refresh and other tree replacements that use `skills::publish_staged_tree`
-(`replace_verified`, library promotion) move the live tree into a staging backup,
-attempt the staged publish, and roll back on publish failure. If rollback also fails,
-the displaced original tree is renamed beside the destination root to
-`.tink-orphan-<skill-name>-<unique>` and the error names that recovery path. The
-temp staging directory is dropped when the orphan move succeeds. Manifest and binary
-replace paths still retain temp-prefixed recovery artifacts; #29 tracks unifying those
-call sites.
+(`replace_verified`, library promotion, divergent library deposit repair) move the
+live tree into a staging backup, attempt the staged publish, and roll back on publish
+failure. If rollback also fails, the displaced original tree is renamed beside the
+destination root to `.tink-orphan-<skill-name>-<unique>` and the error names that
+recovery path. The temp staging directory is dropped when the orphan move succeeds.
+Manifest and binary replace paths still retain temp-prefixed recovery artifacts; #29
+tracks unifying those call sites.
 
 `tink destroy` removes only `.agents/skills/`, then removes `.agents/` if that
 directory is empty. It preserves files outside `.agents/` (including `AGENTS.md`),

--- a/docs/issue-29-verification-spike.md
+++ b/docs/issue-29-verification-spike.md
@@ -13,7 +13,7 @@ Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://gi
 | Stage beside destination | **Mitigated** — all tree replace paths use `tempdir_in` / `tempfile_in` beside the destination root |
 | Move live → backup before publish | **Mitigated** for replace paths via `publish_staged_tree` (`target → staging/old`) |
 | Publish staged → live | **Mitigated** — rename publish in `publish_staged_tree`, `install_local`, create-only paths |
-| On failure: restore; if restore fails, **keep** backup and name path | **Mitigated** for `publish_staged_tree`, `manifest::write_atomic`, and `update::replace_binary`; **Missing** for `library::deposit_at` divergent repair and first-install-only paths |
+| On failure: restore; if restore fails, **keep** backup and name path | **Mitigated** for `publish_staged_tree`, `manifest::write_atomic`, `update::replace_binary`, and `library::deposit_at` divergent repair; **Missing** for first-install-only paths |
 | Shared helper across call sites | **Missing** — three independent implementations remain |
 | Durable orphan names (`.tink-orphan-*`) | **Partial** — `publish_staged_tree` renames displaced originals to `.tink-orphan-*` on double failure; manifest/binary paths still use temp prefixes |
 
@@ -61,7 +61,7 @@ Legend: **Keep** = explicit `TempDir::keep()` / `NamedTempFile::keep()` / `TempP
 | File:line | Function | Pattern | Keep / Drop-risk |
 |---|---|---|---|
 | `src/library.rs:166` | `promote_at` (create) | single `rename(staged → target)` | **Drop-risk** (staging only; no prior live tree) |
-| `src/library.rs:249–250` | `deposit_at` (Divergent) | `clear_path` then `install_local` | **Missing** — removes live tree before install; no backup/keep |
+| `src/library.rs` | `deposit_at` (Divergent) via `repair_divergent_deposit` | `.tink-deposit-*` + `publish_staged_tree` | **Mitigated** — same restore-or-orphan semantics as other replace paths |
 | `src/skillsets.rs:448` | `install_from_checkout` | single rename; `_staging` dropped on success | **Drop-risk** for staging on failure before rename |
 | `src/skillsets.rs:1248` | `copy_project_tree` (create) | single rename | **Drop-risk** (staging only) |
 | `src/inventory.rs:38,57` | `publish` / `publish_from_library` | `install_local` | see `install_local` |
@@ -90,7 +90,7 @@ Design target: **stage beside dest → durable backup name → publish → resto
 |---|---|---|---|---|---|
 | `publish_staged_tree` (+ callers) | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (orphan rename + named error) | **Partial** (shared helper deferred) |
 | `install_local` (Ready) | Mitigated | Missing (N/A — no live tree) | Mitigated | N/A | **Partial** (different shape; not #26-class) |
-| `library::deposit_at` (Divergent) | Missing | Missing | Partial (`install_local`) | Missing | **Missing** |
+| `library::deposit_at` (Divergent) | Mitigated | Mitigated (via `publish_staged_tree`) | Mitigated | Mitigated | **Partial** (shared helper deferred) |
 | `library::promote` create / skillset create paths | Mitigated | Missing | Mitigated | N/A | **Partial** |
 | `manifest::write_atomic` | Mitigated | Partial (temp backup file) | Mitigated | Mitigated (`keep()`) | **Partial** |
 | `update::replace_binary` | Mitigated | Partial (temp backup file) | Mitigated | Mitigated (`keep()`) | **Partial** (file not tree; acceptable per #29) |
@@ -102,6 +102,9 @@ Design target: **stage beside dest → durable backup name → publish → resto
 ```bash
 cargo test rollback_failure_retains_recovery_backup_at_durable_orphan_path -- --nocapture
 cargo test publish_staged_tree_restores_target_when_publish_fails -- --nocapture
+cargo test deposit_diverge_repairs -- --nocapture
+cargo test deposit_divergent_repair_restores_original_on_publish_failure -- --nocapture
+cargo test deposit_divergent_repair_retains_orphan_on_double_failure -- --nocapture
 cargo test write_atomic_restores_manifest_when_lock_publish_fails -- --nocapture
 cargo test replace_binary_retains_recovery_backup_when_rollback_fails -- --nocapture
 cargo test replace_binary_rolls_back_when_published_probe_fails -- --nocapture
@@ -121,7 +124,7 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 ### Not proven (honest gaps)
 
 - End-to-end double failure injected through full `replace_verified` rename window without calling `rollback_or_retain_backup` directly (would need concurrent target recreation or test hooks).
-- `library::deposit_at` divergent `clear_path` data-loss path (documented; no deterministic unit test without invasive hooks).
+- End-to-end double failure injected through full `deposit_at` rename window without calling rollback helpers directly (library tests characterize restore and orphan beside the library root).
 - Durable `.tink-orphan-*` naming for manifest/binary/update paths (tree swap done).
 - Windows, concurrent locks, cross-filesystem rename (explicitly out of v1).
 
@@ -130,7 +133,7 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 ## Residual risks
 
 1. **Temp-named recovery artifacts** — manifest/binary paths still use temp prefixes; tree swap uses `.tink-orphan-*`.
-2. **`deposit_at` divergent repair** — `clear_path` deletes the library tree before `install_local`; install failure leaves no recovery backup (#29 class gap, separate from #26).
+2. **`deposit_at` divergent repair** — mitigated via `repair_divergent_deposit` + `publish_staged_tree` (PR after spike).
 3. **Three parallel implementations** — behavior drift risk between `publish_staged_tree`, `write_atomic`, and `replace_binary`.
 4. **First-install staging** — failed rename drops staged new tree only; existing live content unaffected.
 5. **Concurrent target recreation** — documented; recovery depends on winning the race after rollback failure.
@@ -146,6 +149,6 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 3. Wire `replace_verified_inner`, `library::promote_at`, and skillset callers through the helper without changing staging prefix behavior on the happy path.
 4. Add one characterization test asserting orphan dir name pattern on double failure.
 
-**Defer:** manifest/binary unification, `install_local` / `deposit_at` divergent repair, shared crate-level abstraction across file vs tree shapes.
+**Defer:** manifest/binary unification, `install_local` first-install staging, shared crate-level abstraction across file vs tree shapes.
 
 **Alternative:** Close #29 as “safety done” and open `#29a` (orphan naming), `#29b` (shared helper), `#29c` (`deposit_at` divergent backup) — if maintainers prefer smaller tracked units.

--- a/src/library.rs
+++ b/src/library.rs
@@ -51,16 +51,6 @@ pub struct PromotionOutcome {
 
 const PROMOTION_IGNORED_ROOTS: &[&str] = &[".git", provenance::SIDECAR_FILE, ".tink-skillset.json"];
 
-fn clear_path(target: &Path) -> Result<(), Error> {
-    refuse_symlink(target)?;
-    if target.is_dir() {
-        fs::remove_dir_all(target).map_err(|e| map_io(target, e))?;
-    } else if target.exists() {
-        fs::remove_file(target).map_err(|e| map_io(target, e))?;
-    }
-    Ok(())
-}
-
 fn library_root(home: Option<&Path>) -> Result<PathBuf, Error> {
     let (home, _) = ensure_inventory_root(home)?;
     let root = skills_library_path(&home);
@@ -216,6 +206,25 @@ fn iter_library_skills(library: &Path) -> Result<Vec<Skill>, Error> {
     Ok(skills)
 }
 
+/// Stage and atomically replace a divergent library entry via [`skills::publish_staged_tree`].
+fn repair_divergent_deposit(
+    library: &Path,
+    skill: &Skill,
+    provenance: Option<&Provenance>,
+    target: &Path,
+) -> Result<PathBuf, Error> {
+    let staging = tempfile::Builder::new()
+        .prefix(".tink-deposit-")
+        .tempdir_in(library)
+        .map_err(|e| Error::msg(format!("deposit staging dir: {e}")))?;
+    let staged = staging.path().join(&skill.name);
+    skills::copy_skill_tree(&skill.path, &staged, &[".git"])?;
+    if let Some(provenance) = provenance {
+        provenance::write_file(&staged.join(provenance::SIDECAR_FILE), provenance)?;
+    }
+    skills::publish_staged_tree(staging, staged, target)
+}
+
 /// Copy skill tree into `~/.tink/skills/<name>/`.
 ///
 /// Identical → noop; missing → create; divergent → replace (caller should warn).
@@ -246,8 +255,7 @@ pub(crate) fn deposit_at(
             Ok((path, LibraryWrite::Repaired))
         }
         PreflightOutcome::Divergent => {
-            clear_path(&library.join(&skill.name))?;
-            let (path, _) = skills::install_local(skill, &library, provenance)?;
+            let path = repair_divergent_deposit(&library, skill, provenance, &target)?;
             Ok((path, LibraryWrite::Repaired))
         }
     }
@@ -542,6 +550,19 @@ mod tests {
         provenance
     }
 
+    fn orphan_dirs_in(root: &Path) -> Vec<PathBuf> {
+        fs::read_dir(root)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(".tink-orphan-"))
+            })
+            .collect()
+    }
+
     #[test]
     fn create_only_missing_creates() {
         let home = TempHome::new();
@@ -667,6 +688,93 @@ mod tests {
         assert_eq!(write, LibraryWrite::Repaired);
         assert!(skill_md(&path).contains("incoming body"));
         assert!(!skill_md(&path).contains("original body"));
+    }
+
+    #[test]
+    fn deposit_divergent_repair_restores_original_on_publish_failure() {
+        let home = TempHome::new();
+        let first = home.root.join("first").join("demo-skill");
+        let second = home.root.join("second").join("demo-skill");
+        let original = write_skill(&first, "demo-skill", "original body");
+        let incoming = write_skill(&second, "demo-skill", "incoming body");
+
+        assert_eq!(
+            deposit_at(Some(&home.home), &original, None).unwrap().1,
+            LibraryWrite::Created
+        );
+        let target = home.library_skill("demo-skill");
+        fs::write(target.join("payload.txt"), "original-bytes").unwrap();
+
+        let library = skills_library_path(&home.home);
+        let staging = tempfile::Builder::new()
+            .prefix(".tink-deposit-")
+            .tempdir_in(&library)
+            .unwrap();
+        let staged = staging.path().join("demo-skill");
+
+        let error = skills::publish_staged_tree(staging, staged, &target).unwrap_err();
+
+        assert!(
+            !error.to_string().contains("recovery backup"),
+            "rollback should restore the live library tree without an orphan: {error}"
+        );
+        assert_eq!(
+            fs::read(target.join("payload.txt")).unwrap(),
+            b"original-bytes"
+        );
+        assert!(skill_md(&target).contains("original body"));
+        assert!(!skill_md(&target).contains("incoming body"));
+        assert!(orphan_dirs_in(&library).is_empty(), "{error}");
+        let _ = incoming;
+    }
+
+    #[test]
+    fn deposit_divergent_repair_retains_orphan_on_double_failure() {
+        let home = TempHome::new();
+        ensure_inventory_root(Some(&home.home)).unwrap();
+        let target = home.library_skill("demo-skill");
+        write_skill(&target, "demo-skill", "original body");
+        fs::write(target.join("payload.txt"), "preserve me").unwrap();
+
+        let library = skills_library_path(&home.home);
+        let staging = tempfile::Builder::new()
+            .prefix(".tink-deposit-")
+            .tempdir_in(&library)
+            .unwrap();
+        let staging_path = staging.path().to_path_buf();
+        let backup = staging.path().join("old");
+        fs::rename(&target, &backup).unwrap();
+        fs::write(&target, "rollback blocker").unwrap();
+
+        let error = skills::test_rollback_or_retain_backup(
+            staging,
+            &backup,
+            &target,
+            std::io::Error::other("publish fixture"),
+        );
+
+        assert!(error.to_string().contains("recovery backup"), "{error}");
+        let orphans = orphan_dirs_in(&library);
+        assert_eq!(orphans.len(), 1, "{error}");
+        let orphan = &orphans[0];
+        assert!(
+            orphan
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(".tink-orphan-demo-skill-")),
+            "unexpected orphan name: {}",
+            orphan.display()
+        );
+        assert!(
+            error.to_string().contains(&orphan.display().to_string()),
+            "{error}"
+        );
+        assert_eq!(
+            fs::read(orphan.join("payload.txt")).unwrap(),
+            b"preserve me"
+        );
+        assert!(!staging_path.exists(), "temp staging dir should be removed");
+        assert!(!backup.exists(), "backup should move out of staging");
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -767,6 +767,16 @@ fn orphan_recovery_path(destination_root: &Path, target: &Path) -> PathBuf {
     ))
 }
 
+#[cfg(test)]
+pub(crate) fn test_rollback_or_retain_backup(
+    staging: tempfile::TempDir,
+    backup: &Path,
+    target: &Path,
+    publish_error: std::io::Error,
+) -> Error {
+    rollback_or_retain_backup(staging, backup, target, publish_error)
+}
+
 fn rollback_or_retain_backup(
     staging: tempfile::TempDir,
     backup: &Path,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed / why

`library::deposit_at` on `PreflightOutcome::Divergent` previously called `clear_path` then `install_local`. If install failed after the clear, the only library copy was gone with no recovery path — a #29-class gap distinct from refresh replace (which already uses restore-or-keep via `publish_staged_tree` / #70).

This PR replaces that path with `repair_divergent_deposit`: stage the incoming tree beside the library (`.tink-deposit-*`), then publish via `skills::publish_staged_tree`. On publish failure the live tree is restored; on double failure the displaced original is renamed to `.tink-orphan-<skill-name>-<unique>` beside the library root and the error names that path.

Success semantics are unchanged: divergent repair still reports `LibraryWrite::Repaired`.

## Proof commands + test names

```bash
cargo test deposit_diverg -- --nocapture
cargo test --workspace --all-targets --locked
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
```

| Test | Proves |
|---|---|
| `library::tests::deposit_diverge_repairs` | Divergent repair success; reports `Repaired` and replaces body |
| `library::tests::deposit_divergent_repair_restores_original_on_publish_failure` | Publish failure after live displacement restores original library bytes |
| `library::tests::deposit_divergent_repair_retains_orphan_on_double_failure` | Double failure leaves `.tink-orphan-demo-skill-*` beside library root; error names path |

## What remains on #29

- Shared helper unification across `publish_staged_tree`, `manifest::write_atomic`, and `update::replace_binary`
- Durable `.tink-orphan-*` naming for manifest/binary paths (tree swap already uses it)
- First-install-only staging drop-risk (`install_local` Ready path)
- Closing #29 is intentionally deferred until consolidation scope is addressed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b941f28-fa52-43fe-a3b1-002f70187b39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b941f28-fa52-43fe-a3b1-002f70187b39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

