### PR TITLE
Extract shared restore-or-orphan swap policy (#29)

### DIFF
--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -123,8 +123,9 @@ Manifest pair writes (`manifest::write_atomic`) and binary self-update
 (`update::replace_binary`) follow the same restore-or-orphan principle for file
 replacements: on double failure the recovery backup is renamed beside the destination
 root to `.tink-orphan-<file-name>-<unique>` (falling back to the temp backup path
-only when that durable rename fails). #29 tracks consolidating these independent
-implementations behind one shared swap helper.
+only when that durable rename fails). Tree and file paths share the policy via
+`paths::restore_or_orphan` and `paths::orphan_or_retain_after_restore_failure`;
+staging, publish, and backup capture stay with each owner.
 
 `tink destroy` removes only `.agents/skills/`, then removes `.agents/` if that
 directory is empty. It preserves files outside `.agents/` (including `AGENTS.md`),

--- a/docs/issue-29-verification-spike.md
+++ b/docs/issue-29-verification-spike.md
@@ -1,12 +1,12 @@
 # Verification spike: issue #29 durable atomic skill-tree swap
 
-Spike date: 2026-09-09. Base: `main` @ `4552a04` (includes #68 / post-#26 close).
+Spike date: 2026-09-09. Base: `main` @ `4552a04` (includes #68 / post-#26 close). Consolidation PR base: `main` @ `dcd3a05` (includes #72 durable orphan naming for manifest/binary).
 
-Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://github.com/jon-devlapaz/tink/issues/26) (closed), [#68](https://github.com/jon-devlapaz/tink/pull/68).
+Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://github.com/jon-devlapaz/tink/issues/26) (closed), [#68](https://github.com/jon-devlapaz/tink/pull/68), [#72](https://github.com/jon-devlapaz/tink/pull/72).
 
 ## Verdict
 
-**Mostly done for the safety invariant; still needed for consolidation and durable naming.**
+**Done for #29 consolidation scope.** Safety invariant and shared restore-or-orphan policy are landed; first-install-only staging remains intentionally out of scope.
 
 | #29 design pillar | Status on `main` |
 |---|---|
@@ -14,10 +14,10 @@ Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://gi
 | Move live → backup before publish | **Mitigated** for replace paths via `publish_staged_tree` (`target → staging/old`) |
 | Publish staged → live | **Mitigated** — rename publish in `publish_staged_tree`, `install_local`, create-only paths |
 | On failure: restore; if restore fails, **keep** backup and name path | **Mitigated** for `publish_staged_tree`, `manifest::write_atomic`, `update::replace_binary`, and `library::deposit_at` divergent repair; **Missing** for first-install-only paths |
-| Shared helper across call sites | **Missing** — three independent implementations remain |
+| Shared helper across call sites | **Done** — `paths::restore_or_orphan` / `paths::orphan_or_retain_after_restore_failure` own the policy; tree, manifest, and binary call sites format errors at the edges |
 | Durable orphan names (`.tink-orphan-*`) | **Done** for replace paths — tree, manifest, and binary double failures rename recovery backups to `.tink-orphan-*` beside the destination root |
 
-**Recommendation:** Keep #29 open but **narrow the next implement PR** to `publish_staged_tree` only: introduce a small internal helper + durable orphan rename on double failure. Defer manifest/binary unification and `deposit_at` divergent repair to follow-up issues. Do **not** close #29 until consolidation scope is explicitly split or the first slice lands.
+**Recommendation:** Close #29 when the consolidation PR merges. Track first-install-only staging as a separate follow-up if desired; it is a different shape (no live tree to restore) and not #26-class.
 
 ---
 
@@ -25,9 +25,9 @@ Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://gi
 
 | Item | Status | Evidence |
 |---|---|---|
-| `replace_verified` / new install use a shared helper | **Open** | Replace uses `publish_staged_tree`; fresh install uses direct rename in `install_local` — no shared abstraction |
-| Failure after live-move leaves recoverable path + error names it | **Done** for replace/publish paths | `rollback_or_retain_backup` + `TempDir::keep()` (#53/#68); tests below |
-| Characterization for restore-failure path | **Done** for tree helper | `rollback_failure_retains_recovery_backup`, `publish_staged_tree_restores_target_when_publish_fails`; manifest/binary keep paths characterized in this spike |
+| Replace paths share restore-or-orphan policy | **Done** | `paths::restore_or_orphan` used by `rollback_or_retain_backup` and `write_atomic`; `orphan_or_retain_after_restore_failure` used by `replace_binary` after consuming restore |
+| Failure after live-move leaves recoverable path + error names it | **Done** for replace/publish paths | Characterization tests below |
+| Characterization for restore-failure path | **Done** | Tree, manifest, binary, and library deposit paths |
 | Closes or fully addresses #26 | **Done** | #26 closed; silent `TempDir` drop on refresh replace is fixed |
 
 ---
@@ -36,14 +36,22 @@ Related: [#29](https://github.com/jon-devlapaz/tink/issues/29), [#26](https://gi
 
 Legend: **Keep** = explicit `TempDir::keep()` / `NamedTempFile::keep()` / `TempPath::keep()` on double failure. **Drop-risk** = staging/backup lives only in a `Drop`-deleting temp with no keep-on-failure path.
 
+### Shared policy (`src/paths.rs`)
+
+| Function | Role |
+|---|---|
+| `orphan_recovery_path` / `move_file_to_orphan` | Durable `.tink-orphan-*` naming beside destination root |
+| `restore_or_orphan` | Try restore; on failure orphan backup or retain via caller fallback |
+| `orphan_or_retain_after_restore_failure` | Orphan-or-retain when restore already failed (consuming restore APIs) |
+
 ### Tree swap core (`src/skills.rs`)
 
 | Lines | Function | Stage | Live→backup | Publish | Rollback | Keep on double failure |
 |---|---|---|---|---|---|---|
 | 736–745 | `install_local` (Ready) | `.tink-stage-*` beside dest | — (no prior live tree) | `rename(staged → target)` | — | **Drop-risk** for staged new tree only; live tree untouched |
-| 752–773 | `rollback_or_retain_backup` | — | — | — | `rename(backup → target)` | **Keep** staging dir; error names `recovery backup` |
-| 778–788 | `publish_staged_tree` | caller-owned staging | `rename(target → old)` | `rename(staged → target)` | via `rollback_or_retain_backup` | **Keep** |
-| 805–820 | `replace_verified_inner` | `.tink-update-*` + copy to `new/` | via `publish_staged_tree` | via `publish_staged_tree` | via `publish_staged_tree` | **Keep** |
+| 762–803 | `rollback_or_retain_backup` | — | — | — | via `paths::restore_or_orphan` | **Orphan** or **Keep** staging dir |
+| 805–820 | `publish_staged_tree` | caller-owned staging | `rename(target → old)` | `rename(staged → target)` | via `rollback_or_retain_backup` | **Orphan** or **Keep** |
+| 832+ | `replace_verified_inner` | `.tink-update-*` + copy to `new/` | via `publish_staged_tree` | via `publish_staged_tree` | via `publish_staged_tree` | **Orphan** or **Keep** |
 
 ### Callers of `publish_staged_tree`
 
@@ -70,14 +78,14 @@ Legend: **Keep** = explicit `TempDir::keep()` / `NamedTempFile::keep()` / `TempP
 
 | Lines | Function | Stage | Backup | Publish | Rollback | Keep |
 |---|---|---|---|---|---|---|
-| 296–368 | `write_atomic` | `.skills-toml-*`, `.skills-lock-*` temps | `.skills-manifest-backup-*` temp file of prior manifest | rename manifest then lock | restore manifest from backup or remove new manifest | **Orphan** backup at `.tink-orphan-skills.toml-*` on manifest rollback failure (`keep()` fallback); error names `recovery backup` |
+| 296–376 | `write_atomic` | `.skills-toml-*`, `.skills-lock-*` temps | `.skills-manifest-backup-*` temp file of prior manifest | rename manifest then lock | via `paths::restore_or_orphan` | **Orphan** or **Keep** fallback |
 | 256 | `lock` (caller) | — | — | calls `write_atomic` | — | — |
 
 ### Binary update (`src/update.rs`)
 
 | Lines | Function | Stage | Backup | Publish | Rollback | Keep |
 |---|---|---|---|---|---|---|
-| 375–454 | `replace_binary` | `.tink-update-*` temp file | `.tink-backup-*` copy of current | `TempPath::persist` | `backup.persist(current)` on probe failure | **Orphan** backup at `.tink-orphan-<binary-name>-*` on restore failure (`keep()` fallback); error names `recovery backup` |
+| 375–461 | `replace_binary` | `.tink-update-*` temp file | `.tink-backup-*` copy of current | `TempPath::persist` | `backup.persist(current)` on probe failure | via `paths::orphan_or_retain_after_restore_failure` |
 | 492 | `verify_and_replace` | — | — | calls `replace_binary` | — | — |
 
 ---
@@ -88,18 +96,19 @@ Design target: **stage beside dest → durable backup name → publish → resto
 
 | Site | Stage | Durable backup | Publish | Restore-or-keep | Overall |
 |---|---|---|---|---|---|
-| `publish_staged_tree` (+ callers) | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (orphan rename + named error) | **Partial** (shared helper deferred) |
+| `publish_staged_tree` (+ callers) | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (shared helper) | **Done** |
 | `install_local` (Ready) | Mitigated | Missing (N/A — no live tree) | Mitigated | N/A | **Partial** (different shape; not #26-class) |
-| `library::deposit_at` (Divergent) | Mitigated | Mitigated (via `publish_staged_tree`) | Mitigated | Mitigated | **Partial** (shared helper deferred) |
+| `library::deposit_at` (Divergent) | Mitigated | Mitigated (via `publish_staged_tree`) | Mitigated | Mitigated | **Done** |
 | `library::promote` create / skillset create paths | Mitigated | Missing | Mitigated | N/A | **Partial** |
-| `manifest::write_atomic` | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (orphan rename + named error) | **Partial** (shared helper deferred) |
-| `update::replace_binary` | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (orphan rename + named error) | **Partial** (shared helper deferred) |
+| `manifest::write_atomic` | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (shared helper) | **Done** |
+| `update::replace_binary` | Mitigated | Mitigated (`.tink-orphan-*` on double failure) | Mitigated | Mitigated (shared helper) | **Done** |
 
 ---
 
-## Executable proof (tests run on spike branch)
+## Executable proof (tests run on consolidation branch)
 
 ```bash
+cargo test restore_or_orphan -- --nocapture
 cargo test rollback_failure_retains_recovery_backup_at_durable_orphan_path -- --nocapture
 cargo test publish_staged_tree_restores_target_when_publish_fails -- --nocapture
 cargo test deposit_diverge_repairs -- --nocapture
@@ -116,40 +125,30 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 
 | Test | Proves |
 |---|---|
-| `skills::tests::rollback_failure_retains_recovery_backup_at_durable_orphan_path` | Tree double failure: orphan rename + recovery path in error |
+| `paths::tests::restore_or_orphan_*` | Shared helper: successful rollback and double-failure orphan |
+| `skills::tests::rollback_failure_retains_recovery_backup_at_durable_orphan_path` | Tree double failure via shared policy |
 | `skills::tests::publish_staged_tree_restores_target_when_publish_fails` (#68) | Single failure: rollback restores live bytes; no orphan |
-| `manifest::tests::write_atomic_restores_manifest_when_lock_publish_fails` (this spike) | Manifest pair: lock publish failure rolls back manifest |
-| `manifest::tests::write_atomic_retains_orphan_on_double_failure` | Manifest double failure: orphan rename + recovery path |
-| `update::tests::replace_binary_retains_recovery_backup_when_rollback_fails` | Binary double failure: orphan rename + recovery path in error |
+| `manifest::tests::write_atomic_restores_manifest_when_lock_publish_fails` | Manifest pair: lock publish failure rolls back manifest |
+| `manifest::tests::write_atomic_retains_orphan_on_double_failure` | Manifest double failure via shared policy |
+| `update::tests::replace_binary_retains_recovery_backup_when_rollback_fails` | Binary double failure via shared policy |
 | `update::tests::replace_binary_rolls_back_when_published_probe_fails` | Binary single failure: successful rollback |
 
 ### Not proven (honest gaps)
 
-- End-to-end double failure injected through full `replace_verified` rename window without calling `rollback_or_retain_backup` directly (would need concurrent target recreation or test hooks).
+- End-to-end double failure injected through full `replace_verified` rename window without calling rollback helpers directly (would need concurrent target recreation or test hooks).
 - End-to-end double failure injected through full `deposit_at` rename window without calling rollback helpers directly (library tests characterize restore and orphan beside the library root).
-- Shared helper unifying tree, manifest, and binary swap implementations.
+- First-install-only staging drop-risk (`install_local`, create-only promote/skillset paths).
 - Windows, concurrent locks, cross-filesystem rename (explicitly out of v1).
 
 ---
 
 ## Residual risks
 
-1. **Three parallel implementations** — tree, manifest, and binary paths share orphan naming but not a single swap helper.
-2. **`deposit_at` divergent repair** — mitigated via `repair_divergent_deposit` + `publish_staged_tree` (PR after spike).
-3. **First-install staging** — failed rename drops staged new tree only; existing live content unaffected.
-4. **Concurrent target recreation** — documented; recovery depends on winning the race after rollback failure.
+1. **First-install staging** — failed rename drops staged new tree only; existing live content unaffected.
+2. **Concurrent target recreation** — documented; recovery depends on winning the race after rollback failure.
 
 ---
 
-## Recommended next implement slice (one PR)
+## Consolidation landed
 
-**Scope:** `publish_staged_tree` only (~1 module + call-site prefix constants unchanged).
-
-1. Extract a private `stage_tree_swap(staging, staged, target) -> Result<_, SwapFailure>` that implements steps 2–4 of the design target.
-2. On rollback failure, **rename** `staging/old` to `<dest-root>/.tink-orphan-<skill-name>-<pid or random>` before returning (durable name beside destination, not temp prefix).
-3. Wire `replace_verified_inner`, `library::promote_at`, and skillset callers through the helper without changing staging prefix behavior on the happy path.
-4. Add one characterization test asserting orphan dir name pattern on double failure.
-
-**Defer:** manifest/binary unification, `install_local` first-install staging, shared crate-level abstraction across file vs tree shapes.
-
-**Alternative:** Close #29 as “safety done” and open `#29a` (orphan naming), `#29b` (shared helper), `#29c` (`deposit_at` divergent backup) — if maintainers prefer smaller tracked units.
+Shared restore-or-orphan policy lives in `src/paths.rs`. Staging, publish, and backup capture remain with each owner (`publish_staged_tree`, `write_atomic`, `replace_binary`). File vs tree shapes differ only at the edges (restore closure and error formatting).

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,10 +3,11 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use crate::error::Error;
+use crate::output;
 use crate::paths::{map_io, refuse_symlink};
 use crate::provenance;
 use crate::skills;
@@ -345,32 +346,52 @@ fn write_atomic(root: &Path, manifest: &str, lock: &str) -> Result<(), Error> {
     fs::rename(&manifest_temp_path, &manifest_path).map_err(|e| map_io(&manifest_path, e))?;
     if let Err(error) = fs::rename(&lock_temp_path, &lock_path) {
         // Roll the first rename back so the pair remains consistent.
-        let rollback = match previous_backup.as_ref() {
-            Some(backup) => fs::rename(backup.path(), &manifest_path),
-            None => fs::remove_file(&manifest_path),
-        };
-        if let Err(rollback_error) = rollback {
-            let recovery = match previous_backup.take() {
-                Some(backup) => match crate::paths::move_file_to_orphan(
-                    backup.path(),
+        let outcome = match previous_backup.as_ref() {
+            Some(backup) => {
+                let backup_path = backup.path().to_path_buf();
+                crate::paths::restore_or_orphan(
+                    || fs::rename(&backup_path, &manifest_path),
+                    &backup_path,
                     &directory,
                     &manifest_path,
-                ) {
-                    Ok(orphan) => orphan,
-                    Err(_) => backup
-                        .keep()
-                        .map(|(_, path)| path)
-                        .unwrap_or_else(|_| manifest_path.clone()),
+                    || {
+                        previous_backup
+                            .take()
+                            .expect("backup retained for orphan fallback")
+                            .keep()
+                            .map(|(_, path)| path)
+                            .unwrap_or_else(|_| manifest_path.clone())
+                    },
+                )
+            }
+            None => match fs::remove_file(&manifest_path) {
+                Ok(()) => crate::paths::RestoreOrOrphan::Restored,
+                Err(rollback_error) => crate::paths::RestoreOrOrphan::Retained {
+                    recovery: manifest_path.clone(),
+                    orphan_path: manifest_path.clone(),
+                    rollback_error,
+                    orphan_error: io::Error::other("no manifest backup to orphan"),
                 },
-                None => manifest_path.clone(),
-            };
-            return Err(Error::msg(format!(
-                "could not publish {} ({error}); manifest rollback failed ({rollback_error}); recovery backup: {}",
-                lock_path.display(),
-                recovery.display()
-            )));
+            },
+        };
+        match outcome {
+            crate::paths::RestoreOrOrphan::Restored => return Err(map_io(&lock_path, error)),
+            crate::paths::RestoreOrOrphan::Orphaned {
+                recovery,
+                rollback_error,
+            }
+            | crate::paths::RestoreOrOrphan::Retained {
+                recovery,
+                rollback_error,
+                ..
+            } => {
+                return Err(Error::msg(format!(
+                    "could not publish {} ({error}); manifest rollback failed ({rollback_error}); recovery backup: {}",
+                    output::display_path(&lock_path),
+                    output::display_path(&recovery)
+                )));
+            }
         }
-        return Err(map_io(&lock_path, error));
     }
     Ok(())
 }
@@ -779,14 +800,23 @@ mod tests {
             "fixture: manifest path must block rollback rename"
         );
 
-        let recovery =
-            match crate::paths::move_file_to_orphan(backup.path(), &directory, &manifest_path) {
-                Ok(orphan) => orphan,
-                Err(_) => backup
+        let backup_path = backup.path().to_path_buf();
+        let outcome = crate::paths::orphan_or_retain_after_restore_failure(
+            io::Error::other("rollback fixture"),
+            &backup_path,
+            &directory,
+            &manifest_path,
+            || {
+                backup
                     .keep()
                     .map(|(_, path)| path)
-                    .unwrap_or_else(|_| manifest_path.clone()),
-            };
+                    .unwrap_or_else(|_| manifest_path.clone())
+            },
+        );
+        let recovery = match outcome {
+            crate::paths::RestoreOrOrphan::Orphaned { recovery, .. } => recovery,
+            other => panic!("expected orphaned backup, got {other:?}"),
+        };
 
         let orphans = orphan_files_in(&directory);
         assert_eq!(orphans.len(), 1);

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -123,3 +123,152 @@ pub fn move_file_to_orphan(
     let orphan = orphan_recovery_path(destination_root, displaced);
     std::fs::rename(backup, &orphan).map(|()| orphan)
 }
+
+/// Outcome of attempting rollback, then orphaning the backup on rollback failure.
+#[derive(Debug)]
+pub enum RestoreOrOrphan {
+    /// Rollback restored the live path; caller should surface the publish failure.
+    Restored,
+    /// Rollback failed; backup moved to a durable `.tink-orphan-*` path.
+    Orphaned {
+        recovery: PathBuf,
+        rollback_error: io::Error,
+    },
+    /// Rollback and orphan move both failed; backup retained at `recovery`.
+    Retained {
+        recovery: PathBuf,
+        orphan_path: PathBuf,
+        rollback_error: io::Error,
+        orphan_error: io::Error,
+    },
+}
+
+fn orphan_or_retain(
+    backup: &Path,
+    destination_root: &Path,
+    displaced: &Path,
+    retain_backup: impl FnOnce() -> PathBuf,
+) -> Result<PathBuf, (PathBuf, io::Error)> {
+    match move_file_to_orphan(backup, destination_root, displaced) {
+        Ok(recovery) => Ok(recovery),
+        Err(orphan_error) => Err((retain_backup(), orphan_error)),
+    }
+}
+
+/// Try restoring `backup` over `displaced`; on failure move the backup to a durable
+/// orphan path beside `destination_root`, or retain it via `retain_backup` when the
+/// orphan rename fails.
+pub fn restore_or_orphan(
+    restore: impl FnOnce() -> Result<(), io::Error>,
+    backup: &Path,
+    destination_root: &Path,
+    displaced: &Path,
+    retain_backup: impl FnOnce() -> PathBuf,
+) -> RestoreOrOrphan {
+    match restore() {
+        Ok(()) => RestoreOrOrphan::Restored,
+        Err(rollback_error) => {
+            match orphan_or_retain(backup, destination_root, displaced, retain_backup) {
+                Ok(recovery) => RestoreOrOrphan::Orphaned {
+                    recovery,
+                    rollback_error,
+                },
+                Err((recovery, orphan_error)) => {
+                    let orphan_path = orphan_recovery_path(destination_root, displaced);
+                    RestoreOrOrphan::Retained {
+                        recovery,
+                        orphan_path,
+                        rollback_error,
+                        orphan_error,
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Like [`restore_or_orphan`] when rollback already failed and only orphan-or-retain
+/// remains (for example after a consuming restore attempt).
+pub fn orphan_or_retain_after_restore_failure(
+    rollback_error: io::Error,
+    backup: &Path,
+    destination_root: &Path,
+    displaced: &Path,
+    retain_backup: impl FnOnce() -> PathBuf,
+) -> RestoreOrOrphan {
+    match orphan_or_retain(backup, destination_root, displaced, retain_backup) {
+        Ok(recovery) => RestoreOrOrphan::Orphaned {
+            recovery,
+            rollback_error,
+        },
+        Err((recovery, orphan_error)) => RestoreOrOrphan::Retained {
+            recovery,
+            orphan_path: orphan_recovery_path(destination_root, displaced),
+            rollback_error,
+            orphan_error,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn restore_or_orphan_restores_on_successful_rollback() {
+        let temp = TempDir::new().unwrap();
+        let backup = temp.path().join("backup.txt");
+        let target = temp.path().join("target.txt");
+        fs::write(&backup, "backup-bytes").unwrap();
+        fs::write(&target, "live-bytes").unwrap();
+
+        let outcome = restore_or_orphan(
+            || fs::rename(&backup, &target),
+            &backup,
+            temp.path(),
+            &target,
+            || temp.path().join("unused"),
+        );
+
+        assert!(matches!(outcome, RestoreOrOrphan::Restored));
+        assert_eq!(fs::read(&target).unwrap(), b"backup-bytes");
+        assert!(!backup.exists());
+    }
+
+    #[test]
+    fn restore_or_orphan_moves_backup_to_durable_orphan_on_double_failure() {
+        let temp = TempDir::new().unwrap();
+        let backup = temp.path().join("old");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("payload.txt"), "preserve me").unwrap();
+        let target = temp.path().join("target");
+        fs::write(&target, "rollback blocker").unwrap();
+
+        let outcome = restore_or_orphan(
+            || fs::rename(&backup, &target),
+            &backup,
+            temp.path(),
+            &target,
+            || temp.path().join("fallback"),
+        );
+
+        let RestoreOrOrphan::Orphaned { recovery, .. } = outcome else {
+            panic!("expected orphaned backup, got {outcome:?}");
+        };
+        assert!(
+            recovery
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(".tink-orphan-target-")),
+            "unexpected orphan name: {}",
+            recovery.display()
+        );
+        assert_eq!(
+            fs::read(recovery.join("payload.txt")).unwrap(),
+            b"preserve me"
+        );
+        assert!(!backup.exists());
+    }
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -765,33 +765,41 @@ fn rollback_or_retain_backup(
     target: &Path,
     publish_error: std::io::Error,
 ) -> Error {
-    match fs::rename(backup, target) {
-        Ok(()) => map_io(target, publish_error),
-        Err(rollback_error) => {
-            let destination_root = target.parent().unwrap_or_else(|| Path::new("."));
-            let orphan = crate::paths::orphan_recovery_path(destination_root, target);
-            match fs::rename(backup, &orphan) {
-                Ok(()) => Error::msg(format!(
-                    "could not publish {} ({publish_error}); rollback failed ({rollback_error}); recovery backup: {}",
-                    output::display_path(target),
-                    output::display_path(&orphan)
-                )),
-                Err(orphan_error) => {
-                    let recovery_root = staging.keep();
-                    let recovery = recovery_root.join(
-                        backup
-                            .file_name()
-                            .unwrap_or_else(|| std::ffi::OsStr::new("old")),
-                    );
-                    Error::msg(format!(
-                        "could not publish {} ({publish_error}); rollback failed ({rollback_error}); could not move recovery backup to {} ({orphan_error}); recovery backup: {}",
-                        output::display_path(target),
-                        output::display_path(&orphan),
-                        output::display_path(&recovery)
-                    ))
-                }
-            }
-        }
+    let destination_root = target.parent().unwrap_or_else(|| Path::new("."));
+    match crate::paths::restore_or_orphan(
+        || fs::rename(backup, target),
+        backup,
+        destination_root,
+        target,
+        || {
+            let recovery_root = staging.keep();
+            recovery_root.join(
+                backup
+                    .file_name()
+                    .unwrap_or_else(|| std::ffi::OsStr::new("old")),
+            )
+        },
+    ) {
+        crate::paths::RestoreOrOrphan::Restored => map_io(target, publish_error),
+        crate::paths::RestoreOrOrphan::Orphaned {
+            recovery,
+            rollback_error,
+        } => Error::msg(format!(
+            "could not publish {} ({publish_error}); rollback failed ({rollback_error}); recovery backup: {}",
+            output::display_path(target),
+            output::display_path(&recovery)
+        )),
+        crate::paths::RestoreOrOrphan::Retained {
+            recovery,
+            orphan_path,
+            rollback_error,
+            orphan_error,
+        } => Error::msg(format!(
+            "could not publish {} ({publish_error}); rollback failed ({rollback_error}); could not move recovery backup to {} ({orphan_error}); recovery backup: {}",
+            output::display_path(target),
+            output::display_path(&orphan_path),
+            output::display_path(&recovery)
+        )),
     }
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -440,18 +440,37 @@ fn replace_binary(current: &Path, new_bin: &Path, expected_version: &str) -> Res
                 )))
             }
             Err(restore_error) => {
-                let cause = restore_error.error;
+                let rollback_error = restore_error.error;
                 let temp_path = restore_error.file.into_temp_path();
-                let recovery = match crate::paths::move_file_to_orphan(&temp_path, parent, current)
-                {
-                    Ok(orphan) => orphan,
-                    Err(_) => temp_path
-                        .keep()
-                        .map(|path| path.to_path_buf())
-                        .unwrap_or_else(|_| parent.join("unavailable")),
-                };
+                let recovery_path = temp_path.to_path_buf();
+                let (recovery, rollback_error) =
+                    match crate::paths::orphan_or_retain_after_restore_failure(
+                        rollback_error,
+                        &recovery_path,
+                        parent,
+                        current,
+                        || {
+                            temp_path
+                                .keep()
+                                .map(|path| path.to_path_buf())
+                                .unwrap_or_else(|_| parent.join("unavailable"))
+                        },
+                    ) {
+                        crate::paths::RestoreOrOrphan::Orphaned {
+                            recovery,
+                            rollback_error,
+                        }
+                        | crate::paths::RestoreOrOrphan::Retained {
+                            recovery,
+                            rollback_error,
+                            ..
+                        } => (recovery, rollback_error),
+                        crate::paths::RestoreOrOrphan::Restored => {
+                            unreachable!("rollback already failed before orphan-or-retain")
+                        }
+                    };
                 Err(Error::msg(format!(
-                    "published tink failed exact version verification ({probe_error}); rollback failed ({cause}); recovery backup: {}",
+                    "published tink failed exact version verification ({probe_error}); rollback failed ({rollback_error}); recovery backup: {}",
                     output::display_path(&recovery)
                 )))
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #29.

Three replace paths (`publish_staged_tree`, `manifest::write_atomic`, `update::replace_binary`) previously duplicated the same restore-or-orphan failure policy. This PR extracts that policy into `paths::restore_or_orphan` and `paths::orphan_or_retain_after_restore_failure`, reusing existing `orphan_recovery_path` / `move_file_to_orphan`.

## What was unified vs what stayed separate

**Unified (policy):**
- Try restore from backup
- On rollback failure → rename backup to `.tink-orphan-*` beside destination root
- On orphan rename failure → caller-supplied `keep()` fallback; error names recovery path

**Separate (mechanics at the edges):**
- **Tree** (`rollback_or_retain_backup` / `publish_staged_tree`): `fs::rename` restore; staging `TempDir::keep()` fallback
- **Manifest** (`write_atomic`): manifest backup restore; `NamedTempFile::keep()` fallback; no-backup path still uses `remove_file`
- **Binary** (`replace_binary`): consuming `persist()` restore; `orphan_or_retain_after_restore_failure` after restore already failed

Staging, publish, and backup capture remain with each owner — no leaky file/tree abstraction.

## Proof

```bash
cargo test restore_or_orphan -- --nocapture
cargo test rollback_failure_retains_recovery_backup_at_durable_orphan_path -- --nocapture
cargo test publish_staged_tree_restores_target_when_publish_fails -- --nocapture
cargo test write_atomic_restores_manifest_when_lock_publish_fails -- --nocapture
cargo test write_atomic_retains_orphan_on_double_failure -- --nocapture
cargo test replace_binary_retains_recovery_backup_when_rollback_fails -- --nocapture
cargo test replace_binary_rolls_back_when_published_probe_fails -- --nocapture
cargo test deposit_divergent_repair_retains_orphan_on_double_failure -- --nocapture
cargo test --workspace --all-targets --locked
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
```

All passed locally (200 tests).

## Docs

- `docs/RELIABILITY.md` — notes shared helpers
- `docs/issue-29-verification-spike.md` — matrix updated; shared helper → Done; removed stale "next PR = publish_staged_tree only" guidance

## Close decision

**Closes #29.** Safety invariant, durable orphan naming (#72), and shared policy consolidation are complete. First-install-only staging (create paths with no prior live tree) remains intentionally out of scope — different shape, not #26-class.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9f56a8f-5bcd-44e4-a2ac-dac263a7b0ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9f56a8f-5bcd-44e4-a2ac-dac263a7b0ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

