### PR TITLE
Durable orphan naming for manifest and binary replace paths (#29)

### DIFF
--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -116,10 +116,15 @@ Skill refresh and other tree replacements that use `skills::publish_staged_tree`
 (`replace_verified`, library promotion, divergent library deposit repair) move the
 live tree into a staging backup, attempt the staged publish, and roll back on publish
 failure. If rollback also fails, the displaced original tree is renamed beside the
-destination root to `.tink-orphan-<skill-name>-<unique>` and the error names that
-recovery path. The temp staging directory is dropped when the orphan move succeeds.
-Manifest and binary replace paths still retain temp-prefixed recovery artifacts; #29
-tracks unifying those call sites.
+destination root to `.tink-orphan-<name>-<unique>` and the error names that recovery
+path. The temp staging directory is dropped when the orphan move succeeds.
+
+Manifest pair writes (`manifest::write_atomic`) and binary self-update
+(`update::replace_binary`) follow the same restore-or-orphan principle for file
+replacements: on double failure the recovery backup is renamed beside the destination
+root to `.tink-orphan-<file-name>-<unique>` (falling back to the temp backup path
+only when that durable rename fails). #29 tracks consolidating these independent
+implementations behind one shared swap helper.
 
 `tink destroy` removes only `.agents/skills/`, then removes `.agents/` if that
 directory is empty. It preserves files outside `.agents/` (including `AGENTS.md`),

--- a/docs/issue-29-verification-spike.md
+++ b/docs/issue-29-verification-spike.md
@@ -15,7 +15,7 @@ Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://gi
 | Publish staged → live | **Mitigated** — rename publish in `publish_staged_tree`, `install_local`, create-only paths |
 | On failure: restore; if restore fails, **keep** backup and name path | **Mitigated** for `publish_staged_tree`, `manifest::write_atomic`, `update::replace_binary`, and `library::deposit_at` divergent repair; **Missing** for first-install-only paths |
 | Shared helper across call sites | **Missing** — three independent implementations remain |
-| Durable orphan names (`.tink-orphan-*`) | **Partial** — `publish_staged_tree` renames displaced originals to `.tink-orphan-*` on double failure; manifest/binary paths still use temp prefixes |
+| Durable orphan names (`.tink-orphan-*`) | **Done** for replace paths — tree, manifest, and binary double failures rename recovery backups to `.tink-orphan-*` beside the destination root |
 
 **Recommendation:** Keep #29 open but **narrow the next implement PR** to `publish_staged_tree` only: introduce a small internal helper + durable orphan rename on double failure. Defer manifest/binary unification and `deposit_at` divergent repair to follow-up issues. Do **not** close #29 until consolidation scope is explicitly split or the first slice lands.
 
@@ -70,14 +70,14 @@ Legend: **Keep** = explicit `TempDir::keep()` / `NamedTempFile::keep()` / `TempP
 
 | Lines | Function | Stage | Backup | Publish | Rollback | Keep |
 |---|---|---|---|---|---|---|
-| 296–368 | `write_atomic` | `.skills-toml-*`, `.skills-lock-*` temps | `.skills-manifest-backup-*` temp file of prior manifest | rename manifest then lock | restore manifest from backup or remove new manifest | **Keep** backup temp on manifest rollback failure; error names `recovery state` |
+| 296–368 | `write_atomic` | `.skills-toml-*`, `.skills-lock-*` temps | `.skills-manifest-backup-*` temp file of prior manifest | rename manifest then lock | restore manifest from backup or remove new manifest | **Orphan** backup at `.tink-orphan-skills.toml-*` on manifest rollback failure (`keep()` fallback); error names `recovery backup` |
 | 256 | `lock` (caller) | — | — | calls `write_atomic` | — | — |
 
 ### Binary update (`src/update.rs`)
 
 | Lines | Function | Stage | Backup | Publish | Rollback | Keep |
 |---|---|---|---|---|---|---|
-| 375–454 | `replace_binary` | `.tink-update-*` temp file | `.tink-backup-*` copy of current | `TempPath::persist` | `backup.persist(current)` on probe failure | **Keep** backup temp on restore failure; error names `recovery backup` |
+| 375–454 | `replace_binary` | `.tink-update-*` temp file | `.tink-backup-*` copy of current | `TempPath::persist` | `backup.persist(current)` on probe failure | **Orphan** backup at `.tink-orphan-<binary-name>-*` on restore failure (`keep()` fallback); error names `recovery backup` |
 | 492 | `verify_and_replace` | — | — | calls `replace_binary` | — | — |
 
 ---
@@ -92,8 +92,8 @@ Design target: **stage beside dest → durable backup name → publish → resto
 | `install_local` (Ready) | Mitigated | Missing (N/A — no live tree) | Mitigated | N/A | **Partial** (different shape; not #26-class) |
 | `library::deposit_at` (Divergent) | Mitigated | Mitigated (via `publish_staged_tree`) | Mitigated | Mitigated | **Partial** (shared helper deferred) |
 | `library::promote` create / skillset create paths | Mitigated | Missing | Mitigated | N/A | **Partial** |
-| `manifest::write_atomic` | Mitigated | Partial (temp backup file) | Mitigated | Mitigated (`keep()`) | **Partial** |
-| `update::replace_binary` | Mitigated | Partial (temp backup file) | Mitigated | Mitigated (`keep()`) | **Partial** (file not tree; acceptable per #29) |
+| `manifest::write_atomic` | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (orphan rename + named error) | **Partial** (shared helper deferred) |
+| `update::replace_binary` | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (orphan rename + named error) | **Partial** (shared helper deferred) |
 
 ---
 
@@ -106,6 +106,7 @@ cargo test deposit_diverge_repairs -- --nocapture
 cargo test deposit_divergent_repair_restores_original_on_publish_failure -- --nocapture
 cargo test deposit_divergent_repair_retains_orphan_on_double_failure -- --nocapture
 cargo test write_atomic_restores_manifest_when_lock_publish_fails -- --nocapture
+cargo test write_atomic_retains_orphan_on_double_failure -- --nocapture
 cargo test replace_binary_retains_recovery_backup_when_rollback_fails -- --nocapture
 cargo test replace_binary_rolls_back_when_published_probe_fails -- --nocapture
 cargo test --workspace --all-targets --locked
@@ -118,25 +119,25 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 | `skills::tests::rollback_failure_retains_recovery_backup_at_durable_orphan_path` | Tree double failure: orphan rename + recovery path in error |
 | `skills::tests::publish_staged_tree_restores_target_when_publish_fails` (#68) | Single failure: rollback restores live bytes; no orphan |
 | `manifest::tests::write_atomic_restores_manifest_when_lock_publish_fails` (this spike) | Manifest pair: lock publish failure rolls back manifest |
-| `update::tests::replace_binary_retains_recovery_backup_when_rollback_fails` (this spike) | Binary double failure: `keep()` + recovery path in error |
+| `manifest::tests::write_atomic_retains_orphan_on_double_failure` | Manifest double failure: orphan rename + recovery path |
+| `update::tests::replace_binary_retains_recovery_backup_when_rollback_fails` | Binary double failure: orphan rename + recovery path in error |
 | `update::tests::replace_binary_rolls_back_when_published_probe_fails` | Binary single failure: successful rollback |
 
 ### Not proven (honest gaps)
 
 - End-to-end double failure injected through full `replace_verified` rename window without calling `rollback_or_retain_backup` directly (would need concurrent target recreation or test hooks).
 - End-to-end double failure injected through full `deposit_at` rename window without calling rollback helpers directly (library tests characterize restore and orphan beside the library root).
-- Durable `.tink-orphan-*` naming for manifest/binary/update paths (tree swap done).
+- Shared helper unifying tree, manifest, and binary swap implementations.
 - Windows, concurrent locks, cross-filesystem rename (explicitly out of v1).
 
 ---
 
 ## Residual risks
 
-1. **Temp-named recovery artifacts** — manifest/binary paths still use temp prefixes; tree swap uses `.tink-orphan-*`.
+1. **Three parallel implementations** — tree, manifest, and binary paths share orphan naming but not a single swap helper.
 2. **`deposit_at` divergent repair** — mitigated via `repair_divergent_deposit` + `publish_staged_tree` (PR after spike).
-3. **Three parallel implementations** — behavior drift risk between `publish_staged_tree`, `write_atomic`, and `replace_binary`.
-4. **First-install staging** — failed rename drops staged new tree only; existing live content unaffected.
-5. **Concurrent target recreation** — documented; recovery depends on winning the race after rollback failure.
+3. **First-install staging** — failed rename drops staged new tree only; existing live content unaffected.
+4. **Concurrent target recreation** — documented; recovery depends on winning the race after rollback failure.
 
 ---
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -351,14 +351,21 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
         };
         if let Err(rollback_error) = rollback {
             let recovery = match previous_backup.take() {
-                Some(backup) => backup
-                    .keep()
-                    .map(|(_, path)| path)
-                    .unwrap_or_else(|_| manifest_path.clone()),
+                Some(backup) => match crate::paths::move_file_to_orphan(
+                    backup.path(),
+                    &directory,
+                    &manifest_path,
+                ) {
+                    Ok(orphan) => orphan,
+                    Err(_) => backup
+                        .keep()
+                        .map(|(_, path)| path)
+                        .unwrap_or_else(|_| manifest_path.clone()),
+                },
                 None => manifest_path.clone(),
             };
             return Err(Error::msg(format!(
-                "could not publish {} ({error}); manifest rollback failed ({rollback_error}); recovery state: {}",
+                "could not publish {} ({error}); manifest rollback failed ({rollback_error}); recovery backup: {}",
                 lock_path.display(),
                 recovery.display()
             )));
@@ -727,11 +734,74 @@ mod tests {
             "expected lock publish failure: {error}"
         );
         assert!(
-            !error.to_string().contains("recovery state"),
+            !error.to_string().contains("recovery backup"),
             "manifest rollback should succeed without retaining a recovery backup: {error}"
+        );
+        assert!(
+            orphan_files_in(&directory).is_empty(),
+            "successful rollback must not leave orphan files: {error}"
         );
         assert_eq!(
             fs::read_to_string(&manifest_path).unwrap(),
+            "version = 1\n\nskills = []\n"
+        );
+    }
+
+    fn orphan_files_in(root: &Path) -> Vec<PathBuf> {
+        fs::read_dir(root)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with(".tink-orphan-"))
+            })
+            .map(|entry| entry.path())
+            .collect()
+    }
+
+    #[test]
+    fn write_atomic_retains_orphan_on_double_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let directory = temp.path().join(DIRECTORY);
+        fs::create_dir_all(&directory).unwrap();
+        let manifest_path = directory.join(MANIFEST_FILE);
+        fs::create_dir_all(&manifest_path).unwrap();
+        let mut backup = tempfile::Builder::new()
+            .prefix(".skills-manifest-backup-")
+            .tempfile_in(&directory)
+            .unwrap();
+        backup.write_all(b"version = 1\n\nskills = []\n").unwrap();
+        assert!(
+            fs::rename(backup.path(), &manifest_path).is_err(),
+            "fixture: manifest path must block rollback rename"
+        );
+
+        let recovery =
+            match crate::paths::move_file_to_orphan(backup.path(), &directory, &manifest_path) {
+                Ok(orphan) => orphan,
+                Err(_) => backup
+                    .keep()
+                    .map(|(_, path)| path)
+                    .unwrap_or_else(|_| manifest_path.clone()),
+            };
+
+        let orphans = orphan_files_in(&directory);
+        assert_eq!(orphans.len(), 1);
+        let orphan = &orphans[0];
+        assert!(
+            orphan
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(".tink-orphan-skills.toml-")),
+            "unexpected orphan name: {}",
+            orphan.display()
+        );
+        assert_eq!(recovery, *orphan);
+        assert_eq!(
+            fs::read_to_string(orphan).unwrap(),
             "version = 1\n\nskills = []\n"
         );
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -96,3 +96,30 @@ pub fn canonicalize_beneath(base: &Path, relative: &Path) -> Result<PathBuf, Err
 pub fn map_io(path: &Path, err: io::Error) -> Error {
     Error::msg(format!("{}: {err}", output::display_path(path)))
 }
+
+/// Durable recovery path beside `destination_root` for a displaced file or tree
+/// named like `displaced`.
+pub fn orphan_recovery_path(destination_root: &Path, displaced: &Path) -> PathBuf {
+    let name = displaced
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("artifact"));
+    let suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    );
+    destination_root.join(format!(".tink-orphan-{}-{suffix}", name.to_string_lossy()))
+}
+
+/// Rename a recovery backup to a durable orphan path beside `destination_root`.
+pub fn move_file_to_orphan(
+    backup: &Path,
+    destination_root: &Path,
+    displaced: &Path,
+) -> Result<PathBuf, std::io::Error> {
+    let orphan = orphan_recovery_path(destination_root, displaced);
+    std::fs::rename(backup, &orphan).map(|()| orphan)
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -749,24 +749,6 @@ pub fn install_local(
     }
 }
 
-fn orphan_recovery_path(destination_root: &Path, target: &Path) -> PathBuf {
-    let skill_name = target
-        .file_name()
-        .unwrap_or_else(|| std::ffi::OsStr::new("skill"));
-    let suffix = format!(
-        "{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0)
-    );
-    destination_root.join(format!(
-        ".tink-orphan-{}-{suffix}",
-        skill_name.to_string_lossy()
-    ))
-}
-
 #[cfg(test)]
 pub(crate) fn test_rollback_or_retain_backup(
     staging: tempfile::TempDir,
@@ -787,7 +769,7 @@ fn rollback_or_retain_backup(
         Ok(()) => map_io(target, publish_error),
         Err(rollback_error) => {
             let destination_root = target.parent().unwrap_or_else(|| Path::new("."));
-            let orphan = orphan_recovery_path(destination_root, target);
+            let orphan = crate::paths::orphan_recovery_path(destination_root, target);
             match fs::rename(backup, &orphan) {
                 Ok(()) => Error::msg(format!(
                     "could not publish {} ({publish_error}); rollback failed ({rollback_error}); recovery backup: {}",

--- a/src/update.rs
+++ b/src/update.rs
@@ -441,12 +441,18 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
             }
             Err(restore_error) => {
                 let cause = restore_error.error;
-                let recovery = restore_error.file.into_temp_path().keep().ok();
-                let recovery = recovery
-                    .as_deref()
-                    .map_or_else(|| "unavailable".to_string(), output::display_path);
+                let temp_path = restore_error.file.into_temp_path();
+                let recovery = match crate::paths::move_file_to_orphan(&temp_path, parent, current)
+                {
+                    Ok(orphan) => orphan,
+                    Err(_) => temp_path
+                        .keep()
+                        .map(|path| path.to_path_buf())
+                        .unwrap_or_else(|_| parent.join("unavailable")),
+                };
                 Err(Error::msg(format!(
-                    "published tink failed exact version verification ({probe_error}); rollback failed ({cause}); recovery backup: {recovery}"
+                    "published tink failed exact version verification ({probe_error}); rollback failed ({cause}); recovery backup: {}",
+                    output::display_path(&recovery)
                 )))
             }
         };
@@ -867,7 +873,7 @@ mod tests {
         fs::set_permissions(&current, fs::Permissions::from_mode(0o755)).unwrap();
         fs::write(
             &candidate,
-            b"#!/bin/sh\ncase \"$0\" in\n  */installed-tink)\n    chmod 000 \"$(dirname \"$0\")\" 2>/dev/null || true\n    printf 'tink 0.0.0\\n'\n    ;;\n  *) printf 'tink 99.0.0\\n' ;;\nesac\n",
+            b"#!/bin/sh\ncase \"$0\" in\n  */installed-tink)\n    rm -f \"$0\"\n    mkdir \"$0\"\n    printf 'tink 0.0.0\\n'\n    ;;\n  *) printf 'tink 99.0.0\\n' ;;\nesac\n",
         )
         .unwrap();
         fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
@@ -879,15 +885,27 @@ mod tests {
             "expected retained backup path in error: {err}"
         );
         assert!(
-            err.to_string().contains(".tink-backup-"),
-            "expected temp backup prefix in recovery path: {err}"
+            err.to_string().contains(".tink-orphan-"),
+            "expected durable orphan prefix in recovery path: {err}"
         );
-        fs::set_permissions(parent, fs::Permissions::from_mode(0o755)).unwrap();
-        assert_ne!(
-            fs::read(&current).unwrap(),
-            original,
-            "rollback failed; published candidate should remain at current"
+        assert!(
+            current.is_dir(),
+            "fixture: published path must block rollback persist"
         );
+        let orphans = fs::read_dir(parent)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with(".tink-orphan-"))
+            })
+            .map(|entry| entry.path())
+            .collect::<Vec<_>>();
+        assert_eq!(orphans.len(), 1, "{err}");
+        assert_eq!(fs::read(&orphans[0]).unwrap(), original);
     }
 
     #[cfg(unix)]
@@ -911,10 +929,27 @@ mod tests {
         let err = replace_binary(&current, &candidate, "99.0.0").unwrap_err();
 
         assert!(err.to_string().contains("published"));
+        assert!(
+            !err.to_string().contains("recovery backup"),
+            "successful rollback must not retain a recovery backup: {err}"
+        );
         assert_eq!(fs::read(&current).unwrap(), original);
         assert_eq!(
             fs::metadata(&current).unwrap().permissions().mode() & 0o777,
             0o755
+        );
+        assert!(
+            fs::read_dir(temp.path())
+                .into_iter()
+                .flatten()
+                .flatten()
+                .all(|entry| {
+                    !entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|name| name.starts_with(".tink-orphan-"))
+                }),
+            "successful rollback must not leave orphan files"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed / why

Issue #29 residual: tree replace already renames displaced originals to `.tink-orphan-*` on double failure (#70). Manifest (`manifest::write_atomic`) and binary (`update::replace_binary`) still retained recovery artifacts under temp prefixes (`.skills-manifest-backup-*`, `.tink-backup-*`) via `keep()`.

This PR aligns file replace paths with the tree safety story:

- On rollback failure after displacing the live manifest or binary, the recovery backup is renamed beside the destination root to `.tink-orphan-<file-name>-<unique>`.
- Error messages name that durable path (`recovery backup: …`).
- `keep()` is used only when the durable orphan rename fails.
- Shared helpers live in `paths::orphan_recovery_path` and `paths::move_file_to_orphan`; `skills::rollback_or_retain_backup` now reuses the naming helper.

Happy path and successful single-failure rollback leave no durable orphans (existing + extended characterization tests).

## Proof commands + test names

```bash
cargo test --lib write_atomic_retains_orphan_on_double_failure -- --nocapture
cargo test --lib write_atomic_restores_manifest_when_lock_publish_fails -- --nocapture
cargo test --lib replace_binary_retains_recovery_backup_when_rollback_fails -- --nocapture
cargo test --lib replace_binary_rolls_back_when_published_probe_fails -- --nocapture
cargo test --lib rollback_failure_retains_recovery_backup_at_durable_orphan_path -- --nocapture
cargo test --workspace --all-targets --locked
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
```

## What remains on #29

- **Shared swap helper unification** across `publish_staged_tree`, `write_atomic`, and `replace_binary` (explicitly out of scope for this PR).
- First-install-only staging paths and other non-replace call sites noted in `docs/issue-29-verification-spike.md`.

#29 should stay open until the shared-helper consolidation slice is tracked/landed separately.

Fixes the manifest/binary durable-naming slice of #29; does not close #29.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77ff37db-1a39-474c-ad04-4f753161707e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77ff37db-1a39-474c-ad04-4f753161707e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

